### PR TITLE
CAPI controller modification: network and reconciliation loop

### DIFF
--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -66,7 +66,8 @@ type NutanixMachineSpec struct {
 	// The cluster identifier (uuid or name) can be obtained from the Prism Central console
 	// or using the prism_central API.
 	// +kubebuilder:validation:Required
-	Subnet NutanixResourceIdentifier `json:"subnet"`
+	// +kubebuilder:validation:MinItems=1
+	Subnets []NutanixResourceIdentifier `json:"subnet"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes

--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -94,7 +94,7 @@ type NutanixMachineStatus struct {
 
 	// The Nutanix VM's UUID
 	// +optional
-	VmUUID *string `json:"vmUUID,omitempty"`
+	VmUUID string `json:"vmUUID,omitempty"`
 
 	// NodeRef is a reference to the corresponding workload cluster Node if it exists.
 	// +optional

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -413,7 +413,7 @@ func autoConvert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *v
 func autoConvert_v1alpha4_NutanixMachineStatus_To_v1beta1_NutanixMachineStatus(in *NutanixMachineStatus, out *v1beta1.NutanixMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.Addresses = *(*[]apiv1beta1.MachineAddress)(unsafe.Pointer(&in.Addresses))
-	out.VmUUID = (*string)(unsafe.Pointer(in.VmUUID))
+	out.VmUUID = in.VmUUID
 	out.NodeRef = (*v1.ObjectReference)(unsafe.Pointer(in.NodeRef))
 	out.Conditions = *(*apiv1beta1.Conditions)(unsafe.Pointer(&in.Conditions))
 	return nil
@@ -422,7 +422,7 @@ func autoConvert_v1alpha4_NutanixMachineStatus_To_v1beta1_NutanixMachineStatus(i
 func autoConvert_v1beta1_NutanixMachineStatus_To_v1alpha4_NutanixMachineStatus(in *v1beta1.NutanixMachineStatus, out *NutanixMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.Addresses = *(*[]apiv1alpha4.MachineAddress)(unsafe.Pointer(&in.Addresses))
-	out.VmUUID = (*string)(unsafe.Pointer(in.VmUUID))
+	out.VmUUID = in.VmUUID
 	out.NodeRef = (*v1.ObjectReference)(unsafe.Pointer(in.NodeRef))
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
 	return nil

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -383,9 +383,7 @@ func autoConvert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *N
 	if err := Convert_v1alpha4_NutanixResourceIdentifier_To_v1beta1_NutanixResourceIdentifier(&in.Cluster, &out.Cluster, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha4_NutanixResourceIdentifier_To_v1beta1_NutanixResourceIdentifier(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	out.Subnets = *(*[]v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil
@@ -402,9 +400,7 @@ func autoConvert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *v
 	if err := Convert_v1beta1_NutanixResourceIdentifier_To_v1alpha4_NutanixResourceIdentifier(&in.Cluster, &out.Cluster, s); err != nil {
 		return err
 	}
-	if err := Convert_v1beta1_NutanixResourceIdentifier_To_v1alpha4_NutanixResourceIdentifier(&in.Subnet, &out.Subnet, s); err != nil {
-		return err
-	}
+	out.Subnets = *(*[]NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -223,11 +223,6 @@ func (in *NutanixMachineStatus) DeepCopyInto(out *NutanixMachineStatus) {
 		*out = make([]apiv1alpha4.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
-	if in.VmUUID != nil {
-		in, out := &in.VmUUID, &out.VmUUID
-		*out = new(string)
-		**out = **in
-	}
 	if in.NodeRef != nil {
 		in, out := &in.NodeRef, &out.NodeRef
 		*out = new(v1.ObjectReference)

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -196,7 +196,13 @@ func (in *NutanixMachineSpec) DeepCopyInto(out *NutanixMachineSpec) {
 	out.MemorySize = in.MemorySize.DeepCopy()
 	in.Image.DeepCopyInto(&out.Image)
 	in.Cluster.DeepCopyInto(&out.Cluster)
-	in.Subnet.DeepCopyInto(&out.Subnet)
+	if in.Subnets != nil {
+		in, out := &in.Subnets, &out.Subnets
+		*out = make([]NutanixResourceIdentifier, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.SystemDiskSize = in.SystemDiskSize.DeepCopy()
 	if in.BootstrapRef != nil {
 		in, out := &in.BootstrapRef, &out.BootstrapRef

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -66,7 +66,8 @@ type NutanixMachineSpec struct {
 	// The cluster identifier (uuid or name) can be obtained from the Prism Central console
 	// or using the prism_central API.
 	// +kubebuilder:validation:Required
-	Subnet NutanixResourceIdentifier `json:"subnet"`
+	// +kubebuilder:validation:MinItems=1
+	Subnets []NutanixResourceIdentifier `json:"subnet"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -94,7 +94,7 @@ type NutanixMachineStatus struct {
 
 	// The Nutanix VM's UUID
 	// +optional
-	VmUUID *string `json:"vmUUID,omitempty"`
+	VmUUID string `json:"vmUUID,omitempty"`
 
 	// NodeRef is a reference to the corresponding workload cluster Node if it exists.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -223,11 +223,6 @@ func (in *NutanixMachineStatus) DeepCopyInto(out *NutanixMachineStatus) {
 		*out = make([]apiv1beta1.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
-	if in.VmUUID != nil {
-		in, out := &in.VmUUID, &out.VmUUID
-		*out = new(string)
-		**out = **in
-	}
 	if in.NodeRef != nil {
 		in, out := &in.NodeRef, &out.NodeRef
 		*out = new(v1.ObjectReference)

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -196,7 +196,13 @@ func (in *NutanixMachineSpec) DeepCopyInto(out *NutanixMachineSpec) {
 	out.MemorySize = in.MemorySize.DeepCopy()
 	in.Image.DeepCopyInto(&out.Image)
 	in.Cluster.DeepCopyInto(&out.Cluster)
-	in.Subnet.DeepCopyInto(&out.Subnet)
+	if in.Subnets != nil {
+		in, out := &in.Subnets, &out.Subnets
+		*out = make([]NutanixResourceIdentifier, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.SystemDiskSize = in.SystemDiskSize.DeepCopy()
 	if in.BootstrapRef != nil {
 		in, out := &in.BootstrapRef, &out.BootstrapRef

--- a/cluster-template.yaml
+++ b/cluster-template.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   controlPlaneEndpoint:
     host: "${CONTROL_PLANE_ENDPOINT_IP}"
-    port: ${CONTROLPLANE_ENDPOINT_PORT=6443}
+    port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}
 
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -53,8 +53,8 @@ spec:
         type: name
         name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
       subnet:
-        type: name
-        name: "${NUTANIX_SUBNET_NAME}"
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"
 
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -80,6 +80,66 @@ spec:
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
+    files:
+      - content: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-vip
+            namespace: kube-system
+          spec:
+            containers:
+              - name: kube-vip
+                image: ghcr.io/kube-vip/kube-vip:v0.4.2
+                imagePullPolicy: IfNotPresent
+                args:
+                  - manager
+                env:
+                  - name: vip_arp
+                    value: "true"
+                  - name: address
+                    value: "${CONTROL_PLANE_ENDPOINT_IP}"
+                  - name: port
+                    value: "${CONTROL_PLANE_ENDPOINT_PORT=6443}"
+                  - name: vip_cidr
+                    value: "32"
+                  - name: cp_enable
+                    value: "true"
+                  - name: cp_namespace
+                    value: kube-system
+                  - name: vip_ddns
+                    value: "false"
+                  - name: vip_leaderelection
+                    value: "true"
+                  - name: vip_leaseduration
+                    value: "15"
+                  - name: vip_renewdeadline
+                    value: "10"
+                  - name: vip_retryperiod
+                    value: "2"
+                securityContext:
+                  capabilities:
+                    add:
+                      - NET_ADMIN
+                      - SYS_TIME
+                      - NET_RAW
+                volumeMounts:
+                  - mountPath: /etc/kubernetes/admin.conf
+                    name: kubeconfig
+                resources: {}
+            hostNetwork: true
+            hostAliases:
+              - hostnames:
+                  - kubernetes
+                ip: 127.0.0.1
+            volumes:
+              - name: kubeconfig
+                hostPath:
+                  type: FileOrCreate
+                  path: /etc/kubernetes/admin.conf
+          status: {}
+        owner: root:root
+        path: /etc/kubernetes/manifests/kube-vip.yaml
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -98,6 +158,7 @@ spec:
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
       - echo "after kubeadm call" > /var/log/postkubeadm.log
+    useExperimentalRetryJoin: true
     verbosity: 10
 
 ---

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -150,22 +150,27 @@ spec:
                   use for the Machine's VM The cluster identifier (uuid or name) can
                   be obtained from the Prism Central console or using the prism_central
                   API.
-                properties:
-                  name:
-                    description: name is the resource name in the PC
-                    type: string
-                  type:
-                    description: Type is the identifier type to use for this resource.
-                    enum:
-                    - uuid
-                    - name
-                    type: string
-                  uuid:
-                    description: uuid is the UUID of the resource in the PC.
-                    type: string
-                required:
-                - type
-                type: object
+                items:
+                  description: NutanixResourceIdentifier holds the identity of a Nutanix
+                    PC resource (cluster, image, subnet, etc.)
+                  properties:
+                    name:
+                      description: name is the resource name in the PC
+                      type: string
+                    type:
+                      description: Type is the identifier type to use for this resource.
+                      enum:
+                      - uuid
+                      - name
+                      type: string
+                    uuid:
+                      description: uuid is the UUID of the resource in the PC.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                minItems: 1
+                type: array
               systemDiskSize:
                 anyOf:
                 - type: integer
@@ -441,22 +446,27 @@ spec:
                   use for the Machine's VM The cluster identifier (uuid or name) can
                   be obtained from the Prism Central console or using the prism_central
                   API.
-                properties:
-                  name:
-                    description: name is the resource name in the PC
-                    type: string
-                  type:
-                    description: Type is the identifier type to use for this resource.
-                    enum:
-                    - uuid
-                    - name
-                    type: string
-                  uuid:
-                    description: uuid is the UUID of the resource in the PC.
-                    type: string
-                required:
-                - type
-                type: object
+                items:
+                  description: NutanixResourceIdentifier holds the identity of a Nutanix
+                    PC resource (cluster, image, subnet, etc.)
+                  properties:
+                    name:
+                      description: name is the resource name in the PC
+                      type: string
+                    type:
+                      description: Type is the identifier type to use for this resource.
+                      enum:
+                      - uuid
+                      - name
+                      type: string
+                    uuid:
+                      description: uuid is the UUID of the resource in the PC.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                minItems: 1
+                type: array
               systemDiskSize:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -168,23 +168,29 @@ spec:
                           to use for the Machine's VM The cluster identifier (uuid
                           or name) can be obtained from the Prism Central console
                           or using the prism_central API.
-                        properties:
-                          name:
-                            description: name is the resource name in the PC
-                            type: string
-                          type:
-                            description: Type is the identifier type to use for this
-                              resource.
-                            enum:
-                            - uuid
-                            - name
-                            type: string
-                          uuid:
-                            description: uuid is the UUID of the resource in the PC.
-                            type: string
-                        required:
-                        - type
-                        type: object
+                        items:
+                          description: NutanixResourceIdentifier holds the identity
+                            of a Nutanix PC resource (cluster, image, subnet, etc.)
+                          properties:
+                            name:
+                              description: name is the resource name in the PC
+                              type: string
+                            type:
+                              description: Type is the identifier type to use for
+                                this resource.
+                              enum:
+                              - uuid
+                              - name
+                              type: string
+                            uuid:
+                              description: uuid is the UUID of the resource in the
+                                PC.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        minItems: 1
+                        type: array
                       systemDiskSize:
                         anyOf:
                         - type: integer
@@ -373,23 +379,29 @@ spec:
                           to use for the Machine's VM The cluster identifier (uuid
                           or name) can be obtained from the Prism Central console
                           or using the prism_central API.
-                        properties:
-                          name:
-                            description: name is the resource name in the PC
-                            type: string
-                          type:
-                            description: Type is the identifier type to use for this
-                              resource.
-                            enum:
-                            - uuid
-                            - name
-                            type: string
-                          uuid:
-                            description: uuid is the UUID of the resource in the PC.
-                            type: string
-                        required:
-                        - type
-                        type: object
+                        items:
+                          description: NutanixResourceIdentifier holds the identity
+                            of a Nutanix PC resource (cluster, image, subnet, etc.)
+                          properties:
+                            name:
+                              description: name is the resource name in the PC
+                              type: string
+                            type:
+                              description: Type is the identifier type to use for
+                                this resource.
+                              enum:
+                              - uuid
+                              - name
+                              type: string
+                            uuid:
+                              description: uuid is the UUID of the resource in the
+                                PC.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        minItems: 1
+                        type: array
                       systemDiskSize:
                         anyOf:
                         - type: integer

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	nutanixClientV3 "github.com/nutanix-core/cluster-api-provider-nutanix/pkg/nutanix/v3"
+	"github.com/nutanix-core/cluster-api-provider-nutanix/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+)
+
+const (
+	taskSucceededMessage = "SUCCEEDED"
+)
+
+// deleteVM deletes a VM and is invoked by the NutanixMachineReconciler
+func deleteVM(client *nutanixClientV3.Client, vmName, vmUUID string) (string, error) {
+	var err error
+
+	if vmUUID == "" {
+		klog.Warning(fmt.Sprintf("VmUUID was empty. Skipping delete"))
+		return "", nil
+	}
+
+	klog.Infof("Deleting VM %s with UUID: %s", vmName, vmUUID)
+	vmDeleteResponse, err := client.V3.DeleteVM(vmUUID)
+	if err != nil {
+		klog.Infof("Error deleting machine %s", vmName)
+		return "", err
+	}
+	deleteTaskUUID := vmDeleteResponse.Status.ExecutionContext.TaskUUID.(string)
+
+	return deleteTaskUUID, nil
+}
+
+// findVMByUUID retrieves the VM with the given vm UUID. Returns nil if not found
+func findVMByUUID(client *nutanixClientV3.Client, uuid string) (*nutanixClientV3.VMIntentResponse, error) {
+
+	klog.Infof("Checking if VM with UUID %s exists.", uuid)
+
+	response, err := client.V3.GetVM(uuid)
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+			klog.Infof("vm with uuid %s does not exist.", uuid)
+			return nil, nil
+		} else {
+			klog.Errorf("Failed to find VM by vmUUID %s. error: %v", uuid, err)
+			return nil, err
+		}
+	}
+
+	return response, nil
+}
+
+// findVMByName retrieves the VM with the given vm name
+func findVMByName(client *nutanixClientV3.Client, vmName string) (*nutanixClientV3.VMIntentResource, error) {
+	klog.Infof("Checking if VM with name %s exists.", vmName)
+
+	res, err := client.V3.ListVM(&nutanixClientV3.DSMetadata{
+		Filter: utils.StringPtr(fmt.Sprintf("vm_name==%s", vmName))})
+	if err != nil || len(res.Entities) == 0 {
+		klog.Errorf("Failed to find VM by name %s. error: %v", vmName, err)
+		return nil, fmt.Errorf("Failed to find VM by name %s. error: %v", vmName, err)
+	}
+
+	if len(res.Entities) > 1 {
+		errorMsg := fmt.Sprintf("Found more than one (%v) vms with name %s.", len(res.Entities), vmName)
+		klog.Errorf(errorMsg)
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	return res.Entities[0], nil
+}
+
+func getPEUUID(client *nutanixClientV3.Client, peName, peUUID *string) (string, error) {
+	var foundPEUUID string
+	if peUUID == nil && peName == nil {
+		return "", fmt.Errorf("cluster name or uuid must be passed in order to retrieve the pe")
+	}
+	if peUUID != nil {
+		peIntentResponse, err := client.V3.GetCluster(*peUUID)
+		if err != nil {
+			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+				return "", fmt.Errorf("failed to find Prism Element cluster with UUID %s: %v", *peUUID, err)
+			}
+		}
+		foundPEUUID = *peIntentResponse.Metadata.UUID
+	} else if peName != nil {
+
+		responsePEs, err := client.V3.ListAllCluster()
+		if err != nil {
+			return "", err
+		}
+		foundPEs := make([]*nutanixClientV3.ClusterIntentResource, 0)
+		for _, s := range responsePEs.Entities {
+			peSpec := s.Spec
+			if *peSpec.Name == *peName {
+				foundPEs = append(foundPEs, s)
+			}
+		}
+		if len(foundPEs) == 0 {
+			return "", fmt.Errorf("failed to retrieve Prism Element cluster by name %s", *peName)
+		} else if len(foundPEs) > 1 {
+			return "", fmt.Errorf("more than one Prism Element cluster found with name %s", *peName)
+		} else {
+			foundPEUUID = *foundPEs[0].Metadata.UUID
+		}
+		if foundPEUUID == "" {
+			return "", fmt.Errorf("failed to retrieve Prism Element cluster by name or uuid. Verify input parameters.")
+		}
+	}
+	return foundPEUUID, nil
+}
+
+// getMibValueOfQuantity returns the given quantity value in Mib
+func getMibValueOfQuantity(quantity resource.Quantity) int64 {
+	return quantity.Value() / (1024 * 1024)
+}
+
+func createSystemDiskSpec(imageUUID string, systemDiskSize int64) (*nutanixClientV3.VMDisk, error) {
+	if imageUUID == "" {
+		return nil, fmt.Errorf("image UUID must be set when creating system disk")
+	}
+	if systemDiskSize <= 0 {
+		return nil, fmt.Errorf("Invalid system disk size: %d. Provide in XXGi (for example 70Gi) format instead", systemDiskSize)
+	}
+	systemDisk := &nutanixClientV3.VMDisk{
+		DataSourceReference: &nutanixClientV3.Reference{
+			Kind: utils.StringPtr("image"),
+			UUID: utils.StringPtr(imageUUID),
+		},
+		DiskSizeMib: utils.Int64Ptr(systemDiskSize)}
+	return systemDisk, nil
+
+}
+
+func getSubnetUUID(client *nutanixClientV3.Client, peUUID string, subnetName, subnetUUID *string) (string, error) {
+	var foundSubnetUUID string
+	if subnetUUID == nil && subnetName == nil {
+		return "", fmt.Errorf("subnet name or subnet uuid must be passed in order to retrieve the subnet")
+	}
+	if subnetUUID != nil {
+		subnetIntentResponse, err := client.V3.GetSubnet(*subnetUUID)
+		if err != nil {
+			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+				return "", fmt.Errorf("failed to find subnet with UUID %s: %v", *subnetUUID, err)
+			}
+		}
+		foundSubnetUUID = *subnetIntentResponse.Metadata.UUID
+	} else if subnetName != nil {
+
+		responseSubnets, err := client.V3.ListAllSubnet()
+		if err != nil {
+			return "", err
+		}
+		foundSubnets := make([]*nutanixClientV3.SubnetIntentResponse, 0)
+		for _, s := range responseSubnets.Entities {
+			subnetSpec := s.Spec
+			if *subnetSpec.Name == *subnetName && *subnetSpec.ClusterReference.UUID == peUUID {
+				foundSubnets = append(foundSubnets, s)
+			}
+		}
+		if len(foundSubnets) == 0 {
+			return "", fmt.Errorf("failed to retrieve subnet by name %s", *subnetName)
+		} else if len(foundSubnets) > 1 {
+			return "", fmt.Errorf("more than one subnet found with name %s", *subnetName)
+		} else {
+			foundSubnetUUID = *foundSubnets[0].Metadata.UUID
+		}
+		if foundSubnetUUID == "" {
+			return "", fmt.Errorf("failed to retrieve subnet by name or uuid. Verify input parameters.")
+		}
+	}
+	return foundSubnetUUID, nil
+}
+
+func getImageUUID(client *nutanixClientV3.Client, imageName, imageUUID *string) (string, error) {
+	var foundImageUUID string
+
+	if imageUUID == nil && imageName == nil {
+		return "", fmt.Errorf("image name or image uuid must be passed in order to retrieve the image")
+	}
+	if imageUUID != nil {
+		imageIntentResponse, err := client.V3.GetImage(*imageUUID)
+		if err != nil {
+			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+				return "", fmt.Errorf("failed to find image with UUID %s: %v", *imageUUID, err)
+			}
+		}
+		foundImageUUID = *imageIntentResponse.Metadata.UUID
+	} else if imageName != nil {
+		responseImages, err := client.V3.ListAllImage()
+		if err != nil {
+			return "", err
+		}
+		foundImages := make([]*nutanixClientV3.ImageIntentResponse, 0)
+		for _, s := range responseImages.Entities {
+			imageSpec := s.Spec
+			if *imageSpec.Name == *imageName {
+				foundImages = append(foundImages, s)
+			}
+		}
+		if len(foundImages) == 0 {
+			return "", fmt.Errorf("failed to retrieve image by name %s", *imageName)
+		} else if len(foundImages) > 1 {
+			return "", fmt.Errorf("more than one image found with name %s", *imageName)
+		} else {
+			foundImageUUID = *foundImages[0].Metadata.UUID
+		}
+		if foundImageUUID == "" {
+			return "", fmt.Errorf("failed to retrieve image by name or uuid. Verify input parameters.")
+		}
+	}
+	return foundImageUUID, nil
+}
+
+func isExistingVM(client *nutanixClientV3.Client, vmUUID string) (bool, error) {
+	vm, err := findVMByUUID(client, vmUUID)
+	if err != nil {
+		errorMsg := fmt.Errorf("error finding vm with uuid %s: %v", vmUUID, err)
+		klog.Error(errorMsg)
+		return false, errorMsg
+	}
+
+	return vm == nil, nil
+
+}
+
+func hasTaskInProgress(client *nutanixClientV3.Client, taskUUID string) (bool, error) {
+	taskStatus, err := getTaskState(client, taskUUID)
+	if err != nil {
+		return false, err
+	}
+	if taskStatus != taskSucceededMessage {
+		klog.Infof("VM task with UUID %s still in progress: %s. Requeuing", taskUUID, taskStatus)
+		return true, nil
+	}
+	return false, nil
+}
+
+func getTaskUUIDFromVM(vm *nutanixClientV3.VMIntentResponse) (string, error) {
+	if vm == nil {
+		return "", fmt.Errorf("cannot extract task uuid from empty vm object")
+	}
+	taskInterface := vm.Status.ExecutionContext.TaskUUID
+	vmName := *vm.Spec.Name
+
+	switch t := reflect.TypeOf(taskInterface).Kind(); t {
+	case reflect.Slice:
+		l := taskInterface.([]interface{})
+		if len(l) != 1 {
+			return "", fmt.Errorf("Did not find expected amount of task UUIDs for VM %s", vmName)
+		}
+		return l[0].(string), nil
+	case reflect.String:
+		return taskInterface.(string), nil
+	default:
+		return "", fmt.Errorf("Invalid type found for task uuid extracted from vm %s: %v", vmName, t)
+	}
+}
+
+func getTaskState(client *nutanixClientV3.Client, taskUUID string) (string, error) {
+
+	klog.Infof("Getting task with UUID %s", taskUUID)
+	v, err := client.V3.GetTask(taskUUID)
+
+	if err != nil {
+		klog.Errorf("error occurred while waiting for task with UUID %s: %v", taskUUID, err)
+		return "", err
+	}
+
+	if *v.Status == "INVALID_UUID" || *v.Status == "FAILED" {
+		return *v.Status,
+			fmt.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(v.ErrorDetail), utils.StringValue(v.ProgressMessage))
+	}
+	taskStatus := *v.Status
+	klog.Infof("Status for task with UUID %s: %s", taskUUID, taskStatus)
+	return taskStatus, nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -11,7 +12,8 @@ import (
 )
 
 const (
-	ProviderName = "nutanix"
+	ProviderName  = "nutanix"
+	debugModeName = "DEBUG_MODE"
 )
 
 type ClientOptions struct {
@@ -32,13 +34,28 @@ func Client(options ClientOptions) (*nutanixClientV3.Client, error) {
 		Insecure: true,
 	}
 
-	cli, err := nutanixClientV3.NewV3Client(cred, options.Debug)
+	cli, err := nutanixClientV3.NewV3Client(cred, debugMode(options))
 	if err != nil {
 		klog.Errorf("Failed to create the nutanix client. error: %v", err)
 		return nil, err
 	}
 
 	return cli, nil
+}
+
+func debugMode(options ClientOptions) bool {
+	//Read environment variable to enable debug mode
+	debugModeEnv := getEnvVar(debugModeName)
+	if debugModeEnv != "" {
+		//See if env var is set to 'true', otherwise default to false
+		if strings.ToLower(debugModeEnv) == "true" {
+			return true
+		} else {
+			return false
+		}
+	}
+	// If env var not set -> use options
+	return options.Debug
 }
 
 func getEnvVar(key string) (val string) {

--- a/pkg/client/state.go
+++ b/pkg/client/state.go
@@ -8,9 +8,21 @@ import (
 	"k8s.io/klog/v2"
 
 	nutanixClientV3 "github.com/nutanix-core/cluster-api-provider-nutanix/pkg/nutanix/v3"
+	"github.com/nutanix-core/cluster-api-provider-nutanix/pkg/utils"
 )
 
 type stateRefreshFunc func() (string, error)
+
+func WaitForTaskCompletion(conn *nutanixClientV3.Client, uuid string) error {
+	errCh := make(chan error, 1)
+	go waitForState(
+		errCh,
+		"SUCCEEDED",
+		waitUntilTaskStateFunc(conn, uuid))
+
+	err := <-errCh
+	return err
+}
 
 func WaitForGetVMComplete(conn *nutanixClientV3.Client, vmUUID string) error {
 	errCh := make(chan error, 1)
@@ -106,6 +118,31 @@ func waitUntilSubnetStateFunc(conn *nutanixClientV3.Client, uuid string) stateRe
 
 		return *resp.Status.State, nil
 	}
+}
+
+func waitUntilTaskStateFunc(conn *nutanixClientV3.Client, uuid string) stateRefreshFunc {
+	return func() (string, error) {
+		return GetTaskState(conn, uuid)
+	}
+}
+
+func GetTaskState(client *nutanixClientV3.Client, taskUUID string) (string, error) {
+
+	klog.Infof("Getting task with UUID %s", taskUUID)
+	v, err := client.V3.GetTask(taskUUID)
+
+	if err != nil {
+		klog.Errorf("error occurred while waiting for task with UUID %s: %v", taskUUID, err)
+		return "", err
+	}
+
+	if *v.Status == "INVALID_UUID" || *v.Status == "FAILED" {
+		return *v.Status,
+			fmt.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(v.ErrorDetail), utils.StringValue(v.ProgressMessage))
+	}
+	taskStatus := *v.Status
+	klog.Infof("Status for task with UUID %s: %s", taskUUID, taskStatus)
+	return taskStatus, nil
 }
 
 // RetryableFunc performs an action and returns a bool indicating whether the


### PR DESCRIPTION
- Adding the functionality to add multiple subnets
- Removing static IP configuration
- Adding kube-vip support
- improve reconciliation loop
- Implement wait for tasks

