### PR TITLE
add the vm boot type option (legacy or uefi)

### DIFF
--- a/api/v1alpha4/nutanix_types.go
+++ b/api/v1alpha4/nutanix_types.go
@@ -26,6 +26,12 @@ const (
 	// NutanixIdentifierName is a resource identifier identifying the object by Name.
 	NutanixIdentifierName NutanixIdentifierType = "name"
 
+	// NutanixIdentifierBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
+	NutanixIdentifierBootTypeLegacy NutanixIdentifierType = "legacy"
+
+	// NutanixIdentifierBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
+	NutanixIdentifierBootTypeUEFI NutanixIdentifierType = "uefi"
+
 	// DefaultCAPICategoryPrefix is the default category prefix used for CAPI clusters.
 	DefaultCAPICategoryPrefix = "kubernetes-io-cluster-"
 

--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -72,6 +72,11 @@ type NutanixMachineSpec struct {
 	// +kubebuilder:validation:Optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
 
+	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=legacy;uefi
+	BootType string `json:"bootType"`
+
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes
 	// +kubebuilder:validation:Required

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -417,6 +417,7 @@ func autoConvert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *N
 	}
 	out.Subnets = *(*[]v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]v1beta1.NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
+	out.BootType = in.BootType
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil
@@ -435,6 +436,7 @@ func autoConvert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *v
 	}
 	out.Subnets = *(*[]NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
+	out.BootType = in.BootType
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil

--- a/api/v1beta1/nutanix_types.go
+++ b/api/v1beta1/nutanix_types.go
@@ -26,6 +26,12 @@ const (
 	// NutanixIdentifierName is a resource identifier identifying the object by Name.
 	NutanixIdentifierName NutanixIdentifierType = "name"
 
+	// NutanixIdentifierBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
+	NutanixIdentifierBootTypeLegacy NutanixIdentifierType = "legacy"
+
+	// NutanixIdentifierBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
+	NutanixIdentifierBootTypeUEFI NutanixIdentifierType = "uefi"
+
 	// DefaultCAPICategoryPrefix is the default category prefix used for CAPI clusters.
 	DefaultCAPICategoryPrefix = "kubernetes-io-cluster-"
 

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -72,6 +72,11 @@ type NutanixMachineSpec struct {
 	// +kubebuilder:validation:Optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
 
+	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=legacy;uefi
+	BootType string `json:"bootType"`
+
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes
 	// +kubebuilder:validation:Required

--- a/cluster-template.yaml
+++ b/cluster-template.yaml
@@ -42,6 +42,8 @@ spec:
   template:
     spec:
       providerID: "nutanix://${CLUSTER_NAME}-m1"
+      # Supported options for boot type: legacy and uefi
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
       vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
       vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
       memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"

--- a/cluster-template.yaml
+++ b/cluster-template.yaml
@@ -43,6 +43,7 @@ spec:
     spec:
       providerID: "nutanix://${CLUSTER_NAME}-m1"
       # Supported options for boot type: legacy and uefi
+      # Defaults to legacy if not set
       bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
       vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
       vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -58,6 +58,8 @@ spec:
             description: NutanixMachineSpec defines the desired state of NutanixMachine
             properties:
               additionalCategories:
+                description: List of categories that need to be added to the machines.
+                  Categories must already exist in Prism Central
                 items:
                   properties:
                     key:
@@ -69,6 +71,13 @@ spec:
                       type: string
                   type: object
                 type: array
+              bootType:
+                description: Defines the boot type of the virtual machine. Only supports
+                  UEFI and Legacy
+                enum:
+                - legacy
+                - uefi
+                type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
                   resource that holds configuration details.
@@ -366,6 +375,8 @@ spec:
             description: NutanixMachineSpec defines the desired state of NutanixMachine
             properties:
               additionalCategories:
+                description: List of categories that need to be added to the machines.
+                  Categories must already exist in Prism Central
                 items:
                   properties:
                     key:
@@ -377,6 +388,13 @@ spec:
                       type: string
                   type: object
                 type: array
+              bootType:
+                description: Defines the boot type of the virtual machine. Only supports
+                  UEFI and Legacy
+                enum:
+                - legacy
+                - uefi
+                type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
                   resource that holds configuration details.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -71,6 +71,8 @@ spec:
                       of the machine.
                     properties:
                       additionalCategories:
+                        description: List of categories that need to be added to the
+                          machines. Categories must already exist in Prism Central
                         items:
                           properties:
                             key:
@@ -82,6 +84,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      bootType:
+                        description: Defines the boot type of the virtual machine.
+                          Only supports UEFI and Legacy
+                        enum:
+                        - legacy
+                        - uefi
+                        type: string
                       bootstrapRef:
                         description: BootstrapRef is a reference to a bootstrap provider-specific
                           resource that holds configuration details.
@@ -294,6 +303,8 @@ spec:
                       of the machine.
                     properties:
                       additionalCategories:
+                        description: List of categories that need to be added to the
+                          machines. Categories must already exist in Prism Central
                         items:
                           properties:
                             key:
@@ -305,6 +316,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      bootType:
+                        description: Defines the boot type of the virtual machine.
+                          Only supports UEFI and Legacy
+                        enum:
+                        - legacy
+                        - uefi
+                        type: string
                       bootstrapRef:
                         description: BootstrapRef is a reference to a bootstrap provider-specific
                           resource that holds configuration details.

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -637,6 +637,7 @@ func (r *NutanixMachineReconciler) getMachineCategoryIdentifiers(rctx *nctx.Mach
 
 func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vmSpec *nutanixClientV3.VM) error {
 	bootType := rctx.NutanixMachine.Spec.BootType
+	// Defaults to legacy if boot type is not set.
 	if bootType != "" {
 		if bootType != string(infrav1.NutanixIdentifierBootTypeLegacy) && bootType != string(infrav1.NutanixIdentifierBootTypeUEFI) {
 			errorMsg := fmt.Errorf("%s boot type must be %s or %s but was %s", rctx.LogPrefix, string(infrav1.NutanixIdentifierBootTypeLegacy), string(infrav1.NutanixIdentifierBootTypeUEFI), bootType)
@@ -644,6 +645,7 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 			return errorMsg
 		}
 
+		// Only modify VM spec if boot type is UEFI. Otherwise assume default Legacy mode
 		if bootType == string(infrav1.NutanixIdentifierBootTypeUEFI) {
 			vmSpec.Resources.BootConfig = &nutanixClientV3.VMBootConfig{
 				BootType: utils.StringPtr(strings.ToUpper(bootType)),

--- a/pkg/nutanix/v3/v3_structs.go
+++ b/pkg/nutanix/v3/v3_structs.go
@@ -84,6 +84,7 @@ type VMBootConfig struct {
 	// given then specified boot device will be primary boot device and remaining devices will be assigned boot order
 	// according to boot device order field.
 	BootDevice *VMBootDevice `json:"boot_device,omitempty"`
+	BootType   *string       `json:"boot_type,omitempty" mapstructure:"boot_type,omitempty"`
 
 	// Indicates the order of device types in which VM should try to boot from. If boot device order is not provided the
 	// system will decide appropriate boot device order.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds the option to specify the VM boot type
- Possible options: Legacy and UEFI
- Defaults to Legacy

**Special notes for your reviewer**:
- Use UEFI to test the boot of VMs 

**Release note**:

```release-note
- Adds the option to specify VM boot type. Possible options are: Legacy (default) and UEFI
```