### PR TITLE
Fix duplicate crd creation and IMG path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/nutanix/cloud-native/cluster-api-provider-nutanix/controller:latest
+IMG ?= ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
 
 
 # Extract base and tag from IMG


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix crd generation duplicate in the Makefile
Fix IMG path


**How Has This Been Tested?**:

make manifests and check generated crd
make prepare-local-clusterctl and verify img in overdid file

**Release note**:

```release-note
NONE
```