### PR TITLE
implement additional kube-vip settings

### DIFF
--- a/cluster-template.yaml
+++ b/cluster-template.yaml
@@ -148,6 +148,10 @@ spec:
                     value: "10"
                   - name: vip_retryperiod
                     value: "2"
+                  - name: svc_enable
+                    value: "${KUBEVIP_SVC_ENABLE=false}"
+                  - name: lb_enable
+                    value: "${KUBEVIP_LB_ENABLE=false}"
                 securityContext:
                   capabilities:
                     add:

--- a/clusterctl.yaml
+++ b/clusterctl.yaml
@@ -13,6 +13,9 @@ NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
 NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME: ""
 NUTANIX_SUBNET_NAME: ""
 
+KUBEVIP_LB_ENABLE: "false"
+KUBEVIP_SVC_ENABLE: "false"
+
 providers:
   # add a custom provider
   - name: "nutanix"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -90,6 +90,23 @@ You need to follow specific install guide for your selected CNI and you can inst
 Once a Pod network has been installed, you can confirm that it is working by checking that the CoreDNS Pod is Running in the output of kubectl get pods --all-namespaces.
 
 
+### kube-vip settings
+
+kube-vip has the capability to provide a high availability address for both the Kubernetes control plane and for a Kubernetes Servic and also a true load balancing for the control plane to distribute API requests across control plane nodes.
+
+You can tweak this settings by using the following properties
+
+- KUBEVIP_LB_ENABLE
+
+This setting allow you to enable control plane load balancing using IPVS.
+[Control Plane Load-Balancing documentation](https://kube-vip.chipzoller.dev/docs/about/architecture/#control-plane-load-balancing)
+
+- KUBEVIP_SVC_ENABLE 
+
+This setting allow you to enable Service of type LoadBalancer.
+[Kubernetes Service Load Balancing documentation](https://kube-vip.chipzoller.dev/docs/about/architecture/#kubernetes-service-load-balancing)
+
+
 ## Developer workflow
 
 ### Download source code

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,7 +14,7 @@ NUTANIX_ENDPOINT: ""
 NUTANIX_USER: ""
 NUTANIX_PASSWORD: ""
 
-KUBERNETES_VERSION: "v1.21.0"
+KUBERNETES_VERSION: "v1.22.8"
 WORKER_MACHINE_COUNT: 3
 NUTANIX_SSH_AUTHORIZED_KEY: ""
 
@@ -26,15 +26,26 @@ you can also see the required list of variables by running by following command
 <pre>
 clusterctl generate cluster mycluster -i nutanix --list-variables           
 Required Variables:
+  - CONTROL_PLANE_ENDPOINT_IP
   - KUBERNETES_VERSION
-  - NUTANIX_CLUSTER_UUID
-  - NUTANIX_MACHINE_TEMPLATE_IMAGE_UUID
+  - NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME
+  - NUTANIX_PRISM_ELEMENT_CLUSTER_NAME
   - NUTANIX_SSH_AUTHORIZED_KEY
+  - NUTANIX_SUBNET_NAME
 
 Optional Variables:
-  - CLUSTER_NAME          (defaults to mycluster)
-  - NAMESPACE             (defaults to current Namespace in the KubeConfig file)
-  - WORKER_MACHINE_COUNT  (defaults to 0)
+  - CLUSTER_NAME
+  - CONTROL_PLANE_ENDPOINT_PORT      (defaults to "6443")
+  - CONTROL_PLANE_MACHINE_COUNT      (defaults to 1)
+  - KUBEVIP_LB_ENABLE                (defaults to "false")
+  - KUBEVIP_SVC_ENABLE               (defaults to "false")
+  - NAMESPACE                        (defaults to current Namespace in the KubeConfig file)
+  - NUTANIX_MACHINE_BOOT_TYPE        (defaults to "legacy")
+  - NUTANIX_MACHINE_MEMORY_SIZE      (defaults to "4Gi")
+  - NUTANIX_MACHINE_VCPU_PER_SOCKET  (defaults to "1")
+  - NUTANIX_MACHINE_VCPU_SOCKET      (defaults to "2")
+  - NUTANIX_SYSTEMDISK_SIZE          (defaults to "40Gi")
+  - WORKER_MACHINE_COUNT             (defaults to 0)
 
 </pre>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement additional option for kube-Vip:

KUBEVIP_SVC_ENABLE option allow to enable Kubernetes Service Load Balancing who provide a high availability address for Kubernetes Service. 

KUBEVIP_LB_ENABLE option allow to enable support for true load balancing for the control plane to distribute API requests across control plane nodes.


**How Has This Been Tested?**:

Set option to true and deploy cluster

KUBEVIP_SVC_ENABLE was tested with kube-vip cloud provider, a IP address range-global and the deployment of a load-balancer services, check the ip is correctly assigned to svc and you can connect on it from outside of the k8s cluster.

KUBEVIP_LB_ENABLE was tested by deploying a cluster with 3 control plane nodes and next using ipvsadm -l on the control plane node to verify load balancing is correctly set.


```release-note
implement option to enable Kubernetes Service Load Balancing
implement option to enable Control Plane Load-Balancing
```