### PR TITLE
Added project exists check at cluster level

### DIFF
--- a/api/v1alpha4/conditions.go
+++ b/api/v1alpha4/conditions.go
@@ -46,7 +46,7 @@ const (
 )
 
 const (
-	// VMAddressesAssignedCondition shows the status of the process of assigning the VMs to a project
+	// ProjectAssignedCondition shows the status of the process of assigning the VMs to a project
 	ProjectAssignedCondition capiv1.ConditionType = "ProjectAssigned"
 	ProjectAssignationFailed                      = "ProjectAssignationFailed"
 )

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -46,7 +46,7 @@ const (
 )
 
 const (
-	// VMAddressesAssignedCondition shows the status of the process of assigning the VMs to a project
+	// ProjectAssignedCondition shows the status of the process of assigning the VMs to a project
 	ProjectAssignedCondition capiv1.ConditionType = "ProjectAssigned"
 	ProjectAssignationFailed                      = "ProjectAssignationFailed"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a checking mechanism in the NutanixCluster resource to see if a project exists. Reason is to fail the cluster creation as soon as possible if invalid project information is passed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
- Create a cluster without a project referenced -> No change in behaviour
- Create a cluster with valid project referenced -> No change in behaviour
- Create a cluster with invalid (not existing) project -> NutanixCluster will set failure message

**Special notes for your reviewer**:
N/A

**Release note**:
N/A