### PR TITLE
moved projects to nutanixmachine level

### DIFF
--- a/api/v1alpha4/nutanixcluster_types.go
+++ b/api/v1alpha4/nutanixcluster_types.go
@@ -43,10 +43,6 @@ type NutanixClusterSpec struct {
 	// +optional
 	ControlPlaneEndpoint capiv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// Add the Cluster resources to a Prism Central project
-	// +optional
-	Project *NutanixResourceIdentifier `json:"project"`
-
 	// prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
 	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
 	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the

--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -72,7 +72,9 @@ type NutanixMachineSpec struct {
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
-
+	// Add the machine resources to a Prism Central project
+	// +optional
+	Project *NutanixResourceIdentifier `json:"project"`
 	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:=legacy;uefi

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -322,7 +322,6 @@ func autoConvert_v1alpha4_NutanixClusterSpec_To_v1beta1_NutanixClusterSpec(in *N
 	if err := Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.Project = (*v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
 	if err := Convert_v1alpha4_NutanixPrismEndpoint_To_v1beta1_NutanixPrismEndpoint(&in.PrismCentral, &out.PrismCentral, s); err != nil {
 		return err
 	}
@@ -333,7 +332,6 @@ func autoConvert_v1beta1_NutanixClusterSpec_To_v1alpha4_NutanixClusterSpec(in *v
 	if err := Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.Project = (*NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
 	if err := Convert_v1beta1_NutanixPrismEndpoint_To_v1alpha4_NutanixPrismEndpoint(&in.PrismCentral, &out.PrismCentral, s); err != nil {
 		return err
 	}
@@ -472,6 +470,7 @@ func autoConvert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *N
 	}
 	out.Subnets = *(*[]v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]v1beta1.NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
+	out.Project = (*v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
 	out.BootType = in.BootType
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
@@ -491,6 +490,7 @@ func autoConvert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *v
 	}
 	out.Subnets = *(*[]NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
+	out.Project = (*NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
 	out.BootType = in.BootType
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -106,11 +106,6 @@ func (in *NutanixClusterList) DeepCopyObject() runtime.Object {
 func (in *NutanixClusterSpec) DeepCopyInto(out *NutanixClusterSpec) {
 	*out = *in
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
-	if in.Project != nil {
-		in, out := &in.Project, &out.Project
-		*out = new(NutanixResourceIdentifier)
-		(*in).DeepCopyInto(*out)
-	}
 	in.PrismCentral.DeepCopyInto(&out.PrismCentral)
 }
 
@@ -254,6 +249,11 @@ func (in *NutanixMachineSpec) DeepCopyInto(out *NutanixMachineSpec) {
 		in, out := &in.AdditionalCategories, &out.AdditionalCategories
 		*out = make([]NutanixCategoryIdentifier, len(*in))
 		copy(*out, *in)
+	}
+	if in.Project != nil {
+		in, out := &in.Project, &out.Project
+		*out = new(NutanixResourceIdentifier)
+		(*in).DeepCopyInto(*out)
 	}
 	out.SystemDiskSize = in.SystemDiskSize.DeepCopy()
 	if in.BootstrapRef != nil {

--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -43,10 +43,6 @@ type NutanixClusterSpec struct {
 	// +optional
 	ControlPlaneEndpoint capiv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// Add the Cluster resources to a Prism Central project
-	// +optional
-	Project *NutanixResourceIdentifier `json:"project"`
-
 	// prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
 	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
 	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -72,7 +72,9 @@ type NutanixMachineSpec struct {
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
-
+	// Add the machine resources to a Prism Central project
+	// +optional
+	Project *NutanixResourceIdentifier `json:"project"`
 	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:=legacy;uefi

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -106,11 +106,6 @@ func (in *NutanixClusterList) DeepCopyObject() runtime.Object {
 func (in *NutanixClusterSpec) DeepCopyInto(out *NutanixClusterSpec) {
 	*out = *in
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
-	if in.Project != nil {
-		in, out := &in.Project, &out.Project
-		*out = new(NutanixResourceIdentifier)
-		(*in).DeepCopyInto(*out)
-	}
 	in.PrismCentral.DeepCopyInto(&out.PrismCentral)
 }
 
@@ -254,6 +249,11 @@ func (in *NutanixMachineSpec) DeepCopyInto(out *NutanixMachineSpec) {
 		in, out := &in.AdditionalCategories, &out.AdditionalCategories
 		*out = make([]NutanixCategoryIdentifier, len(*in))
 		copy(*out, *in)
+	}
+	if in.Project != nil {
+		in, out := &in.Project, &out.Project
+		*out = new(NutanixResourceIdentifier)
+		(*in).DeepCopyInto(*out)
 	}
 	out.SystemDiskSize = in.SystemDiskSize.DeepCopy()
 	if in.BootstrapRef != nil {

--- a/cluster-template.yaml
+++ b/cluster-template.yaml
@@ -14,13 +14,6 @@ spec:
   controlPlaneEndpoint:
     host: "${CONTROL_PLANE_ENDPOINT_IP}"
     port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}
-  # Adds the cluster virtual machines to a project defined in Prism Central.
-  # Replace NUTANIX_PROJECT_NAME with the correct project defined in Prism Central
-  # Note: Project must already be present in Prism Central.
-  # project:
-  #   type: name
-  #   name: "NUTANIX_PROJECT_NAME"
-
 ---
 apiVersion: v1
 kind: Secret
@@ -86,6 +79,12 @@ spec:
       # additionalCategories:
       #   - key: AppType
       #     value: Kubernetes
+      # Adds the cluster virtual machines to a project defined in Prism Central.
+      # Replace NUTANIX_PROJECT_NAME with the correct project defined in Prism Central
+      # Note: Project must already be present in Prism Central.
+      # project:
+      #   type: name
+      #   name: "NUTANIX_PROJECT_NAME"
 
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -110,24 +110,6 @@ spec:
                 - address
                 - port
                 type: object
-              project:
-                description: Add the Cluster resources to a Prism Central project
-                properties:
-                  name:
-                    description: name is the resource name in the PC
-                    type: string
-                  type:
-                    description: Type is the identifier type to use for this resource.
-                    enum:
-                    - uuid
-                    - name
-                    type: string
-                  uuid:
-                    description: uuid is the UUID of the resource in the PC.
-                    type: string
-                required:
-                - type
-                type: object
             required:
             - prismCentral
             type: object
@@ -300,24 +282,6 @@ spec:
                 required:
                 - address
                 - port
-                type: object
-              project:
-                description: Add the Cluster resources to a Prism Central project
-                properties:
-                  name:
-                    description: name is the resource name in the PC
-                    type: string
-                  type:
-                    description: Type is the identifier type to use for this resource.
-                    enum:
-                    - uuid
-                    - name
-                    type: string
-                  uuid:
-                    description: uuid is the UUID of the resource in the PC.
-                    type: string
-                required:
-                - type
                 type: object
             required:
             - prismCentral

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -164,6 +164,24 @@ spec:
                   the VM The minimum memorySize is 2Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              project:
+                description: Add the machine resources to a Prism Central project
+                properties:
+                  name:
+                    description: name is the resource name in the PC
+                    type: string
+                  type:
+                    description: Type is the identifier type to use for this resource.
+                    enum:
+                    - uuid
+                    - name
+                    type: string
+                  uuid:
+                    description: uuid is the UUID of the resource in the PC.
+                    type: string
+                required:
+                - type
+                type: object
               providerID:
                 type: string
               subnet:
@@ -487,6 +505,24 @@ spec:
                   the VM The minimum memorySize is 2Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              project:
+                description: Add the machine resources to a Prism Central project
+                properties:
+                  name:
+                    description: name is the resource name in the PC
+                    type: string
+                  type:
+                    description: Type is the identifier type to use for this resource.
+                    enum:
+                    - uuid
+                    - name
+                    type: string
+                  uuid:
+                    description: uuid is the UUID of the resource in the PC.
+                    type: string
+                required:
+                - type
+                type: object
               providerID:
                 type: string
               subnet:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -182,6 +182,26 @@ spec:
                           of the VM The minimum memorySize is 2Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      project:
+                        description: Add the machine resources to a Prism Central
+                          project
+                        properties:
+                          name:
+                            description: name is the resource name in the PC
+                            type: string
+                          type:
+                            description: Type is the identifier type to use for this
+                              resource.
+                            enum:
+                            - uuid
+                            - name
+                            type: string
+                          uuid:
+                            description: uuid is the UUID of the resource in the PC.
+                            type: string
+                        required:
+                        - type
+                        type: object
                       providerID:
                         type: string
                       subnet:
@@ -414,6 +434,26 @@ spec:
                           of the VM The minimum memorySize is 2Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      project:
+                        description: Add the machine resources to a Prism Central
+                          project
+                        properties:
+                          name:
+                            description: name is the resource name in the PC
+                            type: string
+                          type:
+                            description: Type is the identifier type to use for this
+                              resource.
+                            enum:
+                            - uuid
+                            - name
+                            type: string
+                          uuid:
+                            description: uuid is the UUID of the resource in the PC.
+                            type: string
+                        required:
+                        - type
+                        type: object
                       providerID:
                         type: string
                       subnet:

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -699,7 +699,7 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 func (r *NutanixMachineReconciler) addVMToProject(rctx *nctx.MachineContext, vmMetadata *nutanixClientV3.Metadata) error {
 
 	vmName := rctx.NutanixMachine.Name
-	projectRef := rctx.NutanixCluster.Spec.Project
+	projectRef := rctx.NutanixMachine.Spec.Project
 	if projectRef == nil {
 		klog.Infof("%s Not linking VM %s to a project", rctx.LogPrefix, vmName)
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the project attribute at nutanixmachine level for increased flexibility.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
- Create cluster without project assigned
- Create a cluster with machine deployment assigned to a project

Additional tests performed by @tuxtof:
- create a cluster with machine in default project
- create a new machine template with a new project inside
- change the machine template in the machine deployment

=> rolling upgrade of each node in the new project 

**Special notes for your reviewer**:
N/A

**Release note**:
N/A