### PR TITLE
add image info

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,12 +84,24 @@ jobs:
         yq -i '(.releaseSeries[] | select(.contract == "v1beta1")).major |= env(MAJOR)' metadata.yaml
         yq -i '(.releaseSeries[] | select(.contract == "v1beta1")).minor |= env(MINOR)' metadata.yaml
 
+    - name: generate image info
+      env:
+        NEW_IMG: ghcr.io/${{ github.repository }}/controller:${{ steps.meta.outputs.version }}
+      run: |
+        echo "## Images" >> ${{ github.workspace }}-CHANGELOG.txt
+        echo "|Name|Link|" >> ${{ github.workspace }}-CHANGELOG.txt
+        echo "|-|-|" >> ${{ github.workspace }}-CHANGELOG.txt
+        echo "|CAPX|[$NEW_IMG]($NEW_IMG)|" >> ${{ github.workspace }}-CHANGELOG.txt
+
+
     - name: create release
       uses: softprops/action-gh-release@v1
       with:
         draft: false
         prerelease: true
+        body_path: ${{ github.workspace }}-CHANGELOG.txt
         generate_release_notes: true
+        append_body: true
         files: |
           infrastructure-components.yaml
           metadata.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

this change add image reference link at the beginning of a new release notes

![image](https://user-images.githubusercontent.com/180613/173062963-50c6f87e-5904-4d09-97de-72202865c840.png)


**How Has This Been Tested?**:

make a new release and check the release note
