### PR TITLE
adding e2e tests for default secret and credentialRef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ testbin/*
 # Test binary, build with `go test -c`
 *.test
 
+# auto-generated e2e cluster-template yaml files
+test/e2e/data/infrastructure-nutanix/*/cluster-template*.yaml
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,9 @@ cluster-templates-v1alpha4: $(KUSTOMIZE) ## Generate cluster templates for v1alp
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1alpha4/cluster-template --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1alpha4/cluster-template.yaml
 
 cluster-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1beta1
-	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template.yaml 
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-secret --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-secret.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref.yaml
 
 ##@ Testing
 

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -79,6 +79,8 @@ providers:
         files:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-secret.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/bases/cluster-with-kcp.yaml
@@ -15,16 +15,6 @@ spec:
     host: "${CONTROL_PLANE_ENDPOINT_IP}"
     port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "${CLUSTER_NAME}"
-  namespace: "${NAMESPACE}"
-stringData:
-  NUTANIX_PASSWORD: "${NUTANIX_PASSWORD}"
-  NUTANIX_USER: "${NUTANIX_USER}"
-
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -48,44 +38,6 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
     name: "${CLUSTER_NAME}"
-
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixMachineTemplate
-metadata:
-  name: "${CLUSTER_NAME}-mt-0"
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec:
-      providerID: "nutanix://${CLUSTER_NAME}-m1"
-      # Supported options for boot type: legacy and uefi
-      # Defaults to legacy if not set
-      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
-      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
-      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
-      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"
-      systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
-      image:
-        type: name
-        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}"
-      cluster:
-        type: name
-        name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
-      subnet:
-        - type: name
-          name: "${NUTANIX_SUBNET_NAME}"
-      # Adds additional categories to the virtual machines.
-      # Note: Categories must already be present in Prism Central
-      # additionalCategories:
-      #   - key: AppType
-      #     value: Kubernetes
-      # Adds the cluster virtual machines to a project defined in Prism Central.
-      # Replace NUTANIX_PROJECT_NAME with the correct project defined in Prism Central
-      # Note: Project must already be present in Prism Central.
-      # project:
-      #   type: name
-      #   name: "NUTANIX_PROJECT_NAME"
 
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/bases/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/bases/nmt.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-mt-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://${CLUSTER_NAME}-m1"
+      # Supported options for boot type: legacy and uefi
+      # Defaults to legacy if not set
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
+      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
+      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"
+      systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
+      image:
+        type: name
+        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}"
+      cluster:
+        type: name
+        name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
+      subnet:
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"
+      # Adds additional categories to the virtual machines.
+      # Note: Categories must already be present in Prism Central
+      # additionalCategories:
+      #   - key: AppType
+      #     value: Kubernetes
+      # Adds the cluster virtual machines to a project defined in Prism Central.
+      # Replace NUTANIX_PROJECT_NAME with the correct project defined in Prism Central
+      # Note: Project must already be present in Prism Central.
+      # project:
+      #   type: name
+      #   name: "NUTANIX_PROJECT_NAME"

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/bases/secret.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/bases/secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "${CLUSTER_NAME}"
+  namespace: "${NAMESPACE}"
+stringData:
+  NUTANIX_PASSWORD: "${NUTANIX_PASSWORD}"
+  NUTANIX_USER: "${NUTANIX_USER}"

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref/kustomization.yaml
@@ -1,7 +1,9 @@
 bases:
   - ../bases/cluster-with-kcp.yaml
-  - ../bases/secret.yaml
   - ../bases/nmt.yaml
   - ../bases/crs.yaml
   - ../bases/md.yaml
   - ../bases/mhc.yaml
+
+patchesStrategicMerge:
+  - ./nc.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref/nc.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref/nc.yaml
@@ -1,0 +1,15 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  namespace: "${NAMESPACE}"
+spec:
+  prismCentral:
+    address: "${NUTANIX_ENDPOINT}"
+    port: ${NUTANIX_PORT=9440}
+    insecure: ${NUTANIX_INSECURE=false}
+    credentialRef:
+      $patch: delete
+  controlPlaneEndpoint:
+    host: "${CONTROL_PLANE_ENDPOINT_IP}"
+    port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret/kustomization.yaml
@@ -1,6 +1,5 @@
 bases:
   - ../bases/cluster-with-kcp.yaml
-  - ../bases/secret.yaml
   - ../bases/nmt.yaml
   - ../bases/crs.yaml
   - ../bases/md.yaml

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,6 +38,8 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
 // Test suite flags.
@@ -183,6 +185,8 @@ var _ = SynchronizedAfterSuite(func() {
 func initScheme() *runtime.Scheme {
 	sc := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(sc)
+	err := infrav1.AddToScheme(sc)
+	Expect(err).NotTo(HaveOccurred())
 	return sc
 }
 

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -1,0 +1,144 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+var _ = Describe("Nutanix client [PR-Blocking]", func() {
+	var (
+		namespace        *corev1.Namespace
+		specName         = "cluster-ntnx-client"
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+	)
+	BeforeEach(func() {
+		clusterName = generateTestClusterName(specName)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+	})
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster without credentialRef (use default credentials)", func() {
+		flavor = "no-credential-ref"
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		deployClusterAndWait(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				e2eConfig:             *e2eConfig,
+			}, clusterResources)
+
+		By("checking cluster prism client init condition is true")
+		verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			clusterName:           clusterName,
+			namespace:             namespace,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			expectedCondition: clusterv1.Condition{
+				Type:   infrav1.PrismCentralClientCondition,
+				Status: corev1.ConditionTrue,
+			},
+		})
+
+		By("PASSED!")
+	})
+
+	It("Create a cluster without secret and add it later", func() {
+		flavor = "no-secret"
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		deployCluster(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				e2eConfig:             *e2eConfig,
+			}, clusterResources)
+
+		By("Checking cluster condition for credentials is set to false")
+		verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			clusterName:           clusterName,
+			namespace:             namespace,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			expectedCondition: clusterv1.Condition{
+				Type:     infrav1.CredentialRefSecretOwnerSetCondition,
+				Reason:   infrav1.CredentialRefSecretOwnerSetFailed,
+				Severity: clusterv1.ConditionSeverityError,
+				Status:   corev1.ConditionFalse,
+			},
+		})
+
+		By("Creating secret using e2e credentials")
+		nutanixCreds := getNutanixCredentialsFromEnvironment()
+		createSecret(createSecretParams{
+			username:    nutanixCreds.nutanixUsername,
+			password:    nutanixCreds.nutanixPassword,
+			namespace:   namespace,
+			clusterName: clusterName,
+		})
+
+		By("checking cluster credential condition is true")
+		verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			clusterName:           clusterName,
+			namespace:             namespace,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			expectedCondition: clusterv1.Condition{
+				Type:   infrav1.CredentialRefSecretOwnerSetCondition,
+				Status: corev1.ConditionTrue,
+			},
+		})
+
+		By("checking cluster prism client init condition is true")
+		verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			clusterName:           clusterName,
+			namespace:             namespace,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			expectedCondition: clusterv1.Condition{
+				Type:   infrav1.PrismCentralClientCondition,
+				Status: corev1.ConditionTrue,
+			},
+		})
+
+		By("PASSED!")
+	})
+})

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -1,0 +1,231 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	nutanixProviderIDPrefix = "nutanix://"
+
+	defaultTimeout  = time.Second * 60
+	defaultInterval = time.Second * 10
+
+	nutanixUserKey     = "NUTANIX_USER"
+	nutanixPasswordKey = "NUTANIX_PASSWORD"
+)
+
+type deployClusterParams struct {
+	clusterName           string
+	namespace             *corev1.Namespace
+	flavor                string
+	clusterctlConfigPath  string
+	artifactFolder        string
+	bootstrapClusterProxy framework.ClusterProxy
+	e2eConfig             clusterctl.E2EConfig
+}
+
+func deployClusterAndWait(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
+	cc := clusterctl.ConfigClusterInput{
+		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
+		ClusterctlConfigPath:     params.clusterctlConfigPath,
+		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
+		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+		Flavor:                   params.flavor,
+		Namespace:                params.namespace.Name,
+		ClusterName:              params.clusterName,
+		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: pointer.Int64Ptr(1),
+		WorkerMachineCount:       pointer.Int64Ptr(1),
+	}
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 params.bootstrapClusterProxy,
+		ConfigCluster:                cc,
+		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+}
+
+func deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
+	cc := clusterctl.ConfigClusterInput{
+		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
+		ClusterctlConfigPath:     params.clusterctlConfigPath,
+		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
+		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+		Flavor:                   params.flavor,
+		Namespace:                params.namespace.Name,
+		ClusterName:              params.clusterName,
+		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: pointer.Int64Ptr(1),
+		WorkerMachineCount:       pointer.Int64Ptr(1),
+	}
+
+	createClusterFromConfig(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 params.bootstrapClusterProxy,
+		ConfigCluster:                cc,
+		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+}
+
+func generateTestClusterName(specName string) string {
+	return fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+}
+
+func createClusterFromConfig(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for createClusterFromConfig")
+	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling createClusterFromConfig")
+	Expect(result).ToNot(BeNil(), "Invalid argument. result can't be nil when calling createClusterFromConfig")
+	Expect(input.ConfigCluster.ControlPlaneMachineCount).ToNot(BeNil())
+	Expect(input.ConfigCluster.WorkerMachineCount).ToNot(BeNil())
+
+	clusterTemplate := clusterctl.ConfigCluster(ctx, clusterctl.ConfigClusterInput{
+		KubeconfigPath:           input.ConfigCluster.KubeconfigPath,
+		ClusterctlConfigPath:     input.ConfigCluster.ClusterctlConfigPath,
+		Flavor:                   input.ConfigCluster.Flavor,
+		Namespace:                input.ConfigCluster.Namespace,
+		ClusterName:              input.ConfigCluster.ClusterName,
+		KubernetesVersion:        input.ConfigCluster.KubernetesVersion,
+		ControlPlaneMachineCount: input.ConfigCluster.ControlPlaneMachineCount,
+		WorkerMachineCount:       input.ConfigCluster.WorkerMachineCount,
+		InfrastructureProvider:   input.ConfigCluster.InfrastructureProvider,
+		LogFolder:                input.ConfigCluster.LogFolder,
+	})
+	Expect(clusterTemplate).ToNot(BeNil())
+
+	Expect(input.ClusterProxy.Apply(ctx, clusterTemplate, input.Args...)).To(Succeed())
+
+	result.Cluster = framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+		Getter:    input.ClusterProxy.GetClient(),
+		Name:      input.ConfigCluster.ClusterName,
+		Namespace: input.ConfigCluster.Namespace,
+	})
+	Expect(result.Cluster).ToNot(BeNil())
+}
+
+type getNutanixClusterByNameInput struct {
+	Getter    framework.Getter
+	Name      string
+	Namespace string
+}
+
+func getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameInput) *infrav1.NutanixCluster {
+	cluster := &infrav1.NutanixCluster{}
+	key := client.ObjectKey{
+		Namespace: input.Namespace,
+		Name:      input.Name,
+	}
+	Expect(input.Getter.Get(ctx, key, cluster)).To(Succeed(), "Failed to get Nutanix Cluster object %s/%s", input.Namespace, input.Name)
+	return cluster
+}
+
+type verifyConditionOnNutanixClusterParams struct {
+	bootstrapClusterProxy framework.ClusterProxy
+	clusterName           string
+	namespace             *corev1.Namespace
+	expectedCondition     clusterv1.Condition
+}
+
+func verifyConditionOnNutanixCluster(params verifyConditionOnNutanixClusterParams) {
+	Eventually(
+		func() []clusterv1.Condition {
+			cluster := getNutanixClusterByName(ctx, getNutanixClusterByNameInput{
+				Getter:    params.bootstrapClusterProxy.GetClient(),
+				Name:      params.clusterName,
+				Namespace: params.namespace.Name,
+			})
+			return cluster.Status.Conditions
+		},
+		defaultTimeout,
+		defaultInterval,
+	).Should(
+		ContainElement(
+			gstruct.MatchFields(
+				gstruct.IgnoreExtras,
+				gstruct.Fields{
+					"Type":     Equal(params.expectedCondition.Type),
+					"Reason":   Equal(params.expectedCondition.Reason),
+					"Severity": Equal(params.expectedCondition.Severity),
+					"Status":   Equal(params.expectedCondition.Status),
+				},
+			),
+		),
+	)
+}
+
+type createSecretParams struct {
+	namespace   *corev1.Namespace
+	clusterName string
+	username    string
+	password    string
+}
+
+func createSecret(params createSecretParams) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.clusterName,
+			Namespace: params.namespace.Name,
+		},
+		Data: map[string][]byte{
+			"NUTANIX_USER":     []byte(params.username),
+			"NUTANIX_PASSWORD": []byte(params.password),
+		},
+	}
+	Eventually(func() error {
+		return bootstrapClusterProxy.GetClient().Create(ctx, secret)
+	}, defaultTimeout, defaultInterval).Should(Succeed())
+}
+
+type nutanixCredentials struct {
+	nutanixUsername string
+	nutanixPassword string
+}
+
+func getNutanixCredentialsFromEnvironment() nutanixCredentials {
+	nutanixUsername := os.Getenv(nutanixUserKey)
+	Expect(nutanixUsername).ToNot(BeNil())
+	nutanixPassword := os.Getenv(nutanixPasswordKey)
+	Expect(nutanixPassword).ToNot(BeNil())
+	return nutanixCredentials{
+		nutanixUsername: nutanixUsername,
+		nutanixPassword: nutanixPassword,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add nutanix client e2e tests.
Testcases:
- Create a cluster without credentialRef (use default credentials)
- Create a cluster without secret but at it at a later stage

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
```
make test-e2e
```

**Special notes for your reviewer**:
N/A

**Release note**:
```release-note
- Add Nutanix client e2e tests
```