### PR TITLE
fixed setup envtest as well as image update to kind fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,8 +236,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize prepare-local-clusterctl docker-push-kind ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	clusterctl delete --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} --include-crd || true
 	clusterctl init --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} -v 9
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	# cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	# $(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
It was observed that any changes made to the controller code were not getting updated again on the kind cluster during "make deploy" as we were failing to install provider due to existing provider presence and were not installing latest image.

we had 2 options:
1. install provider and if it fails due to existing presence then ignore the error and set the newer image
2. either remove provider and reinstall provider and set the newer image

Tried option 1 but it was failing hence using option 2. will need more investigation with option 1.
uploading this fix to unblock others.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:
<pre>
 make deploy                    
/Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/controller-gen-v0.8.0 "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
mkdir -p ~/.cluster-api/overrides/infrastructure-nutanix/v0.0.0
cd config/manager && /Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 edit set image controller=ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
/Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build config/default > ~/.cluster-api/overrides/infrastructure-nutanix/v0.0.0/infrastructure-components.yaml
cp ./metadata.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v0.0.0
cp ./templates/cluster-template.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v0.0.0
cp ./clusterctl.yaml ~/.cluster-api/clusterctl.yaml
GOBIN=/Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin /Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/scripts/go_install.sh k8s.io/code-generator/cmd/conversion-gen conversion-gen v0.23.6
/Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/controller-gen-v0.8.0 object:headerFile="hack/boilerplate.go.txt" paths="./..."
# /Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/conversion-gen \
	# --input-dirs=./api/v1alpha4 \
	# --input-dirs=./api/v1beta1 \
	# --build-tag=ignore_autogenerated_core \
	# --output-file-base=zz_generated.conversion \
	# --go-header-file=./hack/boilerplate.go.txt
go fmt ./...
go vet ./...
KUBEBUILDER_ASSETS="/Users/deepak.muley/Library/Application Support/io.kubebuilder.envtest/k8s/1.23.5-darwin-amd64" go test ./... -coverprofile cover.out
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix	[no test files]
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1alpha4	[no test files]
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1	[no test files]
ok  	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/controllers	8.048s	coverage: 2.3% of statements
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/client	[no test files]
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/context	[no test files]
?   	github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e	[no test files]
GOOS=linux GOARCH=amd64 KO_DOCKER_REPO=ko.local /Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/ko-v0.11.2 build -B -t latest -L .
2022/06/27 14:22:48 Using base gcr.io/distroless/static:nonroot@sha256:66cd130e90992bebb68b8735a72f8ad154d0cd4a6f3a8b76f1e372467818d1b4 for github.com/nutanix-cloud-native/cluster-api-provider-nutanix
2022/06/27 14:22:49 Building github.com/nutanix-cloud-native/cluster-api-provider-nutanix for linux/amd64
2022/06/27 14:22:54 Loading ko.local/cluster-api-provider-nutanix:9424091256da7668bc18d4aed90a2fabba2686374b1d6438a28aa8287deb1038
2022/06/27 14:22:55 Loaded ko.local/cluster-api-provider-nutanix:9424091256da7668bc18d4aed90a2fabba2686374b1d6438a28aa8287deb1038
2022/06/27 14:22:55 Adding tag latest
2022/06/27 14:22:55 Added tag latest
ko.local/cluster-api-provider-nutanix:9424091256da7668bc18d4aed90a2fabba2686374b1d6438a28aa8287deb1038
docker tag ko.local/cluster-api-provider-nutanix:latest ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
kind load docker-image --name capi-test ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
Image: "ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest" with ID "sha256:67935f8a7d097ae64717cfc7125c1c8b547b08d76f515a165715cb9788d78690" not yet present on node "capi-test-control-plane", loading...
clusterctl delete --infrastructure nutanix:v0.0.0 --include-crd || true
Using configuration File="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
Deleting Provider="infrastructure-nutanix" Version="v0.0.0" Namespace="capx-system"
Deleting ConfigMap="capx-manager-config" Namespace="capx-system"
Deleting ServiceAccount="capx-controller-manager" Namespace="capx-system"
Deleting Secret="capx-nutanix-creds" Namespace="capx-system"
Deleting Endpoints="capx-controller-manager-metrics-service" Namespace="capx-system"
Deleting Service="capx-controller-manager-metrics-service" Namespace="capx-system"
Deleting Deployment="capx-controller-manager" Namespace="capx-system"
Deleting RoleBinding="capx-leader-election-rolebinding" Namespace="capx-system"
Deleting Role="capx-leader-election-role" Namespace="capx-system"
Deleting ClusterRoleBinding="capx-system-capx-manager-rolebinding"
Deleting ClusterRoleBinding="capx-system-capx-proxy-rolebinding"
Deleting ClusterRole="capx-system-capx-manager-role"
Deleting ClusterRole="capx-system-capx-metrics-reader"
Deleting ClusterRole="capx-system-capx-proxy-role"
Deleting CustomResourceDefinition="nutanixclusters.infrastructure.cluster.x-k8s.io"
Deleting CustomResourceDefinition="nutanixmachines.infrastructure.cluster.x-k8s.io"
Deleting CustomResourceDefinition="nutanixmachinetemplates.infrastructure.cluster.x-k8s.io"
Deleting EndpointSlice="capx-controller-manager-metrics-service-mz4kz" Namespace="capx-system"
Deleting Provider="infrastructure-nutanix" Namespace="capx-system"
Using configuration File="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
clusterctl init --infrastructure nutanix:v0.0.0 -v 9
Using configuration File="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
Fetching providers
Using Override="infrastructure-components.yaml" Provider="infrastructure-nutanix" Version="v0.0.0"
Fetching File="metadata.yaml" Provider="cluster-api" Type="CoreProvider" Version="v1.1.4"
Using Override="metadata.yaml" Provider="infrastructure-nutanix" Version="v0.0.0"
Creating Namespace="cert-manager-test"
Creating Issuer="test-selfsigned" Namespace="cert-manager-test"
Creating Certificate="selfsigned-cert" Namespace="cert-manager-test"
Deleting Namespace="cert-manager-test"
Deleting Issuer="test-selfsigned" Namespace="cert-manager-test"
Deleting Certificate="selfsigned-cert" Namespace="cert-manager-test"
Skipping installing cert-manager as it is already installed
Installing Provider="infrastructure-nutanix" Version="v0.0.0" TargetNamespace="capx-system"
Creating objects Provider="infrastructure-nutanix" Version="v0.0.0" TargetNamespace="capx-system"
Patching Namespace="capx-system"
Creating CustomResourceDefinition="nutanixclusters.infrastructure.cluster.x-k8s.io"
Creating CustomResourceDefinition="nutanixmachines.infrastructure.cluster.x-k8s.io"
Creating CustomResourceDefinition="nutanixmachinetemplates.infrastructure.cluster.x-k8s.io"
Creating ServiceAccount="capx-controller-manager" Namespace="capx-system"
Creating Role="capx-leader-election-role" Namespace="capx-system"
Creating ClusterRole="capx-system-capx-manager-role"
Creating ClusterRole="capx-system-capx-metrics-reader"
Creating ClusterRole="capx-system-capx-proxy-role"
Creating RoleBinding="capx-leader-election-rolebinding" Namespace="capx-system"
Creating ClusterRoleBinding="capx-system-capx-manager-rolebinding"
Creating ClusterRoleBinding="capx-system-capx-proxy-rolebinding"
Creating ConfigMap="capx-manager-config" Namespace="capx-system"
Creating Secret="capx-nutanix-creds" Namespace="capx-system"
Creating Service="capx-controller-manager-metrics-service" Namespace="capx-system"
Creating Deployment="capx-controller-manager" Namespace="capx-system"
Creating inventory entry Provider="infrastructure-nutanix" Version="v0.0.0" TargetNamespace="capx-system"
Using configuration File="/Users/deepak.muley/.cluster-api/clusterctl.yaml"
cd config/manager && /Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 edit set image controller=ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
/Users/deepak.muley/go/src/github.com/deepakm-ntnx/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build config/default | kubectl apply -f -
namespace/capx-system unchanged
Warning: resource customresourcedefinitions/nutanixclusters.infrastructure.cluster.x-k8s.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/nutanixclusters.infrastructure.cluster.x-k8s.io configured
Warning: resource customresourcedefinitions/nutanixmachines.infrastructure.cluster.x-k8s.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/nutanixmachines.infrastructure.cluster.x-k8s.io configured
Warning: resource customresourcedefinitions/nutanixmachinetemplates.infrastructure.cluster.x-k8s.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/nutanixmachinetemplates.infrastructure.cluster.x-k8s.io configured
Warning: resource serviceaccounts/capx-controller-manager is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
serviceaccount/capx-controller-manager configured
Warning: resource roles/capx-leader-election-role is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
role.rbac.authorization.k8s.io/capx-leader-election-role configured
clusterrole.rbac.authorization.k8s.io/capx-manager-role configured
clusterrole.rbac.authorization.k8s.io/capx-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/capx-proxy-role unchanged
Warning: resource rolebindings/capx-leader-election-rolebinding is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
rolebinding.rbac.authorization.k8s.io/capx-leader-election-rolebinding configured
clusterrolebinding.rbac.authorization.k8s.io/capx-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/capx-proxy-rolebinding unchanged
Warning: resource configmaps/capx-manager-config is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
configmap/capx-manager-config configured
Warning: resource secrets/capx-nutanix-creds is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
secret/capx-nutanix-creds configured
Warning: resource services/capx-controller-manager-metrics-service is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
service/capx-controller-manager-metrics-service configured
Warning: resource deployments/capx-controller-manager is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
deployment.apps/capx-controller-manager configured
</pre>

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note

```