### PR TITLE
adding nutanix category e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,8 @@ cluster-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1beta
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template.yaml 
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-secret --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-secret.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt.yaml
 
 ##@ Testing
 

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -1,0 +1,183 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	defaultClusterCategoryKeyPrefix           = "kubernetes-io-cluster"
+	defaultClusterCategoryValue               = "owned"
+	defaultNonExistingAdditionalCategoryKey   = "nonExistingCategoryKeyCAPX"
+	defaultNonExistingAdditionalCategoryValue = "nonExistingCategoryValueCAPX"
+)
+
+var _ = Describe("Nutanix categories [PR-Blocking]", func() {
+	const (
+		specName = "cluster-categories"
+	)
+
+	var (
+		namespace        *corev1.Namespace
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+		testHelper       testHelperInterface
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper()
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster with default cluster categories (no additional categories)", func() {
+		Expect(namespace).NotTo(BeNil())
+		flavor := clusterctl.DefaultFlavor
+		expectedCategoryKey := testHelper.getExpectedClusterCategoryKey(clusterName)
+		By("Creating a workload cluster (no additional categories)", func() {
+			testHelper.deployClusterAndWait(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+					e2eConfig:             *e2eConfig,
+				}, clusterResources)
+		})
+
+		By("Checking cluster category condition is true", func() {
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				expectedCondition: clusterv1.Condition{
+					Type:   infrav1.ClusterCategoryCreatedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			})
+		})
+
+		By("Checking if a category was created", func() {
+			testHelper.verifyCategoryExists(expectedCategoryKey, defaultClusterCategoryValue)
+		})
+
+		By("Checking if there are VMs assigned to this category", func() {
+			expectedCategories := map[string]string{
+				expectedCategoryKey: defaultClusterCategoryValue,
+			}
+			testHelper.verifyCategoriesNutanixMachines(clusterName, namespace.Name, expectedCategories)
+		})
+
+		By("PASSED!")
+	})
+
+	It("Create a cluster with additional categories", func() {
+		Expect(namespace).NotTo(BeNil())
+		flavor := "additional-categories"
+
+		By("Creating a workload cluster", func() {
+			testHelper.deployClusterAndWait(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+					e2eConfig:             *e2eConfig,
+				}, clusterResources)
+		})
+
+		By("Verify if additional categories are assigned to the vms", func() {
+			expectedCategoryKey := testHelper.getExpectedClusterCategoryKey(clusterName)
+			expectedCategories := map[string]string{
+				expectedCategoryKey: defaultClusterCategoryValue,
+				"AppType":           "Kubernetes",
+				"Environment":       "Dev",
+			}
+
+			testHelper.verifyCategoriesNutanixMachines(clusterName, namespace.Name, expectedCategories)
+		})
+
+		By("PASSED!")
+	})
+
+	It("Create a cluster linked to non-existing categories (should fail)", func() {
+		flavor = "no-nmt"
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating Nutanix Machine Template with invalid categories", func() {
+			invalidProjectNMT := testHelper.createDefaultNMT(clusterName, namespace.Name)
+			invalidProjectNMT.Spec.Template.Spec.AdditionalCategories = []infrav1.NutanixCategoryIdentifier{
+				{
+					Key:   defaultNonExistingAdditionalCategoryKey,
+					Value: defaultNonExistingAdditionalCategoryValue,
+				},
+			}
+			testHelper.createNutanixMachineTemplate(ctx, createNutanixMachineTemplateParams{
+				creator:                bootstrapClusterProxy.GetClient(),
+				nutanixMachineTemplate: invalidProjectNMT,
+			})
+		})
+
+		By("Creating a workload cluster", func() {
+			testHelper.deployCluster(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+					e2eConfig:             *e2eConfig,
+				}, clusterResources)
+		})
+
+		By("Checking machine status is 'Failed' and failure message is set", func() {
+			testHelper.verifyFailureMessageOnClusterMachines(ctx, verifyFailureMessageOnClusterMachinesParams{
+				clusterName:            clusterName,
+				namespace:              namespace,
+				expectedPhase:          "Failed",
+				expectedFailureMessage: "not found in category",
+				bootstrapClusterProxy:  bootstrapClusterProxy,
+			})
+		})
+
+		By("PASSED!")
+	})
+})

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -81,6 +81,8 @@ providers:
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-secret.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/secret.yaml
+  - ../bases/nmt.yaml
+  - ../bases/crs.yaml
+  - ../bases/md.yaml
+  - ../bases/mhc.yaml
+
+patchesStrategicMerge:
+  - ./nmt.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/nmt.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-mt-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      additionalCategories:
+        # Use System category Apptype:Kubernetes
+        - key: AppType
+          value: Kubernetes
+        # Use System category Environment:Dev
+        - key: Environment
+          value: Dev

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/secret.yaml
+  - ../bases/crs.yaml
+  - ../bases/md.yaml
+  - ../bases/mhc.yaml

--- a/test/e2e/nutanix_client.go
+++ b/test/e2e/nutanix_client.go
@@ -1,0 +1,88 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"os"
+	"strconv"
+
+	prismGoClient "github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix"
+	prismGoClientV3 "github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3"
+	. "github.com/onsi/gomega"
+
+	nutanixClientHelper "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/client"
+)
+
+var (
+	nutanixEndpoint string
+	nutanixPort     string
+	nutanixInsecure string
+)
+
+func init() {
+	flag.StringVar(&nutanixEndpoint, "e2e.nutanixEndpoint", os.Getenv("NUTANIX_ENDPOINT"), "the Nutanix Prism Central used for e2e tests")
+	flag.StringVar(&nutanixPort, "e2e.nutanixPort", os.Getenv("NUTANIX_PORT"), "the Nutanix Prism Central port used for e2e tests")
+	flag.StringVar(&nutanixInsecure, "e2e.nutanixInsecure", os.Getenv("NUTANIX_INSECURE"), "Ignore certificate checks for e2e tests")
+}
+
+type nutanixCredentials struct {
+	nutanixUsername string
+	nutanixPassword string
+}
+
+func getNutanixCredentialsFromEnvironment() nutanixCredentials {
+	nutanixUsername := os.Getenv(nutanixUserKey)
+	Expect(nutanixUsername).ToNot(BeNil())
+	nutanixPassword := os.Getenv(nutanixPasswordKey)
+	Expect(nutanixPassword).ToNot(BeNil())
+	return nutanixCredentials{
+		nutanixUsername: nutanixUsername,
+		nutanixPassword: nutanixPassword,
+	}
+}
+
+func initNutanixClient() (*prismGoClientV3.Client, error) {
+	insecureBool, err := strconv.ParseBool(nutanixInsecure)
+	if err != nil {
+		return nil, err
+	}
+
+	c := getNutanixCredentialsFromEnvironment()
+	creds := prismGoClient.Credentials{
+		Insecure: insecureBool,
+		Port:     nutanixPort,
+		Endpoint: nutanixEndpoint,
+		Username: c.nutanixUsername,
+		Password: c.nutanixPassword,
+	}
+
+	nutanixClient, err := nutanixClientHelper.Client(creds, nutanixClientHelper.ClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = nutanixClient.V3.GetCurrentLoggedInUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nutanixClient, nil
+}

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -24,11 +24,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	prismGoClientV3 "github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -46,71 +49,60 @@ const (
 	defaultTimeout  = time.Second * 60
 	defaultInterval = time.Second * 10
 
+	defaultVCPUsPerSocket = int32(1)
+	defaultVCPUSockets    = int32(2)
+	defaultMemorySize     = "4Gi"
+	defaultSystemDiskSize = "40Gi"
+	defaultBootType       = "legacy"
+
 	nutanixUserKey     = "NUTANIX_USER"
 	nutanixPasswordKey = "NUTANIX_PASSWORD"
+
+	categoryKeyEnvVarKey   = "NUTANIX_ADDITIONAL_CATEGORY_KEY"
+	categoryValueEnvVarKey = "NUTANIX_ADDITIONAL_CATEGORY_VALUE"
+	imageEnvVarKey         = "NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME"
+	clusterEnvVarKey       = "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME"
+	subnetEnvVarKey        = "NUTANIX_SUBNET_NAME"
+
+	nameType = "name"
 )
 
-type deployClusterParams struct {
-	clusterName           string
-	namespace             *corev1.Namespace
-	flavor                string
-	clusterctlConfigPath  string
-	artifactFolder        string
-	bootstrapClusterProxy framework.ClusterProxy
-	e2eConfig             clusterctl.E2EConfig
+
+type testHelperInterface interface {
+	createClusterFromConfig(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult)
+	createDefaultNMT(clusterName, namespace string) *infrav1.NutanixMachineTemplate
+	createNutanixMachineTemplate(ctx context.Context, params createNutanixMachineTemplateParams)
+	createSecret(params createSecretParams)
+	deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult)
+	deployClusterAndWait(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult)
+	generateNMTName(clusterName string) string
+	generateNMTProviderID(clusterName string) string
+	generateTestClusterName(specName string) string
+	getExpectedClusterCategoryKey(clusterName string) string
+	getMachinesForCluster(ctx context.Context, clusterName, namespace string, bootstrapClusterProxy framework.ClusterProxy) *clusterv1.MachineList
+	getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameInput) *infrav1.NutanixCluster
+	getNutanixResourceIdentifierFromEnv(envVarKey string) infrav1.NutanixResourceIdentifier
+	stripNutanixIDFromProviderID(providerID string) string
+	verifyCategoryExists(categoryKey, categoyValue string)
+	verifyCategoriesNutanixMachines(clusterName, namespace string, expectedCategories map[string]string)
+	verifyConditionOnNutanixCluster(params verifyConditionOnNutanixClusterParams)
+	verifyFailureMessageOnClusterMachines(ctx context.Context, params verifyFailureMessageOnClusterMachinesParams)
 }
 
-func deployClusterAndWait(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
-	cc := clusterctl.ConfigClusterInput{
-		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
-		ClusterctlConfigPath:     params.clusterctlConfigPath,
-		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
-		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-		Flavor:                   params.flavor,
-		Namespace:                params.namespace.Name,
-		ClusterName:              params.clusterName,
-		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
-		ControlPlaneMachineCount: pointer.Int64Ptr(1),
-		WorkerMachineCount:       pointer.Int64Ptr(1),
+type testHelper struct{
+	nutanixClient *prismGoClientV3.Client
+}
+
+func newTestHelper() testHelperInterface{
+	c, err := initNutanixClient()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return testHelper{
+		nutanixClient: c,
 	}
-
-	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-		ClusterProxy:                 params.bootstrapClusterProxy,
-		ConfigCluster:                cc,
-		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
-		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
-		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
-	}, clusterResources)
 }
 
-func deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
-	cc := clusterctl.ConfigClusterInput{
-		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
-		ClusterctlConfigPath:     params.clusterctlConfigPath,
-		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
-		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-		Flavor:                   params.flavor,
-		Namespace:                params.namespace.Name,
-		ClusterName:              params.clusterName,
-		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
-		ControlPlaneMachineCount: pointer.Int64Ptr(1),
-		WorkerMachineCount:       pointer.Int64Ptr(1),
-	}
-
-	createClusterFromConfig(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
-		ClusterProxy:                 params.bootstrapClusterProxy,
-		ConfigCluster:                cc,
-		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
-		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
-		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
-	}, clusterResources)
-}
-
-func generateTestClusterName(specName string) string {
-	return fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-}
-
-func createClusterFromConfig(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult) {
+func (t testHelper) createClusterFromConfig(ctx context.Context, input clusterctl.ApplyClusterTemplateAndWaitInput, result *clusterctl.ApplyClusterTemplateAndWaitResult) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for createClusterFromConfig")
 	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling createClusterFromConfig")
 	Expect(result).ToNot(BeNil(), "Invalid argument. result can't be nil when calling createClusterFromConfig")
@@ -141,13 +133,145 @@ func createClusterFromConfig(ctx context.Context, input clusterctl.ApplyClusterT
 	Expect(result.Cluster).ToNot(BeNil())
 }
 
+func (t testHelper) createDefaultNMT(clusterName, namespace string) *infrav1.NutanixMachineTemplate {
+	return &infrav1.NutanixMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.generateNMTName(clusterName),
+			Namespace: namespace,
+		},
+		Spec: infrav1.NutanixMachineTemplateSpec{
+			Template: infrav1.NutanixMachineTemplateResource{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID:     t.generateNMTProviderID(clusterName),
+					BootType:       defaultBootType,
+					VCPUsPerSocket: defaultVCPUsPerSocket,
+					VCPUSockets:    defaultVCPUSockets,
+					MemorySize:     resource.MustParse(defaultMemorySize),
+					Image:          t.getNutanixResourceIdentifierFromEnv(imageEnvVarKey),
+					Cluster:        t.getNutanixResourceIdentifierFromEnv(clusterEnvVarKey),
+					Subnets: []infrav1.NutanixResourceIdentifier{
+						t.getNutanixResourceIdentifierFromEnv(subnetEnvVarKey),
+					},
+					SystemDiskSize: resource.MustParse(defaultSystemDiskSize),
+				},
+			},
+		},
+	}
+}
+
+type createNutanixMachineTemplateParams struct {
+	creator                framework.Creator
+	nutanixMachineTemplate client.Object
+}
+
+func (t testHelper) createNutanixMachineTemplate(ctx context.Context, params createNutanixMachineTemplateParams) {
+	Eventually(func() error {
+		return params.creator.Create(ctx, params.nutanixMachineTemplate)
+	}, defaultTimeout, defaultInterval).Should(Succeed())
+}
+
+type createSecretParams struct {
+	namespace   *corev1.Namespace
+	clusterName string
+	username    string
+	password    string
+}
+
+func (t testHelper) createSecret(params createSecretParams) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.clusterName,
+			Namespace: params.namespace.Name,
+		},
+		Data: map[string][]byte{
+			"NUTANIX_USER":     []byte(params.username),
+			"NUTANIX_PASSWORD": []byte(params.password),
+		},
+	}
+	Eventually(func() error {
+		return bootstrapClusterProxy.GetClient().Create(ctx, secret)
+	}, defaultTimeout, defaultInterval).Should(Succeed())
+}
+
+type deployClusterParams struct {
+	clusterName           string
+	namespace             *corev1.Namespace
+	flavor                string
+	clusterctlConfigPath  string
+	artifactFolder        string
+	bootstrapClusterProxy framework.ClusterProxy
+	e2eConfig             clusterctl.E2EConfig
+}
+
+func (t testHelper) deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
+	cc := clusterctl.ConfigClusterInput{
+		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
+		ClusterctlConfigPath:     params.clusterctlConfigPath,
+		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
+		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+		Flavor:                   params.flavor,
+		Namespace:                params.namespace.Name,
+		ClusterName:              params.clusterName,
+		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: pointer.Int64Ptr(1),
+		WorkerMachineCount:       pointer.Int64Ptr(1),
+	}
+
+	t.createClusterFromConfig(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 params.bootstrapClusterProxy,
+		ConfigCluster:                cc,
+		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+}
+
+func (t testHelper) deployClusterAndWait(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
+	cc := clusterctl.ConfigClusterInput{
+		LogFolder:                filepath.Join(params.artifactFolder, "clusters", params.bootstrapClusterProxy.GetName()),
+		ClusterctlConfigPath:     params.clusterctlConfigPath,
+		KubeconfigPath:           params.bootstrapClusterProxy.GetKubeconfigPath(),
+		InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+		Flavor:                   params.flavor,
+		Namespace:                params.namespace.Name,
+		ClusterName:              params.clusterName,
+		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		ControlPlaneMachineCount: pointer.Int64Ptr(1),
+		WorkerMachineCount:       pointer.Int64Ptr(1),
+	}
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		ClusterProxy:                 params.bootstrapClusterProxy,
+		ConfigCluster:                cc,
+		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+	}, clusterResources)
+}
+
+func (t testHelper) generateNMTName(clusterName string) string {
+	return fmt.Sprintf("%s-mt-0", clusterName)
+}
+
+func (t testHelper) generateNMTProviderID(clusterName string) string {
+	return fmt.Sprintf("nutanix://%s-m1", clusterName)
+}
+
+func (t testHelper) generateTestClusterName(specName string) string {
+	return fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+}
+
+func (t testHelper) getExpectedClusterCategoryKey(clusterName string) string {
+	return fmt.Sprintf("%s-%s", defaultClusterCategoryKeyPrefix, clusterName)
+}
+
 type getNutanixClusterByNameInput struct {
 	Getter    framework.Getter
 	Name      string
 	Namespace string
 }
 
-func getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameInput) *infrav1.NutanixCluster {
+func (t testHelper) getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameInput) *infrav1.NutanixCluster {
 	cluster := &infrav1.NutanixCluster{}
 	key := client.ObjectKey{
 		Namespace: input.Namespace,
@@ -157,6 +281,46 @@ func getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameI
 	return cluster
 }
 
+func (t testHelper) getMachinesForCluster(ctx context.Context, clusterName, namespace string, bootstrapClusterProxy framework.ClusterProxy) *clusterv1.MachineList {
+	machineList := &clusterv1.MachineList{}
+	labels := map[string]string{clusterv1.ClusterLabelName: clusterName}
+	err := bootstrapClusterProxy.GetClient().List(ctx, machineList, client.InNamespace(namespace), client.MatchingLabels(labels))
+	Expect(err).ShouldNot(HaveOccurred())
+	return machineList
+}
+
+func (t testHelper) getNutanixResourceIdentifierFromEnv(envVarKey string) infrav1.NutanixResourceIdentifier {
+	envVarValue := os.Getenv(envVarKey)
+	return infrav1.NutanixResourceIdentifier{
+		Type: nameType,
+		Name: pointer.StringPtr(envVarValue),
+	}
+}
+
+func (t testHelper) stripNutanixIDFromProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, nutanixProviderIDPrefix)
+}
+
+func (t testHelper) verifyCategoryExists(categoryKey, categoryValue string){
+	_, err := t.nutanixClient.V3.GetCategoryValue(categoryKey, categoryValue)
+	Expect(err).ShouldNot(HaveOccurred())
+}
+
+func (t testHelper) verifyCategoriesNutanixMachines(clusterName, namespace string, expectedCategories map[string]string) {
+	nutanixMachines := t.getMachinesForCluster(ctx, clusterName, namespace, bootstrapClusterProxy)
+	for _, m := range nutanixMachines.Items {
+		machineProviderID := m.Spec.ProviderID
+		Expect(machineProviderID).NotTo(BeNil())
+		machineVmUUID := t.stripNutanixIDFromProviderID(*machineProviderID)
+		vm, err := t.nutanixClient.V3.GetVM(machineVmUUID)
+		Expect(err).ShouldNot(HaveOccurred())
+		categoriesMeta := vm.Metadata.Categories
+		for k, v := range expectedCategories {
+			Expect(categoriesMeta).To(HaveKeyWithValue(k, v))
+		}
+	}
+}
+
 type verifyConditionOnNutanixClusterParams struct {
 	bootstrapClusterProxy framework.ClusterProxy
 	clusterName           string
@@ -164,10 +328,10 @@ type verifyConditionOnNutanixClusterParams struct {
 	expectedCondition     clusterv1.Condition
 }
 
-func verifyConditionOnNutanixCluster(params verifyConditionOnNutanixClusterParams) {
+func (t testHelper) verifyConditionOnNutanixCluster(params verifyConditionOnNutanixClusterParams) {
 	Eventually(
 		func() []clusterv1.Condition {
-			cluster := getNutanixClusterByName(ctx, getNutanixClusterByNameInput{
+			cluster := t.getNutanixClusterByName(ctx, getNutanixClusterByNameInput{
 				Getter:    params.bootstrapClusterProxy.GetClient(),
 				Name:      params.clusterName,
 				Namespace: params.namespace.Name,
@@ -191,41 +355,23 @@ func verifyConditionOnNutanixCluster(params verifyConditionOnNutanixClusterParam
 	)
 }
 
-type createSecretParams struct {
-	namespace   *corev1.Namespace
-	clusterName string
-	username    string
-	password    string
+type verifyFailureMessageOnClusterMachinesParams struct {
+	clusterName            string
+	namespace              *corev1.Namespace
+	expectedPhase          string
+	expectedFailureMessage string
+	bootstrapClusterProxy  framework.ClusterProxy
 }
 
-func createSecret(params createSecretParams) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      params.clusterName,
-			Namespace: params.namespace.Name,
-		},
-		Data: map[string][]byte{
-			"NUTANIX_USER":     []byte(params.username),
-			"NUTANIX_PASSWORD": []byte(params.password),
-		},
-	}
-	Eventually(func() error {
-		return bootstrapClusterProxy.GetClient().Create(ctx, secret)
-	}, defaultTimeout, defaultInterval).Should(Succeed())
-}
-
-type nutanixCredentials struct {
-	nutanixUsername string
-	nutanixPassword string
-}
-
-func getNutanixCredentialsFromEnvironment() nutanixCredentials {
-	nutanixUsername := os.Getenv(nutanixUserKey)
-	Expect(nutanixUsername).ToNot(BeNil())
-	nutanixPassword := os.Getenv(nutanixPasswordKey)
-	Expect(nutanixPassword).ToNot(BeNil())
-	return nutanixCredentials{
-		nutanixUsername: nutanixUsername,
-		nutanixPassword: nutanixPassword,
-	}
+func (t testHelper) verifyFailureMessageOnClusterMachines(ctx context.Context, params verifyFailureMessageOnClusterMachinesParams) {
+	Eventually(func() bool {
+		nutanixMachines := t.getMachinesForCluster(ctx, params.clusterName, params.namespace.Name, params.bootstrapClusterProxy)
+		for _, m := range nutanixMachines.Items {
+			machineStatus := m.Status
+			if machineStatus.Phase == params.expectedPhase && strings.Contains(*machineStatus.FailureMessage, params.expectedFailureMessage) {
+				return true
+			}
+		}
+		return false
+	}, defaultTimeout, defaultInterval).Should(BeTrue())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e tests for Nutanix categories created and/or consumed by CAPX.

Tests added:
- Create a cluster with default cluster categories
- Create a cluster with additional categories
- Create a cluster linked to non-existing categories

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
make test-e2e

```
Ran 6 of 17 Specs in 1039.478 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 11 Skipped
PASS

Test Suite Passed
```

**Special notes for your reviewer**:

Following System categories are being used:
- Apptype:Kubernetes
- Environment:Dev  

**Release note**:

```release-note
- Adds e2e tests for Nutanix categories created and/or consumed by CAPX
```