### PR TITLE
added e2e tests for VMs with multiple nics

### DIFF
--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -105,6 +105,8 @@ variables:
   NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
   NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME: "ubuntu-2004-kube-v1.21.10"
   NUTANIX_SUBNET_NAME: ""
+  # NOTE: 'NUTANIX_ADDITIONAL_SUBNET_NAME' is required for multi network interface e2e tests
+  NUTANIX_ADDITIONAL_SUBNET_NAME: ""
   KUBEVIP_LB_ENABLE: "false"
   KUBEVIP_SVC_ENABLE: "false"
   CNI: "./data/cni/kindnet/kindnet.yaml"

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -1,0 +1,126 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	additionalSubnetEnvVarKey = "NUTANIX_ADDITIONAL_SUBNET_NAME"
+)
+
+var _ = Describe("Nutanix Subnets [PR-Blocking]", func() {
+	const specName = "cluster-multi-nic"
+
+	var (
+		namespace        *corev1.Namespace
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+		testHelper       testHelperInterface
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper()
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster where machines have multiple subnets attached to the machines", func() {
+		const (
+			flavor = "no-nmt"
+		)
+
+		var nmtSubnets []infrav1.NutanixResourceIdentifier
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating Nutanix Machine Template with multiple subnets", func() {
+			multiNicNMT := testHelper.createDefaultNMT(clusterName, namespace.Name)
+			multiNicNMT.Spec.Template.Spec.Subnets = append(multiNicNMT.Spec.Template.Spec.Subnets,
+				testHelper.getNutanixResourceIdentifierFromEnv(additionalSubnetEnvVarKey),
+			)
+			nmtSubnets = multiNicNMT.Spec.Template.Spec.Subnets
+			testHelper.createNutanixMachineTemplate(ctx, createNutanixMachineTemplateParams{
+				creator:                bootstrapClusterProxy.GetClient(),
+				nutanixMachineTemplate: multiNicNMT,
+			})
+		})
+
+		By("Creating a workload cluster", func() {
+			testHelper.deployClusterAndWait(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+					e2eConfig:             *e2eConfig,
+				}, clusterResources)
+		})
+
+		By("Checking subnets attached to cluster machines", func() {
+			toMatchFields := make([]types.GomegaMatcher, 0)
+			for _, s := range nmtSubnets {
+				toMatchFields = append(toMatchFields, gstruct.PointTo(
+					gstruct.MatchFields(
+						gstruct.IgnoreExtras,
+						gstruct.Fields{
+							"SubnetReference": gstruct.PointTo(
+								gstruct.MatchFields(
+									gstruct.IgnoreExtras,
+									gstruct.Fields{
+										"Name": gstruct.PointTo(Equal(*s.Name)),
+									},
+								),
+							),
+						},
+					),
+				))
+			}
+
+			nutanixVMs := testHelper.getNutanixVMsForCluster(clusterName, namespace.Name)
+			for _, vm := range nutanixVMs {
+				vmSubnets := vm.Status.Resources.NicList
+				Expect(len(vmSubnets)).To(Equal(len(nmtSubnets)), "expected amount subnets linked to VMs to be equal to %d but was %d", len(nmtSubnets), len(vmSubnets))
+				Expect(vmSubnets).Should(ContainElements(toMatchFields))
+			}
+		})
+
+		By("PASSED!")
+	})
+})

--- a/test/e2e/nutanix_client.go
+++ b/test/e2e/nutanix_client.go
@@ -50,9 +50,9 @@ type nutanixCredentials struct {
 
 func getNutanixCredentialsFromEnvironment() nutanixCredentials {
 	nutanixUsername := os.Getenv(nutanixUserKey)
-	Expect(nutanixUsername).ToNot(BeNil())
+	Expect(nutanixUsername).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixUserKey)
 	nutanixPassword := os.Getenv(nutanixPasswordKey)
-	Expect(nutanixPassword).ToNot(BeNil())
+	Expect(nutanixPassword).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixPasswordKey)
 	return nutanixCredentials{
 		nutanixUsername: nutanixUsername,
 		nutanixPassword: nutanixPassword,


### PR DESCRIPTION

**What this PR does / why we need it**:
Add e2e test for CAPX VMs with multiple NICs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Running e2e tests: 
`make test-e2e`

```
Ran 6 of 17 Specs in 980.788 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 11 Skipped
```


**Special notes for your reviewer**:

Added new env var: `NUTANIX_ADDITIONAL_SUBNET_NAME `

**Release note**:

```release-note
- Add e2e test for CAPX VMs with multiple NICs
```