### PR TITLE
Add additional check when creating Nutanix Client for CAPX

### DIFF
--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -151,7 +151,7 @@ func (r *NutanixClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	client, err := CreateNutanixClient(ctx, r.Client, cluster)
 	if err != nil {
 		conditions.MarkFalse(cluster, infrav1.PrismCentralClientCondition, infrav1.PrismCentralClientInitializationFailed, capiv1.ConditionSeverityError, err.Error())
-		return ctrl.Result{Requeue: true}, fmt.Errorf("Client Auth error: %v", err)
+		return ctrl.Result{Requeue: true}, fmt.Errorf("Nutanix Client error: %v", err)
 	}
 	conditions.MarkTrue(cluster, infrav1.PrismCentralClientCondition)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add additional check when creating Nutanix client in order to validate connection details and credentials. Also add e2e test for this new check.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Added new e2e for this use-case
make test-e2e
```
```

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
- Added additional check when creating Nutanix Client for CAPX
- Add e2e to test Nutanix Client creation
```