### PR TITLE
Add option to run e2e tests using Calico

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,18 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 EXP_DIR := exp
 BIN_DIR := bin
 TEST_DIR := test
+E2E_DIR ?= ${REPO_ROOT}/test/e2e
 TOOLS_DIR := $(REPO_ROOT)/hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/$(BIN_DIR))
 E2E_FRAMEWORK_DIR := $(TEST_DIR)/framework
 CAPD_DIR := $(TEST_DIR)/infrastructure/docker
 GO_INSTALL := $(REPO_ROOT)/scripts/go_install.sh
-NUTANIX_E2E_TEMPLATES := $(REPO_ROOT)/test/e2e/data/infrastructure-nutanix
+NUTANIX_E2E_TEMPLATES := ${E2E_DIR}/data/infrastructure-nutanix
 
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
+
+# CNI paths for e2e tests
+CNI_PATH_CALICO ?= "${E2E_DIR}/data/cni/calico/calico.yaml"
 
 #
 # Binaries.
@@ -128,7 +132,7 @@ GINKGO_FOCUS ?= "\\[PR-Blocking\\]"
 # GINKGO_FOCUS ?= "\\[health-remediation\\]"
 GINKGO_SKIP ?=
 GINKGO_NODES  ?= 1
-E2E_CONF_FILE  ?= ${REPO_ROOT}/test/e2e/config/nutanix.yaml
+E2E_CONF_FILE  ?= ${E2E_DIR}/config/nutanix.yaml
 ARTIFACTS ?= ${REPO_ROOT}/_artifacts
 SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
@@ -313,6 +317,14 @@ test-e2e: docker-build-e2e $(GINKGO) cluster-templates ## Run the end-to-end tes
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \
 	    -e2e.config="$(E2E_CONF_FILE)" \
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER)
+
+.PHONY: test-e2e-calico
+test-e2e-calico:
+	CNI=$(CNI_PATH_CALICO) $(MAKE) test-e2e
+
+.PHONY: test-e2e-all-cni
+test-e2e-all-cni: test-e2e test-e2e-calico
+
 
 ## --------------------------------------
 ## Hack / Tools

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,7 +15,16 @@ TBD
 Run the following command to execute the CAPX e2e tests:
 
 ```shell
-make e2e
+make test-e2e
 ```
 
 The above command should build the CAPX manager image locally and use that image with the e2e test suite.
+
+Running e2e with other CNIs can be done by invoking following command:
+```shell
+#run e2e with Calico:
+make test-e2e-calico
+
+#run e2e tests with every CNI:
+make test-e2e-all-cni
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the Makefile to run e2e tests with Calico as CNI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:

```
make test-e2e-calico
```

**Special notes for your reviewer**:
N/A

**Release note**:
N/A