### PR TITLE
adding e2e tests for projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ cluster-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1beta
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-credential-ref.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project.yaml
 
 ##@ Testing
 

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Nutanix categories [PR-Blocking]", func() {
 		})
 
 		By("Checking cluster category condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -83,6 +83,7 @@ providers:
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-project.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus
@@ -107,6 +108,8 @@ variables:
   NUTANIX_SUBNET_NAME: ""
   # NOTE: 'NUTANIX_ADDITIONAL_SUBNET_NAME' is required for multi network interface e2e tests
   NUTANIX_ADDITIONAL_SUBNET_NAME: ""
+  # NOTE: 'NUTANIX_PROJECT_NAME' is required for project e2e tests
+  NUTANIX_PROJECT_NAME: ""
   KUBEVIP_LB_ENABLE: "false"
   KUBEVIP_SVC_ENABLE: "false"
   CNI: "./data/cni/kindnet/kindnet.yaml"

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/secret.yaml
+  - ../bases/nmt.yaml
+  - ../bases/crs.yaml
+  - ../bases/md.yaml
+  - ../bases/mhc.yaml
+
+patchesStrategicMerge:
+  - ./nmt.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/nmt.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-mt-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      project:
+        type: name
+        name: "${NUTANIX_PROJECT_NAME}"

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("checking cluster prism client init condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,
@@ -106,7 +106,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("Checking cluster condition for credentials is set to false", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,
@@ -130,7 +130,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("checking cluster credential condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,
@@ -142,7 +142,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("checking cluster prism client init condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,
@@ -187,7 +187,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("Checking cluster credential condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,
@@ -199,7 +199,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("Checking cluster prism client init condition is false", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionOnNutanixClusterParams{
+			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
 				clusterName:           clusterName,
 				namespace:             namespace,
 				bootstrapClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/projects_test.go
+++ b/test/e2e/projects_test.go
@@ -1,0 +1,166 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	nutanixProjectNameEnv  = "NUTANIX_PROJECT_NAME"
+	nonExistingProjectName = "nonExistingProjectNameCAPX"
+)
+
+var _ = Describe("Nutanix projects [PR-Blocking]", func() {
+	const specName = "cluster-projects"
+
+	var (
+		namespace          *corev1.Namespace
+		clusterName        string
+		clusterResources   *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches      context.CancelFunc
+		nutanixProjectName string
+		testHelper         testHelperInterface
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper()
+		nutanixProjectName = os.Getenv(nutanixProjectNameEnv)
+		Expect(nutanixProjectName).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixProjectNameEnv)
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster linked to non-existing project (should fail)", func() {
+		const flavor = "no-nmt"
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating invalid Project Nutanix Machine Template", func() {
+			invalidProjectNMT := testHelper.createDefaultNMT(clusterName, namespace.Name)
+			invalidProjectNMT.Spec.Template.Spec.Project = &infrav1.NutanixResourceIdentifier{
+				Type: "name",
+				Name: pointer.StringPtr(nonExistingProjectName),
+			}
+			testHelper.createNutanixMachineTemplate(ctx, createNutanixMachineTemplateParams{
+				creator:                bootstrapClusterProxy.GetClient(),
+				nutanixMachineTemplate: invalidProjectNMT,
+			})
+		})
+
+		By("Creating a workload cluster", func() {
+			testHelper.deployCluster(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+					e2eConfig:             *e2eConfig,
+				},
+				clusterResources,
+			)
+		})
+
+		By("Checking project assigned condition is false", func() {
+			testHelper.verifyConditionOnNutanixMachines(verifyConditionParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				expectedCondition: clusterv1.Condition{
+					Type:     infrav1.ProjectAssignedCondition,
+					Reason:   infrav1.ProjectAssignationFailed,
+					Severity: clusterv1.ConditionSeverityError,
+					Status:   corev1.ConditionFalse,
+				},
+			})
+		})
+
+		By("Checking machine status is 'Failed' and failure message is set", func() {
+			testHelper.verifyFailureMessageOnClusterMachines(ctx, verifyFailureMessageOnClusterMachinesParams{
+				clusterName:            clusterName,
+				namespace:              namespace,
+				expectedPhase:          "Failed",
+				expectedFailureMessage: "failed to retrieve project",
+				bootstrapClusterProxy:  bootstrapClusterProxy,
+			})
+		})
+
+		By("PASSED!")
+	})
+
+	It("Create a cluster linked to an existing project", func() {
+		flavor = "project"
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		testHelper.deployClusterAndWait(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				e2eConfig:             *e2eConfig,
+			}, clusterResources)
+
+		By("Checking project assigned condition is true", func() {
+			testHelper.verifyConditionOnNutanixMachines(verifyConditionParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				expectedCondition: clusterv1.Condition{
+					Type:   infrav1.ProjectAssignedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			})
+		})
+
+		By("Verifying if project is assigned to the VMs")
+		Expect(nutanixProjectName).ToNot(BeEmpty())
+		testHelper.verifyProjectNutanixMachines(ctx, verifyProjectNutanixMachinesParams{
+			clusterName:           clusterName,
+			namespace:             namespace.Name,
+			nutanixProjectName:    nutanixProjectName,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+		})
+
+		By("PASSED!")
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e tests for projects.
Tests:
- Add a cluster to an existing project
- Try to add a cluster to non-existing project (check if failure is propagated)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
make test-e2e

Ran 10 of 20 Specs in 1510.411 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS


**Special notes for your reviewer**:
N/A

**Release note**:
-->
```release-note

```