### PR TITLE
implement cluster flavors (csi,ccm)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,7 @@ jobs:
       run: |
         (cd config/manager && kustomize edit set image controller=$NEW_IMG)
         kustomize build config/default > infrastructure-components.yaml
+        make cluster-flavors
 
     - name: update metadata.yaml
       env:
@@ -104,4 +105,4 @@ jobs:
         files: |
           infrastructure-components.yaml
           metadata.yaml
-          templates/*.yaml
+          templates/cluster-template*.yaml

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ EXP_DIR := exp
 BIN_DIR := bin
 TEST_DIR := test
 E2E_DIR ?= ${REPO_ROOT}/test/e2e
+FLAVORS_DIR := flavors
+TEMPLATES_DIR := templates
 TOOLS_DIR := $(REPO_ROOT)/hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/$(BIN_DIR))
 E2E_FRAMEWORK_DIR := $(TEST_DIR)/framework
@@ -262,6 +264,10 @@ cluster-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1beta
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-additional-categories.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project.yaml
+
+cluster-flavors: $(KUSTOMIZE) ## Generate cluster flavors for all versions
+	$(KUSTOMIZE) build $(FLAVORS_DIR)/csi > $(TEMPLATES_DIR)/cluster-template-csi.yaml
+	$(KUSTOMIZE) build $(FLAVORS_DIR)/ccm > $(TEMPLATES_DIR)/cluster-template-ccm.yaml
 
 ##@ Testing
 

--- a/flavors/ccm/kustomization.yaml
+++ b/flavors/ccm/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../templates/
+
+patches:
+- patch: |-
+    - op: add
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+      value: { 
+            "cloud-provider": "external"
+        }
+    - op: add
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+      value: {
+            "cloud-provider": "external"
+        }
+    - op: add
+      path: /spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+      value: {
+            "cloud-provider": "external"
+        }
+  target:
+    kind: KubeadmControlPlane
+- patch: |-
+    - op: add
+      path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+      value: {
+            "cloud-provider": "external"
+        }
+  target:
+    kind: KubeadmConfigTemplate
+- patch: |-
+    - op: add
+      path: /metadata/labels
+      value: {
+            "ccm": "nutanix"
+        }
+  target:
+    kind: Cluster

--- a/flavors/csi/kustomization.yaml
+++ b/flavors/csi/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+- name: nutanix-csi
+  behavior: merge
+  files:
+  - nutanix-csi-storage.yaml
+  - nutanix-csi-snapshot.yaml
+  - nutanix-csi-sc.yaml
+
+resources:
+- ../../templates/
+- nutanix-csi.yaml
+- nutanix-csi-crs.yaml
+
+patches:
+- patch: |-
+    - op: add
+      path: /metadata/labels
+      value: {
+            "csi": "nutanix"
+        }
+  target:
+    kind: Cluster

--- a/flavors/csi/nutanix-csi-crs.yaml
+++ b/flavors/csi/nutanix-csi-crs.yaml
@@ -1,0 +1,13 @@
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: nutanix-csi-crs
+spec:
+  clusterSelector:
+    matchLabels:
+      csi: nutanix
+  resources:
+  - kind: ConfigMap
+    name: nutanix-csi
+  strategy: ApplyOnce
+

--- a/flavors/csi/nutanix-csi-sc.yaml
+++ b/flavors/csi/nutanix-csi-sc.yaml
@@ -1,0 +1,31 @@
+# Source: nutanix-csi-storage/templates/ntnx-secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ntnx-secret
+  namespace: ntnx-system
+stringData:
+  # prism-ip:prism-port:admin:password.
+  key: ${NUTANIX_PE_ENDPOINT}:${NUTANIX_PE_PORT=9440}:${NUTANIX_PE_USER=admin}:${NUTANIX_PE_PASSWORD}
+---
+# Source: nutanix-csi-storage/templates/ntnx-sc.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: nutanix-volume
+provisioner: csi.nutanix.com
+parameters:
+    storageType: NutanixVolumes
+    csi.storage.k8s.io/provisioner-secret-name: ntnx-secret
+    csi.storage.k8s.io/provisioner-secret-namespace: ntnx-system
+    csi.storage.k8s.io/node-publish-secret-name: ntnx-secret
+    csi.storage.k8s.io/node-publish-secret-namespace: ntnx-system
+    csi.storage.k8s.io/controller-expand-secret-name: ntnx-secret
+    csi.storage.k8s.io/controller-expand-secret-namespace: ntnx-system
+    storageContainer: ${NUTANIX_STORAGE_CONTAINER}
+    csi.storage.k8s.io/fstype: ext4
+    isSegmentedIscsiNetwork: "false"
+    description: "nutanix-volume"
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/flavors/csi/nutanix-csi-snapshot.yaml
+++ b/flavors/csi/nutanix-csi-snapshot.yaml
@@ -1,0 +1,1142 @@
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+# RBAC file for the snapshot controller.
+#
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshot-controller
+  namespace: ntnx-system
+---
+# Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+# RBAC file for the snapshot webhook.
+#
+# The snapshot webhook implements the validation and admission for CSI snapshot functionality.
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshot-webhook
+  namespace:  ntnx-system
+---
+# Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-snapshot-validation-webhook-cert
+  namespace: ntnx-system
+type: kubernetes.io/tls
+stringData:
+  ca.crt: ${WEBHOOK_CA}
+  tls.key: ${WEBHOOK_KEY}
+  tls.crt: ${WEBHOOK_CERT}
+---
+# Source: nutanix-csi-snapshot/templates/volumesnapshotclasses_rel60.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+  creationTimestamp: null
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    shortNames:
+    - vsclass
+    - vsclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeSnapshotContent created through the
+        VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotClass specifies parameters that a underlying storage
+          system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+          is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+          are non-namespaced
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          deletionPolicy:
+            description: deletionPolicy determines whether a VolumeSnapshotContent
+              created through the VolumeSnapshotClass should be deleted when its bound
+              VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeSnapshotContent and its physical snapshot
+              on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
+              and its physical snapshot on underlying storage system are deleted.
+              Required.
+            enum:
+            - Delete
+            - Retain
+            type: string
+          driver:
+            description: driver is the name of the storage driver that handles this
+              VolumeSnapshotClass. Required.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          parameters:
+            additionalProperties:
+              type: string
+            description: parameters is a key-value map with storage driver specific
+              parameters for creating snapshots. These values are opaque to Kubernetes.
+            type: object
+        required:
+        - deletionPolicy
+        - driver
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    # This indicates the v1beta1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1beta1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          deletionPolicy:
+            description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+            enum:
+            - Delete
+            - Retain
+            type: string
+          driver:
+            description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          parameters:
+            additionalProperties:
+              type: string
+            description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+            type: object
+        required:
+        - deletionPolicy
+        - driver
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: nutanix-csi-snapshot/templates/volumesnapshotcontents_rel60.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+  creationTimestamp: null
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    shortNames:
+    - vsc
+    - vscs
+    singular: volumesnapshotcontent
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Indicates if the snapshot is ready to be used to restore a volume.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Represents the complete size of the snapshot in bytes
+      jsonPath: .status.restoreSize
+      name: RestoreSize
+      type: integer
+    - description: Determines whether this VolumeSnapshotContent and its physical
+        snapshot on the underlying storage system should be deleted when its bound
+        VolumeSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical snapshot on
+        the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+      jsonPath: .spec.volumeSnapshotClassName
+      name: VolumeSnapshotClass
+      type: string
+    - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeSnapshotRef.name
+      name: VolumeSnapshot
+      type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+          object in the underlying storage system
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: spec defines properties of a VolumeSnapshotContent created
+              by the underlying storage system. Required.
+            properties:
+              deletionPolicy:
+                description: deletionPolicy determines whether this VolumeSnapshotContent
+                  and its physical snapshot on the underlying storage system should
+                  be deleted when its bound VolumeSnapshot is deleted. Supported values
+                  are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                  and its physical snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeSnapshotContent and its physical snapshot
+                  on underlying storage system are deleted. For dynamically provisioned
+                  snapshots, this field will automatically be filled in by the CSI
+                  snapshotter sidecar with the "DeletionPolicy" field defined in the
+                  corresponding VolumeSnapshotClass. For pre-existing snapshots, users
+                  MUST specify this field when creating the VolumeSnapshotContent
+                  object. Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: driver is the name of the CSI driver used to create the
+                  physical snapshot on the underlying storage system. This MUST be
+                  the same as the name returned by the CSI GetPluginName() call for
+                  that driver. Required.
+                type: string
+              source:
+                description: source specifies whether the snapshot is (or should be)
+                  dynamically provisioned or already exists, and just requires a Kubernetes
+                  object representation. This field is immutable after creation. Required.
+                properties:
+                  snapshotHandle:
+                    description: snapshotHandle specifies the CSI "snapshot_id" of
+                      a pre-existing snapshot on the underlying storage system for
+                      which a Kubernetes object representation was (or should be)
+                      created. This field is immutable.
+                    type: string
+                  volumeHandle:
+                    description: volumeHandle specifies the CSI "volume_id" of the
+                      volume from which a snapshot should be dynamically taken from.
+                      This field is immutable.
+                    type: string
+                type: object
+                oneOf:
+                - required: ["snapshotHandle"]
+                - required: ["volumeHandle"]
+              sourceVolumeMode:
+                description: SourceVolumeMode is the mode of the volume whose snapshot
+                  is taken. Can be either “Filesystem” or “Block”. If not specified,
+                  it indicates the source volume's mode is unknown. This field is
+                  immutable. This field is an alpha field.
+                type: string
+              volumeSnapshotClassName:
+                description: name of the VolumeSnapshotClass from which this snapshot
+                  was (or will be) created. Note that after provisioning, the VolumeSnapshotClass
+                  may be deleted or recreated with different set of values, and as
+                  such, should not be referenced post-snapshot creation.
+                type: string
+              volumeSnapshotRef:
+                description: volumeSnapshotRef specifies the VolumeSnapshot object
+                  to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                  field must reference to this VolumeSnapshotContent's name for the
+                  bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                  object, name and namespace of the VolumeSnapshot object MUST be
+                  provided for binding to happen. This field is immutable after creation.
+                  Required.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeSnapshotRef
+            type: object
+          status:
+            description: status represents the current information of a snapshot.
+            properties:
+              creationTime:
+                description: creationTime is the timestamp when the point-in-time
+                  snapshot is taken by the underlying storage system. In dynamic snapshot
+                  creation case, this field will be filled in by the CSI snapshotter
+                  sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
+                  gRPC call. For a pre-existing snapshot, this field will be filled
+                  with the "creation_time" value returned from the CSI "ListSnapshots"
+                  gRPC call if the driver supports it. If not specified, it indicates
+                  the creation time is unknown. The format of this field is a Unix
+                  nanoseconds time encoded as an int64. On Unix, the command `date
+                  +%s%N` returns the current time in nanoseconds since 1970-01-01
+                  00:00:00 UTC.
+                format: int64
+                type: integer
+              error:
+                description: error is the last observed error during snapshot creation,
+                  if any. Upon success after retry, this error field will be cleared.
+                properties:
+                  message:
+                    description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: readyToUse indicates if a snapshot is ready to be used
+                  to restore a volume. In dynamic snapshot creation case, this field
+                  will be filled in by the CSI snapshotter sidecar with the "ready_to_use"
+                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                  snapshot, this field will be filled with the "ready_to_use" value
+                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                  it, otherwise, this field will be set to "True". If not specified,
+                  it means the readiness of a snapshot is unknown.
+                type: boolean
+              restoreSize:
+                description: restoreSize represents the complete size of the snapshot
+                  in bytes. In dynamic snapshot creation case, this field will be
+                  filled in by the CSI snapshotter sidecar with the "size_bytes" value
+                  returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                  snapshot, this field will be filled with the "size_bytes" value
+                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                  it. When restoring a volume from this snapshot, the size of the
+                  volume MUST NOT be smaller than the restoreSize if it is specified,
+                  otherwise the restoration will fail. If not specified, it indicates
+                  that the size is unknown.
+                format: int64
+                minimum: 0
+                type: integer
+              snapshotHandle:
+                description: snapshotHandle is the CSI "snapshot_id" of a snapshot
+                  on the underlying storage system. If not specified, it indicates
+                  that dynamic snapshot creation has either failed or it is still
+                  in progress.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if the snapshot is ready to be used to restore a volume.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Represents the complete size of the snapshot in bytes
+      jsonPath: .status.restoreSize
+      name: RestoreSize
+      type: integer
+    - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+      jsonPath: .spec.volumeSnapshotClassName
+      name: VolumeSnapshotClass
+      type: string
+    - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.name
+      name: VolumeSnapshot
+      type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    # This indicates the v1beta1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1beta1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+            properties:
+              deletionPolicy:
+                description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                type: string
+              source:
+                description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                properties:
+                  snapshotHandle:
+                    description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                    type: string
+                  volumeHandle:
+                    description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                    type: string
+                type: object
+              volumeSnapshotClassName:
+                description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                type: string
+              volumeSnapshotRef:
+                description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeSnapshotRef
+            type: object
+          status:
+            description: status represents the current information of a snapshot.
+            properties:
+              creationTime:
+                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                format: int64
+                type: integer
+              error:
+                description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                properties:
+                  message:
+                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                type: boolean
+              restoreSize:
+                description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                format: int64
+                minimum: 0
+                type: integer
+              snapshotHandle:
+                description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: nutanix-csi-snapshot/templates/volumesnapshots_rel60.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+  creationTimestamp: null
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    shortNames:
+    - vs
+    singular: volumesnapshot
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Indicates if the snapshot is ready to be used to restore a volume.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: If a new snapshot needs to be created, this contains the name of
+        the source PVC from which this snapshot was (or will be) created.
+      jsonPath: .spec.source.persistentVolumeClaimName
+      name: SourcePVC
+      type: string
+    - description: If a snapshot already exists, this contains the name of the existing
+        VolumeSnapshotContent object representing the existing snapshot.
+      jsonPath: .spec.source.volumeSnapshotContentName
+      name: SourceSnapshotContent
+      type: string
+    - description: Represents the minimum size of volume required to rehydrate from
+        this snapshot.
+      jsonPath: .status.restoreSize
+      name: RestoreSize
+      type: string
+    - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+      jsonPath: .spec.volumeSnapshotClassName
+      name: SnapshotClass
+      type: string
+    - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot
+        object intends to bind to. Please note that verification of binding actually
+        requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure
+        both are pointing at each other. Binding MUST be verified prior to usage of
+        this object.
+      jsonPath: .status.boundVolumeSnapshotContentName
+      name: SnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time snapshot was taken by the underlying
+        storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshot is a user's request for either creating a point-in-time
+          snapshot of a persistent volume, or binding to a pre-existing snapshot.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: 'spec defines the desired characteristics of a snapshot requested
+              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+              Required.'
+            properties:
+              source:
+                description: source specifies where a snapshot will be created from.
+                  This field is immutable after creation. Required.
+                properties:
+                  persistentVolumeClaimName:
+                    description: persistentVolumeClaimName specifies the name of the
+                      PersistentVolumeClaim object representing the volume from which
+                      a snapshot should be created. This PVC is assumed to be in the
+                      same namespace as the VolumeSnapshot object. This field should
+                      be set if the snapshot does not exists, and needs to be created.
+                      This field is immutable.
+                    type: string
+                  volumeSnapshotContentName:
+                    description: volumeSnapshotContentName specifies the name of a
+                      pre-existing VolumeSnapshotContent object representing an existing
+                      volume snapshot. This field should be set if the snapshot already
+                      exists and only needs a representation in Kubernetes. This field
+                      is immutable.
+                    type: string
+                type: object
+                oneOf:
+                - required: ["persistentVolumeClaimName"]
+                - required: ["volumeSnapshotContentName"]
+              volumeSnapshotClassName:
+                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+                  left nil to indicate that the default SnapshotClass should be used.
+                  A given cluster may have multiple default Volume SnapshotClasses:
+                  one default per CSI Driver. If a VolumeSnapshot does not specify
+                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
+                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
+                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
+                  exist for a given CSI Driver and more than one have been marked
+                  as default, CreateSnapshot will fail and generate an event. Empty
+                  string is not allowed for this field.'
+                type: string
+            required:
+            - source
+            type: object
+          status:
+            description: status represents the current information of a snapshot.
+              Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent
+              objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent
+              point at each other) before using this object.
+            properties:
+              boundVolumeSnapshotContentName:
+                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                  object to which this VolumeSnapshot object intends to bind to. If
+                  not specified, it indicates that the VolumeSnapshot object has not
+                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
+                  To avoid possible security issues, consumers must verify binding
+                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
+                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                  point at each other) before using this object.'
+                type: string
+              creationTime:
+                description: creationTime is the timestamp when the point-in-time
+                  snapshot is taken by the underlying storage system. In dynamic snapshot
+                  creation case, this field will be filled in by the snapshot controller
+                  with the "creation_time" value returned from CSI "CreateSnapshot"
+                  gRPC call. For a pre-existing snapshot, this field will be filled
+                  with the "creation_time" value returned from the CSI "ListSnapshots"
+                  gRPC call if the driver supports it. If not specified, it may indicate
+                  that the creation time of the snapshot is unknown.
+                format: date-time
+                type: string
+              error:
+                description: error is the last observed error during snapshot creation,
+                  if any. This field could be helpful to upper level controllers(i.e.,
+                  application controller) to decide whether they should continue on
+                  waiting for the snapshot to be created based on the type of error
+                  reported. The snapshot controller will keep retrying when an error
+                  occurs during the snapshot creation. Upon success, this error field
+                  will be cleared.
+                properties:
+                  message:
+                    description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: readyToUse indicates if the snapshot is ready to be used
+                  to restore a volume. In dynamic snapshot creation case, this field
+                  will be filled in by the snapshot controller with the "ready_to_use"
+                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                  snapshot, this field will be filled with the "ready_to_use" value
+                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                  it, otherwise, this field will be set to "True". If not specified,
+                  it means the readiness of a snapshot is unknown.
+                type: boolean
+              restoreSize:
+                type: string
+                description: restoreSize represents the minimum size of volume required
+                  to create a volume from this snapshot. In dynamic snapshot creation
+                  case, this field will be filled in by the snapshot controller with
+                  the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the
+                  "size_bytes" value returned from the CSI "ListSnapshots" gRPC call
+                  if the driver supports it. When restoring a volume from this snapshot,
+                  the size of the volume MUST NOT be smaller than the restoreSize
+                  if it is specified, otherwise the restoration will fail. If not
+                  specified, it indicates that the size is unknown.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if the snapshot is ready to be used to restore a volume.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+      jsonPath: .spec.source.persistentVolumeClaimName
+      name: SourcePVC
+      type: string
+    - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+      jsonPath: .spec.source.volumeSnapshotContentName
+      name: SourceSnapshotContent
+      type: string
+    - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+      jsonPath: .status.restoreSize
+      name: RestoreSize
+      type: string
+    - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+      jsonPath: .spec.volumeSnapshotClassName
+      name: SnapshotClass
+      type: string
+    - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+      jsonPath: .status.boundVolumeSnapshotContentName
+      name: SnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    # This indicates the v1beta1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1beta1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+    schema:
+      openAPIV3Schema:
+        description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+            properties:
+              source:
+                description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                properties:
+                  persistentVolumeClaimName:
+                    description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                    type: string
+                  volumeSnapshotContentName:
+                    description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                    type: string
+                type: object
+              volumeSnapshotClassName:
+                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                type: string
+            required:
+            - source
+            type: object
+          status:
+            description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+            properties:
+              boundVolumeSnapshotContentName:
+                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                type: string
+              creationTime:
+                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                format: date-time
+                type: string
+              error:
+                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                properties:
+                  message:
+                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                type: boolean
+              restoreSize:
+                type: string
+                description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-controller-runner
+  namespace: ntnx-system
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update", "patch"]
+---
+# Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-webhook-runner
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-controller-role
+  namespace: ntnx-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-controller
+    namespace: ntnx-system
+roleRef:
+  kind: ClusterRole
+  name: csi-snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-webhook
+    namespace:  ntnx-system
+roleRef:
+  kind: ClusterRole
+  name: csi-snapshot-webhook-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-controller-leaderelection
+  namespace: ntnx-system
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshot-controller-leaderelection
+  namespace: ntnx-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshot-controller
+    namespace: ntnx-system
+roleRef:
+  kind: Role
+  name: csi-snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nutanix-csi-snapshot/templates/validating-deployment.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-snapshot-webhook
+  namespace: ntnx-system
+spec:
+  selector:
+    app: csi-snapshot-webhook
+  ports:
+    - name: webhook
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+---
+# Source: nutanix-csi-snapshot/templates/snapshot-controller-deployment.yaml
+# This YAML file shows how to deploy the snapshot controller
+
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-snapshot-controller
+  namespace: ntnx-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller
+  minReadySeconds: 15
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: csi-snapshot-controller
+    spec:
+      serviceAccount: csi-snapshot-controller
+      containers:
+        - name: snapshot-controller
+          image: k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=2"
+            - "--leader-election=true"
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: csi-snapshot-controller
+                topologyKey: kubernetes.io/hostname
+---
+# Source: nutanix-csi-snapshot/templates/validating-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-snapshot-webhook
+  namespace: ntnx-system
+  labels:
+    app: csi-snapshot-webhook
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: csi-snapshot-webhook
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: csi-snapshot-webhook
+    spec:
+      serviceAccountName: csi-snapshot-webhook
+      containers:
+      - name: snapshot-validation
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1
+        imagePullPolicy: IfNotPresent
+        args:
+          - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
+          - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
+          - --v=2
+          - --port=8443
+        ports:
+        - containerPort: 8443
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+          - name: snapshot-validation-webhook-certs
+            mountPath: /etc/snapshot-validation-webhook/certs
+            readOnly: true
+      volumes:
+        - name: snapshot-validation-webhook-certs
+          secret:
+            secretName: csi-snapshot-validation-webhook-cert
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+      nodeSelector:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: csi-snapshot-webhook
+                topologyKey: kubernetes.io/hostname
+---
+# Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+# Check if the TLS secret already exists and initialize variables for later use at the top level
+---
+# Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "validation-webhook.snapshot.storage.k8s.io"
+  namespace: ntnx-system
+webhooks:
+- name: "validation-webhook.snapshot.storage.k8s.io"
+  rules:
+  - apiGroups:   ["snapshot.storage.k8s.io"]
+    apiVersions: ["v1", "v1beta1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["volumesnapshots", "volumesnapshotcontents"]
+    scope:       "*"
+  clientConfig:
+    service:
+      namespace: ntnx-system
+      name: "csi-snapshot-webhook"
+      path: "/volumesnapshot"
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURXVENDQWtHZ0F3SUJBZ0lSQUlSMEZrQ1BidXJLVVdleXRiMUsxcFV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1kzTnBMWE51WVhCemFHOTBMWGRsWW1odmIyc3ViblJ1ZUMxemVYTjBaVzB1YzNaagpNQjRYRFRJeU1EY3lNREV3TURVek4xb1hEVE15TURjeE56RXdNRFV6TjFvd0x6RXRNQ3NHQTFVRUF4TWtZM05wCkxYTnVZWEJ6YUc5MExYZGxZbWh2YjJzdWJuUnVlQzF6ZVhOMFpXMHVjM1pqTUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBelVZYUM5ZkE1VndXQ0prcitnT1VoQXViMys2VjdZYTd5a2YvN1JpLwpuYU5YUWQ0YnAycXczQTBrUFhUVnozQUVEaUVKQmY1c3JmUG01ZFl5TUNvbTZXTVkzTWxRaFdWRHVSdFVWNFh2Cldyb294MEtkUUxEeWszSGJ3cGwrVTFPUTlVdkFKNnQ1Snh6NzF6ZFh6WDZqTTA1ZGpWM3JhM0V0eWhhOVpmVFAKTzJCcklOcnkxRHArNGNRRUpYL3gvdGhtQWFUU1ltUEhvUlRHY29hMjJQODVwTGJBV0I3YzdDUFU0a2JpeDhqcQpNdTY3WlNQUCtoK0J5RGVFejF5MlBHbk9jeVFmNi9KbUxIV1EwT1VHVllrVCt6RHowYkFvRGlpVVhpUTArZXVjCjAwTHZrNUQrWXdiRUFpTDJjZmtBQ3R6SkZaemowYnBKM1FoOE4xREVyY1hiWlFJREFRQUJvM0F3YmpBT0JnTlYKSFE4QkFmOEVCQU1DQmFBd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQXdHQTFVZApFd0VCL3dRQ01BQXdMd1lEVlIwUkJDZ3dKb0lrWTNOcExYTnVZWEJ6YUc5MExYZGxZbWh2YjJzdWJuUnVlQzF6CmVYTjBaVzB1YzNaak1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQlpHNi9tL0dHSFBYaENtWWNRdGJuYmFjRFoKQlpXTmg1djRQbUpoRnhIYm9ERThhTE54ZDZXWG1qa0F0OUJjTGxXZ1oySVRYSW9UR3hRWlNxUTVIRXJieEVHdwpWZnUySXg1TkhpRFdJeDE2U20yT2NjOWFZRmFvVTNEL1h3T2NicksrL3NSeW4wL0MvSUxMcnFsSWZDdWdIbmhjCkZjVVlTYUIxcW84eFM3WXZZSmhWcnlJdytHUy9hWXBJdzRvUUNieXZJdG5UN0krSGdES1RXZlhVN054eVpyNjYKMGd5b1Z2NEtKblQ3YVhmazMzM3l2OHJmZS8zK3k4YzQ4amtNNjBHdEEvNzhJOWlLMU13cWlQR1ZxNEpKMUJXVwpjMkxzQnBLTmdlbVVYdHZGZndxbGJ3MGZrcTZZRXZRYy9lS2IrQ3N1UXh1MEswb29DNERvWVRGSDBlME0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  failurePolicy: Fail
+  timeoutSeconds: 2

--- a/flavors/csi/nutanix-csi-storage.yaml
+++ b/flavors/csi/nutanix-csi-storage.yaml
@@ -1,0 +1,463 @@
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nutanix-csi-controller
+  namespace: ntnx-system
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nutanix-csi-node
+  namespace: ntnx-system
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nutanix-csi-controller-role
+  namespace: ntnx-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "delete", "update", "patch"]
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nutanix-csi-node-role
+  namespace: ntnx-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nutanix-csi-controller-binding
+  namespace: ntnx-system
+subjects:
+  - kind: ServiceAccount
+    name: nutanix-csi-controller
+    namespace: ntnx-system
+roleRef:
+  kind: ClusterRole
+  name: nutanix-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nutanix-csi-node-binding
+  namespace: ntnx-system
+subjects:
+  - kind: ServiceAccount
+    name: nutanix-csi-node
+    namespace: ntnx-system
+roleRef:
+  kind: ClusterRole
+  name: nutanix-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nutanix-csi-storage/templates/service-prometheus-csi.yaml
+# Copyright 2021 Nutanix Inc
+# 
+# example usage: kubectl create -f <this_file>
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nutanix-csi-metrics
+  namespace: ntnx-system
+  labels:
+    app: nutanix-csi-metrics
+spec:
+  type: ClusterIP
+  selector:
+    app: nutanix-csi-controller
+  ports:
+    - name: provisioner
+      port: 9809
+      targetPort: 9809
+      protocol: TCP
+    - name: resizer
+      port: 9810
+      targetPort: 9810
+      protocol: TCP
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml
+# Copyright 2021 Nutanix Inc
+#
+# example usage: kubectl create -f <this_file>
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: nutanix-csi-node
+  namespace: ntnx-system
+spec:
+  selector:
+    matchLabels:
+      app: nutanix-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: nutanix-csi-node
+    spec:
+      serviceAccount: nutanix-csi-node
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.nutanix.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+            - name: registration-dir
+              mountPath: /registration
+        - name: nutanix-csi-node
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          image: quay.io/karbon/ntnx-csi:v2.5.1
+          imagePullPolicy: IfNotPresent
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(NODE_ID)"
+            - "--drivername=csi.nutanix.com"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - mountPath: /dev
+              name: device-dir
+            - mountPath: /etc/iscsi
+              name: iscsi-dir
+            - mountPath: /host
+              name: root-dir
+              # This is needed because mount is run from host using chroot.
+              mountPropagation: "Bidirectional"
+          ports:
+            - containerPort: 9808
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 3
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:9808
+      priorityClassName: system-cluster-critical
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.nutanix.com/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi
+            type: Directory
+        - name: root-dir
+          hostPath:
+            path: /
+            type: Directory
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml
+# Copyright 2021 Nutanix Inc
+#
+# example usage: kubectl create -f <this_file>
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nutanix-csi-controller
+  namespace: ntnx-system
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: nutanix-csi-controller
+  template:
+    metadata:
+      labels:
+        app: nutanix-csi-controller
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nutanix-csi-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccount: nutanix-csi-controller
+      hostNetwork: true
+      containers:
+        - name: csi-provisioner
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --timeout=60s
+            - --worker-threads=16
+            # This adds PV/PVC metadata to create volume requests
+            - --extra-create-metadata=true
+            - --default-fstype=ext4
+            # This is used to collect CSI operation metrics
+            - --http-endpoint=:9809
+            - --v=2
+            - --leader-election=true
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --csi-address=$(ADDRESS)
+            - --timeout=60s
+            - --leader-election=true
+            # NTNX CSI dirver supports online volume expansion.
+            - --handle-volume-inuse-error=false
+            - --http-endpoint=:9810
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+          imagePullPolicy: IfNotPresent
+          args:
+          - --csi-address=$(ADDRESS)
+          - --leader-election=true
+          - --logtostderr=true
+          - --timeout=300s
+          env:
+          - name: ADDRESS
+            value: /csi/csi.sock
+          volumeMounts:
+          - name: socket-dir
+            mountPath: /csi
+        - name: nutanix-csi-plugin
+          image: quay.io/karbon/ntnx-csi:v2.5.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --nodeid=$(NODE_ID)
+            - --drivername=csi.nutanix.com
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+            # This is needed for static NFS volume feature.
+            - mountPath: /host
+              name: root-dir
+          ports:
+            - containerPort: 9807
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 3
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --http-endpoint=:9807
+      priorityClassName: system-cluster-critical
+      volumes:
+        - emptyDir: {}
+          name: socket-dir
+        - hostPath:
+            path: /
+            type: Directory
+          name: root-dir
+---
+# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
+# Copyright 2018 Nutanix Inc
+#
+# Configuration to deploy the Nutanix CSI driver
+#
+# example usage: kubectl create -f <this_file>
+---
+# Source: nutanix-csi-storage/templates/ntnx-sc.yaml
+---
+---
+# Source: nutanix-csi-storage/templates/csi-driver.yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.nutanix.com
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/flavors/csi/nutanix-csi.yaml
+++ b/flavors/csi/nutanix-csi.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nutanix-csi
+data:
+  ns.yaml: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ntnx-system

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -37,7 +37,7 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-rm "${GOBIN}/${2}"* || true
+rm -f "${GOBIN}/${2}"* || true
 
 # install the golang module specified as the first argument
 go install -tags tools "${1}@${3}"

--- a/templates/cluster-template-ccm.yaml
+++ b/templates/cluster-template-ccm.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+stringData:
+  NUTANIX_PASSWORD: ${NUTANIX_PASSWORD}
+  NUTANIX_USER: ${NUTANIX_USER}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-kcfg-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+      postKubeadmCommands:
+      - echo "after kubeadm call" > /var/log/postkubeadm.log
+      preKubeadmCommands:
+      - echo "before kubeadm call" > /var/log/prekubeadm.log
+      users:
+      - lockPassword: false
+        name: capiuser
+        sshAuthorizedKeys:
+        - ${NUTANIX_SSH_AUTHORIZED_KEY}
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      verbosity: 10
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    ccm: nutanix
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 172.20.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 172.19.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-kcp
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-wmd
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-kcfg-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: ${CLUSTER_NAME}-mt-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  unhealthyConditions:
+  - status: "False"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "True"
+    timeout: 300s
+    type: MemoryPressure
+  - status: "True"
+    timeout: 300s
+    type: DiskPressure
+  - status: "True"
+    timeout: 300s
+    type: PIDPressure
+  - status: "True"
+    timeout: 300s
+    type: NetworkUnavailable
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-kcp
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+        extraArgs:
+          cloud-provider: external
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: ghcr.io/kube-vip/kube-vip:v0.4.2
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "${CONTROL_PLANE_ENDPOINT_IP}"
+                - name: port
+                  value: "${CONTROL_PLANE_ENDPOINT_PORT=6443}"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "${KUBEVIP_SVC_ENABLE=false}"
+                - name: lb_enable
+                  value: "${KUBEVIP_LB_ENABLE=false}"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          hostAliases:
+            - hostnames:
+                - kubernetes
+              ip: 127.0.0.1
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+    postKubeadmCommands:
+    - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    - echo "after kubeadm call" > /var/log/postkubeadm.log
+    preKubeadmCommands:
+    - echo "before kubeadm call" > /var/log/prekubeadm.log
+    useExperimentalRetryJoin: true
+    users:
+    - lockPassword: false
+      name: capiuser
+      sshAuthorizedKeys:
+      - ${NUTANIX_SSH_AUTHORIZED_KEY}
+      sudo: ALL=(ALL) NOPASSWD:ALL
+    verbosity: 10
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: ${CLUSTER_NAME}-mt-0
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT=1}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
+    port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}
+  prismCentral:
+    address: ${NUTANIX_ENDPOINT}
+    credentialRef:
+      kind: Secret
+      name: ${CLUSTER_NAME}
+    insecure: ${NUTANIX_INSECURE=false}
+    port: ${NUTANIX_PORT=9440}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-mt-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      cluster:
+        name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+        type: name
+      image:
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        type: name
+      memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
+      providerID: nutanix://${CLUSTER_NAME}-m1
+      subnet:
+      - name: ${NUTANIX_SUBNET_NAME}
+        type: name
+      systemDiskSize: ${NUTANIX_SYSTEMDISK_SIZE=40Gi}
+      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
+      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1,0 +1,1626 @@
+apiVersion: v1
+data:
+  ns.yaml: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ntnx-system
+  nutanix-csi-sc.yaml: |-
+    # Source: nutanix-csi-storage/templates/ntnx-secret.yaml
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ntnx-secret
+      namespace: ntnx-system
+    stringData:
+      # prism-ip:prism-port:admin:password.
+      key: ${NUTANIX_PE_ENDPOINT}:${NUTANIX_PE_PORT=9440}:${NUTANIX_PE_USER=admin}:${NUTANIX_PE_PASSWORD}
+    ---
+    # Source: nutanix-csi-storage/templates/ntnx-sc.yaml
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+        name: nutanix-volume
+    provisioner: csi.nutanix.com
+    parameters:
+        storageType: NutanixVolumes
+        csi.storage.k8s.io/provisioner-secret-name: ntnx-secret
+        csi.storage.k8s.io/provisioner-secret-namespace: ntnx-system
+        csi.storage.k8s.io/node-publish-secret-name: ntnx-secret
+        csi.storage.k8s.io/node-publish-secret-namespace: ntnx-system
+        csi.storage.k8s.io/controller-expand-secret-name: ntnx-secret
+        csi.storage.k8s.io/controller-expand-secret-namespace: ntnx-system
+        storageContainer: ${NUTANIX_STORAGE_CONTAINER}
+        csi.storage.k8s.io/fstype: ext4
+        isSegmentedIscsiNetwork: "false"
+        description: "nutanix-volume"
+    allowVolumeExpansion: true
+    reclaimPolicy: Delete
+  nutanix-csi-snapshot.yaml: |
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+    # RBAC file for the snapshot controller.
+    #
+    # The snapshot controller implements the control loop for CSI snapshot functionality.
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: csi-snapshot-controller
+      namespace: ntnx-system
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+    # RBAC file for the snapshot webhook.
+    #
+    # The snapshot webhook implements the validation and admission for CSI snapshot functionality.
+
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: csi-snapshot-webhook
+      namespace:  ntnx-system
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: csi-snapshot-validation-webhook-cert
+      namespace: ntnx-system
+    type: kubernetes.io/tls
+    stringData:
+      ca.crt: ${WEBHOOK_CA}
+      tls.key: ${WEBHOOK_KEY}
+      tls.crt: ${WEBHOOK_CERT}
+    ---
+    # Source: nutanix-csi-snapshot/templates/volumesnapshotclasses_rel60.yaml
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.8.0
+        api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+      creationTimestamp: null
+      name: volumesnapshotclasses.snapshot.storage.k8s.io
+    spec:
+      group: snapshot.storage.k8s.io
+      names:
+        kind: VolumeSnapshotClass
+        listKind: VolumeSnapshotClassList
+        plural: volumesnapshotclasses
+        shortNames:
+        - vsclass
+        - vsclasses
+        singular: volumesnapshotclass
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the
+            VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshotClass specifies parameters that a underlying storage
+              system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+              is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+              are non-namespaced
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              deletionPolicy:
+                description: deletionPolicy determines whether a VolumeSnapshotContent
+                  created through the VolumeSnapshotClass should be deleted when its bound
+                  VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeSnapshotContent and its physical snapshot
+                  on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
+                  and its physical snapshot on underlying storage system are deleted.
+                  Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: driver is the name of the storage driver that handles this
+                  VolumeSnapshotClass. Required.
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: parameters is a key-value map with storage driver specific
+                  parameters for creating snapshots. These values are opaque to Kubernetes.
+                type: object
+            required:
+            - deletionPolicy
+            - driver
+            type: object
+        served: true
+        storage: true
+        subresources: {}
+      - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        # This indicates the v1beta1 version of the custom resource is deprecated.
+        # API requests to this version receive a warning in the server response.
+        deprecated: true
+        # This overrides the default warning returned to clients making v1beta1 API requests.
+        deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              deletionPolicy:
+                description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+                type: object
+            required:
+            - deletionPolicy
+            - driver
+            type: object
+        served: false
+        storage: false
+        subresources: {}
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    # Source: nutanix-csi-snapshot/templates/volumesnapshotcontents_rel60.yaml
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.8.0
+        api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+      creationTimestamp: null
+      name: volumesnapshotcontents.snapshot.storage.k8s.io
+    spec:
+      group: snapshot.storage.k8s.io
+      names:
+        kind: VolumeSnapshotContent
+        listKind: VolumeSnapshotContentList
+        plural: volumesnapshotcontents
+        shortNames:
+        - vsc
+        - vscs
+        singular: volumesnapshotcontent
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical
+            snapshot on the underlying storage system should be deleted when its bound
+            VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on
+            the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+            object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+              object in the underlying storage system
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              spec:
+                description: spec defines properties of a VolumeSnapshotContent created
+                  by the underlying storage system. Required.
+                properties:
+                  deletionPolicy:
+                    description: deletionPolicy determines whether this VolumeSnapshotContent
+                      and its physical snapshot on the underlying storage system should
+                      be deleted when its bound VolumeSnapshot is deleted. Supported values
+                      are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                      and its physical snapshot on underlying storage system are kept.
+                      "Delete" means that the VolumeSnapshotContent and its physical snapshot
+                      on underlying storage system are deleted. For dynamically provisioned
+                      snapshots, this field will automatically be filled in by the CSI
+                      snapshotter sidecar with the "DeletionPolicy" field defined in the
+                      corresponding VolumeSnapshotClass. For pre-existing snapshots, users
+                      MUST specify this field when creating the VolumeSnapshotContent
+                      object. Required.
+                    enum:
+                    - Delete
+                    - Retain
+                    type: string
+                  driver:
+                    description: driver is the name of the CSI driver used to create the
+                      physical snapshot on the underlying storage system. This MUST be
+                      the same as the name returned by the CSI GetPluginName() call for
+                      that driver. Required.
+                    type: string
+                  source:
+                    description: source specifies whether the snapshot is (or should be)
+                      dynamically provisioned or already exists, and just requires a Kubernetes
+                      object representation. This field is immutable after creation. Required.
+                    properties:
+                      snapshotHandle:
+                        description: snapshotHandle specifies the CSI "snapshot_id" of
+                          a pre-existing snapshot on the underlying storage system for
+                          which a Kubernetes object representation was (or should be)
+                          created. This field is immutable.
+                        type: string
+                      volumeHandle:
+                        description: volumeHandle specifies the CSI "volume_id" of the
+                          volume from which a snapshot should be dynamically taken from.
+                          This field is immutable.
+                        type: string
+                    type: object
+                    oneOf:
+                    - required: ["snapshotHandle"]
+                    - required: ["volumeHandle"]
+                  sourceVolumeMode:
+                    description: SourceVolumeMode is the mode of the volume whose snapshot
+                      is taken. Can be either “Filesystem” or “Block”. If not specified,
+                      it indicates the source volume's mode is unknown. This field is
+                      immutable. This field is an alpha field.
+                    type: string
+                  volumeSnapshotClassName:
+                    description: name of the VolumeSnapshotClass from which this snapshot
+                      was (or will be) created. Note that after provisioning, the VolumeSnapshotClass
+                      may be deleted or recreated with different set of values, and as
+                      such, should not be referenced post-snapshot creation.
+                    type: string
+                  volumeSnapshotRef:
+                    description: volumeSnapshotRef specifies the VolumeSnapshot object
+                      to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                      field must reference to this VolumeSnapshotContent's name for the
+                      bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                      object, name and namespace of the VolumeSnapshot object MUST be
+                      provided for binding to happen. This field is immutable after creation.
+                      Required.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of
+                          an entire object, this string should contain a valid JSON/Go
+                          field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part of
+                          an object. TODO: this design is not final and this field is
+                          subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+                type: object
+              status:
+                description: status represents the current information of a snapshot.
+                properties:
+                  creationTime:
+                    description: creationTime is the timestamp when the point-in-time
+                      snapshot is taken by the underlying storage system. In dynamic snapshot
+                      creation case, this field will be filled in by the CSI snapshotter
+                      sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
+                      gRPC call. For a pre-existing snapshot, this field will be filled
+                      with the "creation_time" value returned from the CSI "ListSnapshots"
+                      gRPC call if the driver supports it. If not specified, it indicates
+                      the creation time is unknown. The format of this field is a Unix
+                      nanoseconds time encoded as an int64. On Unix, the command `date
+                      +%s%N` returns the current time in nanoseconds since 1970-01-01
+                      00:00:00 UTC.
+                    format: int64
+                    type: integer
+                  error:
+                    description: error is the last observed error during snapshot creation,
+                      if any. Upon success after retry, this error field will be cleared.
+                    properties:
+                      message:
+                        description: 'message is a string detailing the encountered error
+                          during snapshot creation if specified. NOTE: message may be
+                          logged, and it should not contain sensitive information.'
+                        type: string
+                      time:
+                        description: time is the timestamp when the error was encountered.
+                        format: date-time
+                        type: string
+                    type: object
+                  readyToUse:
+                    description: readyToUse indicates if a snapshot is ready to be used
+                      to restore a volume. In dynamic snapshot creation case, this field
+                      will be filled in by the CSI snapshotter sidecar with the "ready_to_use"
+                      value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                      snapshot, this field will be filled with the "ready_to_use" value
+                      returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                      it, otherwise, this field will be set to "True". If not specified,
+                      it means the readiness of a snapshot is unknown.
+                    type: boolean
+                  restoreSize:
+                    description: restoreSize represents the complete size of the snapshot
+                      in bytes. In dynamic snapshot creation case, this field will be
+                      filled in by the CSI snapshotter sidecar with the "size_bytes" value
+                      returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                      snapshot, this field will be filled with the "size_bytes" value
+                      returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                      it. When restoring a volume from this snapshot, the size of the
+                      volume MUST NOT be smaller than the restoreSize if it is specified,
+                      otherwise the restoration will fail. If not specified, it indicates
+                      that the size is unknown.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  snapshotHandle:
+                    description: snapshotHandle is the CSI "snapshot_id" of a snapshot
+                      on the underlying storage system. If not specified, it indicates
+                      that dynamic snapshot creation has either failed or it is still
+                      in progress.
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        # This indicates the v1beta1 version of the custom resource is deprecated.
+        # API requests to this version receive a warning in the server response.
+        deprecated: true
+        # This overrides the default warning returned to clients making v1beta1 API requests.
+        deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              spec:
+                description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+                properties:
+                  deletionPolicy:
+                    description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                    enum:
+                    - Delete
+                    - Retain
+                    type: string
+                  driver:
+                    description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                    type: string
+                  source:
+                    description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                    properties:
+                      snapshotHandle:
+                        description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                        type: string
+                      volumeHandle:
+                        description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                        type: string
+                    type: object
+                  volumeSnapshotClassName:
+                    description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                    type: string
+                  volumeSnapshotRef:
+                    description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+                type: object
+              status:
+                description: status represents the current information of a snapshot.
+                properties:
+                  creationTime:
+                    description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                    format: int64
+                    type: integer
+                  error:
+                    description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                    properties:
+                      message:
+                        description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                        type: string
+                      time:
+                        description: time is the timestamp when the error was encountered.
+                        format: date-time
+                        type: string
+                    type: object
+                  readyToUse:
+                    description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                    type: boolean
+                  restoreSize:
+                    description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  snapshotHandle:
+                    description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    # Source: nutanix-csi-snapshot/templates/volumesnapshots_rel60.yaml
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.8.0
+        api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
+      creationTimestamp: null
+      name: volumesnapshots.snapshot.storage.k8s.io
+    spec:
+      group: snapshot.storage.k8s.io
+      names:
+        kind: VolumeSnapshot
+        listKind: VolumeSnapshotList
+        plural: volumesnapshots
+        shortNames:
+        - vs
+        singular: volumesnapshot
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of
+            the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing
+            VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from
+            this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot
+            object intends to bind to. Please note that verification of binding actually
+            requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure
+            both are pointing at each other. Binding MUST be verified prior to usage of
+            this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying
+            storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshot is a user's request for either creating a point-in-time
+              snapshot of a persistent volume, or binding to a pre-existing snapshot.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              spec:
+                description: 'spec defines the desired characteristics of a snapshot requested
+                  by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+                  Required.'
+                properties:
+                  source:
+                    description: source specifies where a snapshot will be created from.
+                      This field is immutable after creation. Required.
+                    properties:
+                      persistentVolumeClaimName:
+                        description: persistentVolumeClaimName specifies the name of the
+                          PersistentVolumeClaim object representing the volume from which
+                          a snapshot should be created. This PVC is assumed to be in the
+                          same namespace as the VolumeSnapshot object. This field should
+                          be set if the snapshot does not exists, and needs to be created.
+                          This field is immutable.
+                        type: string
+                      volumeSnapshotContentName:
+                        description: volumeSnapshotContentName specifies the name of a
+                          pre-existing VolumeSnapshotContent object representing an existing
+                          volume snapshot. This field should be set if the snapshot already
+                          exists and only needs a representation in Kubernetes. This field
+                          is immutable.
+                        type: string
+                    type: object
+                    oneOf:
+                    - required: ["persistentVolumeClaimName"]
+                    - required: ["volumeSnapshotContentName"]
+                  volumeSnapshotClassName:
+                    description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                      requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+                      left nil to indicate that the default SnapshotClass should be used.
+                      A given cluster may have multiple default Volume SnapshotClasses:
+                      one default per CSI Driver. If a VolumeSnapshot does not specify
+                      a SnapshotClass, VolumeSnapshotSource will be checked to figure
+                      out what the associated CSI Driver is, and the default VolumeSnapshotClass
+                      associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
+                      exist for a given CSI Driver and more than one have been marked
+                      as default, CreateSnapshot will fail and generate an event. Empty
+                      string is not allowed for this field.'
+                    type: string
+                required:
+                - source
+                type: object
+              status:
+                description: status represents the current information of a snapshot.
+                  Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent
+                  objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                  point at each other) before using this object.
+                properties:
+                  boundVolumeSnapshotContentName:
+                    description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                      object to which this VolumeSnapshot object intends to bind to. If
+                      not specified, it indicates that the VolumeSnapshot object has not
+                      been successfully bound to a VolumeSnapshotContent object yet. NOTE:
+                      To avoid possible security issues, consumers must verify binding
+                      between VolumeSnapshot and VolumeSnapshotContent objects is successful
+                      (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                      point at each other) before using this object.'
+                    type: string
+                  creationTime:
+                    description: creationTime is the timestamp when the point-in-time
+                      snapshot is taken by the underlying storage system. In dynamic snapshot
+                      creation case, this field will be filled in by the snapshot controller
+                      with the "creation_time" value returned from CSI "CreateSnapshot"
+                      gRPC call. For a pre-existing snapshot, this field will be filled
+                      with the "creation_time" value returned from the CSI "ListSnapshots"
+                      gRPC call if the driver supports it. If not specified, it may indicate
+                      that the creation time of the snapshot is unknown.
+                    format: date-time
+                    type: string
+                  error:
+                    description: error is the last observed error during snapshot creation,
+                      if any. This field could be helpful to upper level controllers(i.e.,
+                      application controller) to decide whether they should continue on
+                      waiting for the snapshot to be created based on the type of error
+                      reported. The snapshot controller will keep retrying when an error
+                      occurs during the snapshot creation. Upon success, this error field
+                      will be cleared.
+                    properties:
+                      message:
+                        description: 'message is a string detailing the encountered error
+                          during snapshot creation if specified. NOTE: message may be
+                          logged, and it should not contain sensitive information.'
+                        type: string
+                      time:
+                        description: time is the timestamp when the error was encountered.
+                        format: date-time
+                        type: string
+                    type: object
+                  readyToUse:
+                    description: readyToUse indicates if the snapshot is ready to be used
+                      to restore a volume. In dynamic snapshot creation case, this field
+                      will be filled in by the snapshot controller with the "ready_to_use"
+                      value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                      snapshot, this field will be filled with the "ready_to_use" value
+                      returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                      it, otherwise, this field will be set to "True". If not specified,
+                      it means the readiness of a snapshot is unknown.
+                    type: boolean
+                  restoreSize:
+                    type: string
+                    description: restoreSize represents the minimum size of volume required
+                      to create a volume from this snapshot. In dynamic snapshot creation
+                      case, this field will be filled in by the snapshot controller with
+                      the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call.
+                      For a pre-existing snapshot, this field will be filled with the
+                      "size_bytes" value returned from the CSI "ListSnapshots" gRPC call
+                      if the driver supports it. When restoring a volume from this snapshot,
+                      the size of the volume MUST NOT be smaller than the restoreSize
+                      if it is specified, otherwise the restoration will fail. If not
+                      specified, it indicates that the size is unknown.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        # This indicates the v1beta1 version of the custom resource is deprecated.
+        # API requests to this version receive a warning in the server response.
+        deprecated: true
+        # This overrides the default warning returned to clients making v1beta1 API requests.
+        deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+        schema:
+          openAPIV3Schema:
+            description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              spec:
+                description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+                properties:
+                  source:
+                    description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                    properties:
+                      persistentVolumeClaimName:
+                        description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                        type: string
+                      volumeSnapshotContentName:
+                        description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                        type: string
+                    type: object
+                  volumeSnapshotClassName:
+                    description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                    type: string
+                required:
+                - source
+                type: object
+              status:
+                description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+                properties:
+                  boundVolumeSnapshotContentName:
+                    description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                    type: string
+                  creationTime:
+                    description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                    format: date-time
+                    type: string
+                  error:
+                    description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                    properties:
+                      message:
+                        description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                        type: string
+                      time:
+                        description: time is the timestamp when the error was encountered.
+                        format: date-time
+                        type: string
+                    type: object
+                  readyToUse:
+                    description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                    type: boolean
+                  restoreSize:
+                    type: string
+                    description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+            required:
+            - spec
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: csi-snapshot-controller-runner
+      namespace: ntnx-system
+    rules:
+      - apiGroups: [""]
+        resources: ["persistentvolumes"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: [""]
+        resources: ["persistentvolumeclaims"]
+        verbs: ["get", "list", "watch", "update"]
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["list", "watch", "create", "update", "patch"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshotclasses"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshotcontents"]
+        verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshotcontents/status"]
+        verbs: ["patch"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshots"]
+        verbs: ["get", "list", "watch", "update", "patch"]
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshots/status"]
+        verbs: ["update", "patch"]
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: csi-snapshot-webhook-runner
+    rules:
+      - apiGroups: ["snapshot.storage.k8s.io"]
+        resources: ["volumesnapshotclasses"]
+        verbs: ["get", "list", "watch"]
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: csi-snapshot-controller-role
+      namespace: ntnx-system
+    subjects:
+      - kind: ServiceAccount
+        name: csi-snapshot-controller
+        namespace: ntnx-system
+    roleRef:
+      kind: ClusterRole
+      name: csi-snapshot-controller-runner
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-rbac.yaml
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: snapshot-webhook-role
+    subjects:
+      - kind: ServiceAccount
+        name: csi-snapshot-webhook
+        namespace:  ntnx-system
+    roleRef:
+      kind: ClusterRole
+      name: csi-snapshot-webhook-runner
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+    kind: Role
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: csi-snapshot-controller-leaderelection
+      namespace: ntnx-system
+    rules:
+    - apiGroups: ["coordination.k8s.io"]
+      resources: ["leases"]
+      verbs: ["get", "watch", "list", "delete", "update", "create"]
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-rbac.yaml
+    kind: RoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: csi-snapshot-controller-leaderelection
+      namespace: ntnx-system
+    subjects:
+      - kind: ServiceAccount
+        name: csi-snapshot-controller
+        namespace: ntnx-system
+    roleRef:
+      kind: Role
+      name: csi-snapshot-controller-leaderelection
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-deployment.yaml
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: csi-snapshot-webhook
+      namespace: ntnx-system
+    spec:
+      selector:
+        app: csi-snapshot-webhook
+      ports:
+        - name: webhook
+          protocol: TCP
+          port: 443
+          targetPort: 8443
+    ---
+    # Source: nutanix-csi-snapshot/templates/snapshot-controller-deployment.yaml
+    # This YAML file shows how to deploy the snapshot controller
+
+    # The snapshot controller implements the control loop for CSI snapshot functionality.
+
+    kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      name: csi-snapshot-controller
+      namespace: ntnx-system
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: csi-snapshot-controller
+      minReadySeconds: 15
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: csi-snapshot-controller
+        spec:
+          serviceAccount: csi-snapshot-controller
+          containers:
+            - name: snapshot-controller
+              image: k8s.gcr.io/sig-storage/snapshot-controller:v6.0.1
+              imagePullPolicy: IfNotPresent
+              args:
+                - "--v=2"
+                - "--leader-election=true"
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 20Mi
+          priorityClassName: system-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app: csi-snapshot-controller
+                    topologyKey: kubernetes.io/hostname
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-deployment.yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: csi-snapshot-webhook
+      namespace: ntnx-system
+      labels:
+        app: csi-snapshot-webhook
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: csi-snapshot-webhook
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app: csi-snapshot-webhook
+        spec:
+          serviceAccountName: csi-snapshot-webhook
+          containers:
+          - name: snapshot-validation
+            image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1
+            imagePullPolicy: IfNotPresent
+            args:
+              - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
+              - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
+              - --v=2
+              - --port=8443
+            ports:
+            - containerPort: 8443
+            resources:
+              requests:
+                cpu: 10m
+                memory: 20Mi
+            securityContext:
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+            volumeMounts:
+              - name: snapshot-validation-webhook-certs
+                mountPath: /etc/snapshot-validation-webhook/certs
+                readOnly: true
+          volumes:
+            - name: snapshot-validation-webhook-certs
+              secret:
+                secretName: csi-snapshot-validation-webhook-cert
+          priorityClassName: system-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+          nodeSelector:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app: csi-snapshot-webhook
+                    topologyKey: kubernetes.io/hostname
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+    # Check if the TLS secret already exists and initialize variables for later use at the top level
+    ---
+    # Source: nutanix-csi-snapshot/templates/validating-webhook.yaml
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: "validation-webhook.snapshot.storage.k8s.io"
+      namespace: ntnx-system
+    webhooks:
+    - name: "validation-webhook.snapshot.storage.k8s.io"
+      rules:
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1", "v1beta1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["volumesnapshots", "volumesnapshotcontents"]
+        scope:       "*"
+      clientConfig:
+        service:
+          namespace: ntnx-system
+          name: "csi-snapshot-webhook"
+          path: "/volumesnapshot"
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURXVENDQWtHZ0F3SUJBZ0lSQUlSMEZrQ1BidXJLVVdleXRiMUsxcFV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1kzTnBMWE51WVhCemFHOTBMWGRsWW1odmIyc3ViblJ1ZUMxemVYTjBaVzB1YzNaagpNQjRYRFRJeU1EY3lNREV3TURVek4xb1hEVE15TURjeE56RXdNRFV6TjFvd0x6RXRNQ3NHQTFVRUF4TWtZM05wCkxYTnVZWEJ6YUc5MExYZGxZbWh2YjJzdWJuUnVlQzF6ZVhOMFpXMHVjM1pqTUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBelVZYUM5ZkE1VndXQ0prcitnT1VoQXViMys2VjdZYTd5a2YvN1JpLwpuYU5YUWQ0YnAycXczQTBrUFhUVnozQUVEaUVKQmY1c3JmUG01ZFl5TUNvbTZXTVkzTWxRaFdWRHVSdFVWNFh2Cldyb294MEtkUUxEeWszSGJ3cGwrVTFPUTlVdkFKNnQ1Snh6NzF6ZFh6WDZqTTA1ZGpWM3JhM0V0eWhhOVpmVFAKTzJCcklOcnkxRHArNGNRRUpYL3gvdGhtQWFUU1ltUEhvUlRHY29hMjJQODVwTGJBV0I3YzdDUFU0a2JpeDhqcQpNdTY3WlNQUCtoK0J5RGVFejF5MlBHbk9jeVFmNi9KbUxIV1EwT1VHVllrVCt6RHowYkFvRGlpVVhpUTArZXVjCjAwTHZrNUQrWXdiRUFpTDJjZmtBQ3R6SkZaemowYnBKM1FoOE4xREVyY1hiWlFJREFRQUJvM0F3YmpBT0JnTlYKSFE4QkFmOEVCQU1DQmFBd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQXdHQTFVZApFd0VCL3dRQ01BQXdMd1lEVlIwUkJDZ3dKb0lrWTNOcExYTnVZWEJ6YUc5MExYZGxZbWh2YjJzdWJuUnVlQzF6CmVYTjBaVzB1YzNaak1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQlpHNi9tL0dHSFBYaENtWWNRdGJuYmFjRFoKQlpXTmg1djRQbUpoRnhIYm9ERThhTE54ZDZXWG1qa0F0OUJjTGxXZ1oySVRYSW9UR3hRWlNxUTVIRXJieEVHdwpWZnUySXg1TkhpRFdJeDE2U20yT2NjOWFZRmFvVTNEL1h3T2NicksrL3NSeW4wL0MvSUxMcnFsSWZDdWdIbmhjCkZjVVlTYUIxcW84eFM3WXZZSmhWcnlJdytHUy9hWXBJdzRvUUNieXZJdG5UN0krSGdES1RXZlhVN054eVpyNjYKMGd5b1Z2NEtKblQ3YVhmazMzM3l2OHJmZS8zK3k4YzQ4amtNNjBHdEEvNzhJOWlLMU13cWlQR1ZxNEpKMUJXVwpjMkxzQnBLTmdlbVVYdHZGZndxbGJ3MGZrcTZZRXZRYy9lS2IrQ3N1UXh1MEswb29DNERvWVRGSDBlME0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      admissionReviewVersions: ["v1", "v1beta1"]
+      sideEffects: None
+      failurePolicy: Fail
+      timeoutSeconds: 2
+  nutanix-csi-storage.yaml: "---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\napiVersion:
+    v1\nkind: ServiceAccount\nmetadata:\n  name: nutanix-csi-controller\n  namespace:
+    ntnx-system\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\napiVersion:
+    v1\nkind: ServiceAccount\nmetadata:\n  name: nutanix-csi-node\n  namespace: ntnx-system\n---\n#
+    Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind: ClusterRole\napiVersion:
+    rbac.authorization.k8s.io/v1\nmetadata:\n  name: nutanix-csi-controller-role\n
+    \ namespace: ntnx-system\nrules:\n  - apiGroups: [\"\"]\n    resources: [\"secrets\"]\n
+    \   verbs: [\"get\", \"list\", \"watch\"]\n  - apiGroups: [\"\"]\n    resources:
+    [\"nodes\"]\n    verbs: [\"get\"]\n  - apiGroups: [\"\"]\n    resources: [\"persistentvolumes\"]\n
+    \   verbs: [\"get\", \"list\", \"watch\", \"create\", \"delete\", \"update\",
+    \"patch\"]\n  - apiGroups: [\"\"]\n    resources: [\"persistentvolumeclaims\"]\n
+    \   verbs: [\"get\", \"list\", \"watch\", \"update\"]\n  - apiGroups: [\"\"]\n
+    \   resources: [\"persistentvolumeclaims/status\"]\n    verbs: [\"update\", \"patch\"]\n
+    \ - apiGroups: [\"storage.k8s.io\"]\n    resources: [\"storageclasses\"]\n    verbs:
+    [\"get\", \"list\", \"watch\"]\n  - apiGroups: [\"\"]\n    resources: [\"events\"]\n
+    \   verbs: [\"list\", \"watch\", \"create\", \"update\", \"patch\"]\n  - apiGroups:
+    [\"snapshot.storage.k8s.io\"]\n    resources: [\"volumesnapshotclasses\"]\n    verbs:
+    [\"get\", \"list\", \"watch\"]\n  - apiGroups: [\"snapshot.storage.k8s.io\"]\n
+    \   resources: [\"volumesnapshots\"]\n    verbs: [\"get\", \"list\", \"watch\",
+    \"update\"]\n  - apiGroups: [\"snapshot.storage.k8s.io\"]\n    resources: [\"volumesnapshots/status\"]\n
+    \   verbs: [\"update\"]\n  - apiGroups: [\"snapshot.storage.k8s.io\"]\n    resources:
+    [\"volumesnapshotcontents\"]\n    verbs: [\"create\", \"get\", \"list\", \"watch\",
+    \"update\", \"delete\", \"patch\"]\n  - apiGroups: [\"snapshot.storage.k8s.io\"]\n
+    \   resources: [\"volumesnapshotcontents/status\"]\n    verbs: [\"update\", \"patch\"]\n
+    \ - apiGroups: [\"storage.k8s.io\"]\n    resources: [\"csinodes\"]\n    verbs:
+    [\"get\", \"list\", \"watch\"]\n  - apiGroups: [\"coordination.k8s.io\"]\n    resources:
+    [\"leases\"]\n    verbs: [\"get\", \"create\", \"delete\", \"update\", \"patch\"]\n---\n#
+    Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind: ClusterRole\napiVersion:
+    rbac.authorization.k8s.io/v1\nmetadata:\n  name: nutanix-csi-node-role\n  namespace:
+    ntnx-system\nrules:\n  - apiGroups: [\"\"]\n    resources: [\"secrets\"]\n    verbs:
+    [\"get\", \"list\"]\n  - apiGroups: [\"\"]\n    resources: [\"nodes\"]\n    verbs:
+    [\"get\", \"list\", \"update\"]\n  - apiGroups: [\"\"]\n    resources: [\"namespaces\"]\n
+    \   verbs: [\"get\", \"list\"]\n  - apiGroups: [\"\"]\n    resources: [\"persistentvolumes\"]\n
+    \   verbs: [\"get\", \"list\", \"watch\", \"update\"]\n  - apiGroups: [\"storage.k8s.io\"]\n
+    \   resources: [\"volumeattachments\"]\n    verbs: [\"get\", \"list\", \"watch\",
+    \"update\"]\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind:
+    ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name:
+    nutanix-csi-controller-binding\n  namespace: ntnx-system\nsubjects:\n  - kind:
+    ServiceAccount\n    name: nutanix-csi-controller\n    namespace: ntnx-system\nroleRef:\n
+    \ kind: ClusterRole\n  name: nutanix-csi-controller-role\n  apiGroup: rbac.authorization.k8s.io\n---\n#
+    Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind: ClusterRoleBinding\napiVersion:
+    rbac.authorization.k8s.io/v1\nmetadata:\n  name: nutanix-csi-node-binding\n  namespace:
+    ntnx-system\nsubjects:\n  - kind: ServiceAccount\n    name: nutanix-csi-node\n
+    \   namespace: ntnx-system\nroleRef:\n  kind: ClusterRole\n  name: nutanix-csi-node-role\n
+    \ apiGroup: rbac.authorization.k8s.io\n---\n# Source: nutanix-csi-storage/templates/service-prometheus-csi.yaml\n#
+    Copyright 2021 Nutanix Inc\n# \n# example usage: kubectl create -f <this_file>\n#\n\napiVersion:
+    v1\nkind: Service\nmetadata:\n  name: nutanix-csi-metrics\n  namespace: ntnx-system\n
+    \ labels:\n    app: nutanix-csi-metrics\nspec:\n  type: ClusterIP\n  selector:\n
+    \   app: nutanix-csi-controller\n  ports:\n    - name: provisioner\n      port:
+    9809\n      targetPort: 9809\n      protocol: TCP\n    - name: resizer\n      port:
+    9810\n      targetPort: 9810\n      protocol: TCP\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml\n#
+    Copyright 2021 Nutanix Inc\n#\n# example usage: kubectl create -f <this_file>\n\nkind:
+    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: nutanix-csi-node\n  namespace:
+    ntnx-system\nspec:\n  selector:\n    matchLabels:\n      app: nutanix-csi-node\n
+    \ updateStrategy:\n    type: \"RollingUpdate\"\n    rollingUpdate:\n      maxUnavailable:
+    1\n  template:\n    metadata:\n      labels:\n        app: nutanix-csi-node\n
+    \   spec:\n      serviceAccount: nutanix-csi-node\n      hostNetwork: true\n      containers:\n
+    \       - name: driver-registrar\n          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1\n
+    \         imagePullPolicy: IfNotPresent\n          args:\n            - --v=2\n
+    \           - --csi-address=$(ADDRESS)\n            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)\n
+    \         env:\n            - name: ADDRESS\n              value: /csi/csi.sock\n
+    \           - name: DRIVER_REG_SOCK_PATH\n              value: /var/lib/kubelet/plugins/csi.nutanix.com/csi.sock\n
+    \           - name: KUBE_NODE_NAME\n              valueFrom:\n                fieldRef:\n
+    \                 fieldPath: spec.nodeName\n          resources:\n            limits:\n
+    \             cpu: 100m\n              memory: 200Mi\n            requests:\n
+    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
+    \           - name: plugin-dir\n              mountPath: /csi/\n            -
+    name: registration-dir\n              mountPath: /registration\n        - name:
+    nutanix-csi-node\n          securityContext:\n            privileged: true\n            allowPrivilegeEscalation:
+    true\n          image: quay.io/karbon/ntnx-csi:v2.5.1\n          imagePullPolicy:
+    IfNotPresent\n          args :\n            - \"--endpoint=$(CSI_ENDPOINT)\"\n
+    \           - \"--nodeid=$(NODE_ID)\"\n            - \"--drivername=csi.nutanix.com\"\n
+    \         env:\n            - name: CSI_ENDPOINT\n              value: unix:///csi/csi.sock\n
+    \           - name: NODE_ID\n              valueFrom:\n                fieldRef:\n
+    \                 fieldPath: spec.nodeName\n            - name: NODE_IP\n              valueFrom:\n
+    \               fieldRef:\n                  fieldPath: status.hostIP\n          resources:\n
+    \           limits:\n              cpu: 100m\n              memory: 200Mi\n            requests:\n
+    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
+    \           - name: plugin-dir\n              mountPath: /csi\n            - name:
+    pods-mount-dir\n              mountPath: /var/lib/kubelet\n              # needed
+    so that any mounts setup inside this container are\n              # propagated
+    back to the host machine.\n              mountPropagation: \"Bidirectional\"\n
+    \           - mountPath: /dev\n              name: device-dir\n            - mountPath:
+    /etc/iscsi\n              name: iscsi-dir\n            - mountPath: /host\n              name:
+    root-dir\n              # This is needed because mount is run from host using
+    chroot.\n              mountPropagation: \"Bidirectional\"\n          ports:\n
+    \           - containerPort: 9808\n              name: http-endpoint\n              protocol:
+    TCP\n          livenessProbe:\n            httpGet:\n              path: /healthz\n
+    \             port: http-endpoint\n            initialDelaySeconds: 10\n            timeoutSeconds:
+    3\n            periodSeconds: 2\n            failureThreshold: 3\n        - name:
+    liveness-probe\n          volumeMounts:\n            - mountPath: /csi\n              name:
+    plugin-dir\n          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0\n          imagePullPolicy:
+    IfNotPresent\n          args:\n            - --csi-address=/csi/csi.sock\n            -
+    --http-endpoint=:9808\n      priorityClassName: system-cluster-critical\n      volumes:\n
+    \       - name: registration-dir\n          hostPath:\n            path: /var/lib/kubelet/plugins_registry/\n
+    \           type: Directory\n        - name: plugin-dir\n          hostPath:\n
+    \           path: /var/lib/kubelet/plugins/csi.nutanix.com/\n            type:
+    DirectoryOrCreate\n        - name: pods-mount-dir\n          hostPath:\n            path:
+    /var/lib/kubelet\n            type: Directory\n        - name: device-dir\n          hostPath:\n
+    \           path: /dev\n        - name: iscsi-dir\n          hostPath:\n            path:
+    /etc/iscsi\n            type: Directory\n        - name: root-dir\n          hostPath:\n
+    \           path: /\n            type: Directory\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml\n#
+    Copyright 2021 Nutanix Inc\n#\n# example usage: kubectl create -f <this_file>\n\nkind:
+    Deployment\napiVersion: apps/v1\nmetadata:\n  name: nutanix-csi-controller\n  namespace:
+    ntnx-system\nspec:\n  replicas: 2\n  strategy:\n    type: RollingUpdate\n    rollingUpdate:\n
+    \     maxUnavailable: 1\n      maxSurge: 0\n  selector:\n    matchLabels:\n      app:
+    nutanix-csi-controller\n  template:\n    metadata:\n      labels:\n        app:
+    nutanix-csi-controller\n    spec:\n      affinity:\n        podAntiAffinity:\n
+    \         preferredDuringSchedulingIgnoredDuringExecution:\n          - podAffinityTerm:\n
+    \             labelSelector:\n                matchLabels:\n                  app:
+    nutanix-csi-controller\n              topologyKey: kubernetes.io/hostname\n            weight:
+    100\n      serviceAccount: nutanix-csi-controller\n      hostNetwork: true\n      containers:\n
+    \       - name: csi-provisioner\n          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0\n
+    \         imagePullPolicy: IfNotPresent\n          args:\n            - --csi-address=$(ADDRESS)\n
+    \           - --timeout=60s\n            - --worker-threads=16\n            #
+    This adds PV/PVC metadata to create volume requests\n            - --extra-create-metadata=true\n
+    \           - --default-fstype=ext4\n            # This is used to collect CSI
+    operation metrics\n            - --http-endpoint=:9809\n            - --v=2\n
+    \           - --leader-election=true\n          env:\n            - name: ADDRESS\n
+    \             value: /var/lib/csi/sockets/pluginproxy/csi.sock\n          resources:\n
+    \           limits:\n              cpu: 100m\n              memory: 200Mi\n            requests:\n
+    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
+    \           - name: socket-dir\n              mountPath: /var/lib/csi/sockets/pluginproxy/\n
+    \       - name: csi-resizer\n          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0\n
+    \         imagePullPolicy: IfNotPresent\n          args:\n            - --v=2\n
+    \           - --csi-address=$(ADDRESS)\n            - --timeout=60s\n            -
+    --leader-election=true\n            # NTNX CSI dirver supports online volume expansion.\n
+    \           - --handle-volume-inuse-error=false\n            - --http-endpoint=:9810\n
+    \         env:\n            - name: ADDRESS\n              value: /var/lib/csi/sockets/pluginproxy/csi.sock\n
+    \         volumeMounts:\n            - name: socket-dir\n              mountPath:
+    /var/lib/csi/sockets/pluginproxy/\n        - name: csi-snapshotter\n          image:
+    k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3\n          imagePullPolicy: IfNotPresent\n
+    \         args:\n          - --csi-address=$(ADDRESS)\n          - --leader-election=true\n
+    \         - --logtostderr=true\n          - --timeout=300s\n          env:\n          -
+    name: ADDRESS\n            value: /csi/csi.sock\n          volumeMounts:\n          -
+    name: socket-dir\n            mountPath: /csi\n        - name: nutanix-csi-plugin\n
+    \         image: quay.io/karbon/ntnx-csi:v2.5.1\n          imagePullPolicy: IfNotPresent\n
+    \         securityContext:\n            allowPrivilegeEscalation: true\n            privileged:
+    true\n          args:\n            - --endpoint=$(CSI_ENDPOINT)\n            -
+    --nodeid=$(NODE_ID)\n            - --drivername=csi.nutanix.com\n          env:\n
+    \           - name: CSI_ENDPOINT\n              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock\n
+    \           - name: NODE_ID\n              valueFrom:\n                fieldRef:\n
+    \                 fieldPath: spec.nodeName\n          resources:\n            limits:\n
+    \             cpu: 100m\n              memory: 200Mi\n            requests:\n
+    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
+    \           - mountPath: /var/lib/csi/sockets/pluginproxy/\n              name:
+    socket-dir\n            # This is needed for static NFS volume feature.\n            -
+    mountPath: /host\n              name: root-dir\n          ports:\n            -
+    containerPort: 9807\n              name: http-endpoint\n              protocol:
+    TCP\n          livenessProbe:\n            httpGet:\n              path: /healthz\n
+    \             port: http-endpoint\n            initialDelaySeconds: 10\n            timeoutSeconds:
+    3\n            periodSeconds: 2\n            failureThreshold: 3\n        - name:
+    liveness-probe\n          volumeMounts:\n            - mountPath: /csi\n              name:
+    socket-dir\n          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0\n          imagePullPolicy:
+    IfNotPresent\n          args:\n            - --csi-address=/csi/csi.sock\n            -
+    --http-endpoint=:9807\n      priorityClassName: system-cluster-critical\n      volumes:\n
+    \       - emptyDir: {}\n          name: socket-dir\n        - hostPath:\n            path:
+    /\n            type: Directory\n          name: root-dir\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\n#
+    Copyright 2018 Nutanix Inc\n#\n# Configuration to deploy the Nutanix CSI driver\n#\n#
+    example usage: kubectl create -f <this_file>\n---\n# Source: nutanix-csi-storage/templates/ntnx-sc.yaml\n---\n---\n#
+    Source: nutanix-csi-storage/templates/csi-driver.yaml\napiVersion: storage.k8s.io/v1\nkind:
+    CSIDriver\nmetadata:\n  name: csi.nutanix.com\nspec:\n  attachRequired: false\n
+    \ podInfoOnMount: true\n"
+kind: ConfigMap
+metadata:
+  name: nutanix-csi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+stringData:
+  NUTANIX_PASSWORD: ${NUTANIX_PASSWORD}
+  NUTANIX_USER: ${NUTANIX_USER}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: nutanix-csi-crs
+spec:
+  clusterSelector:
+    matchLabels:
+      csi: nutanix
+  resources:
+  - kind: ConfigMap
+    name: nutanix-csi
+  strategy: ApplyOnce
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-kcfg-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      postKubeadmCommands:
+      - echo "after kubeadm call" > /var/log/postkubeadm.log
+      preKubeadmCommands:
+      - echo "before kubeadm call" > /var/log/prekubeadm.log
+      users:
+      - lockPassword: false
+        name: capiuser
+        sshAuthorizedKeys:
+        - ${NUTANIX_SSH_AUTHORIZED_KEY}
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      verbosity: 10
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    csi: nutanix
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 172.20.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 172.19.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-kcp
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-wmd
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-kcfg-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: ${CLUSTER_NAME}-mt-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  unhealthyConditions:
+  - status: "False"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "True"
+    timeout: 300s
+    type: MemoryPressure
+  - status: "True"
+    timeout: 300s
+    type: DiskPressure
+  - status: "True"
+    timeout: 300s
+    type: PIDPressure
+  - status: "True"
+    timeout: 300s
+    type: NetworkUnavailable
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-kcp
+  namespace: ${NAMESPACE}
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: ghcr.io/kube-vip/kube-vip:v0.4.2
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "${CONTROL_PLANE_ENDPOINT_IP}"
+                - name: port
+                  value: "${CONTROL_PLANE_ENDPOINT_PORT=6443}"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "${KUBEVIP_SVC_ENABLE=false}"
+                - name: lb_enable
+                  value: "${KUBEVIP_LB_ENABLE=false}"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          hostAliases:
+            - hostnames:
+                - kubernetes
+              ip: 127.0.0.1
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    postKubeadmCommands:
+    - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    - echo "after kubeadm call" > /var/log/postkubeadm.log
+    preKubeadmCommands:
+    - echo "before kubeadm call" > /var/log/prekubeadm.log
+    useExperimentalRetryJoin: true
+    users:
+    - lockPassword: false
+      name: capiuser
+      sshAuthorizedKeys:
+      - ${NUTANIX_SSH_AUTHORIZED_KEY}
+      sudo: ALL=(ALL) NOPASSWD:ALL
+    verbosity: 10
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: ${CLUSTER_NAME}-mt-0
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT=1}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
+    port: ${CONTROL_PLANE_ENDPOINT_PORT=6443}
+  prismCentral:
+    address: ${NUTANIX_ENDPOINT}
+    credentialRef:
+      kind: Secret
+      name: ${CLUSTER_NAME}
+    insecure: ${NUTANIX_INSECURE=false}
+    port: ${NUTANIX_PORT=9440}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-mt-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      cluster:
+        name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+        type: name
+      image:
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        type: name
+      memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
+      providerID: nutanix://${CLUSTER_NAME}-m1
+      subnet:
+      - name: ${NUTANIX_SUBNET_NAME}
+        type: name
+      systemDiskSize: ${NUTANIX_SYSTEMDISK_SIZE=40Gi}
+      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
+      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}

--- a/templates/kustomization.yaml
+++ b/templates/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster-template.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR implements two cluster template flavors:
- csi: deploy Nutanix CSI driver (snapshot v6.0.1 , storage v2.5.4)
- ccm: prepare cluster for Nutanix Cloud Controller Manager by setting cloud-provider to external

**How Has This Been Tested?**:

deploy cluster with respective flavors

`clusterctl generate cluster test-csi -f csi`

`clusterctl generate cluster test-ccm -f ccm`


**Release note**:

```release-note
- implement cluster template flavor to deploy Nutanix CSI
- implement cluster template flavor to prepare cluster for external Nutanix CCM
```