### PR TITLE
[WIP]: Code to facilitate project association to a VM post creation

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -75,6 +75,26 @@ func deleteVM(client *nutanixClientV3.Client, vmName, vmUUID string) (string, er
 	return deleteTaskUUID, nil
 }
 
+// updateVM updates a VM and is invoked by the NutanixMachineReconciler
+func updateVM(client *nutanixClientV3.Client, body *nutanixClientV3.VMIntentInput, vmName, vmUUID string) (string, error) {
+	var err error
+
+	if vmUUID == "" {
+		klog.Warning("VmUUID was empty. Skipping update")
+		return "", nil
+	}
+
+	klog.Infof("Updating VM %s with UUID: %s", vmName, vmUUID)
+	vmIntentResponse, err := client.V3.UpdateVM(vmUUID, body)
+	if err != nil {
+		klog.Infof("Error updating machine %s", vmName)
+		return "", err
+	}
+	updateTaskUUID := vmIntentResponse.Status.ExecutionContext.TaskUUID.(string)
+
+	return updateTaskUUID, nil
+}
+
 // findVMByUUID retrieves the VM with the given vm UUID. Returns nil if not found
 func findVMByUUID(client *nutanixClientV3.Client, uuid string) (*nutanixClientV3.VMIntentResponse, error) {
 	klog.Infof("Checking if VM with UUID %s exists.", uuid)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR is regarding facilitating already existing nutanix machine (VM in Prism) of a workload cluster to be associated with a Prism Project. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

Steps: 

1. Create a capx workload cluster.
2. Fetch json/yaml of a nutanixmachine object, lets say nutanixmachine.json
3. Make changes to nutanixmachine object to add a project to it.
    In the nutanixmachine.json file, add the following fields/values in the spec field: 
   "project": (
          "name" : "project_name",
          "type" : "name"         
     }

4. Apply the following json file using the command: kubectl apply -n capx-test-ns -f nutanixmachine.json 
5. Verify that the VM is associated with the project as per the changes in the nutanixmachine.json file

 Setup for testing:
  Prism Cluster: 10.40.142.15
  This cluster has a project called "my-project" that can be used for testing.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
6. If no release note is required, just write "NONE".
-->
```release-note

```