### PR TITLE
read e2e parameters from e2econfig instead of env var

### DIFF
--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Nutanix categories [PR-Blocking]", func() {
 	)
 
 	BeforeEach(func() {
-		testHelper = newTestHelper()
+		testHelper = newTestHelper(e2eConfig)
 		clusterName = testHelper.generateTestClusterName(specName)
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -76,7 +76,6 @@ var _ = Describe("Nutanix categories [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 
@@ -119,7 +118,6 @@ var _ = Describe("Nutanix categories [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 
@@ -164,7 +162,6 @@ var _ = Describe("Nutanix categories [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	additionalSubnetEnvVarKey = "NUTANIX_ADDITIONAL_SUBNET_NAME"
+	additionalSubnetVarKey = "NUTANIX_ADDITIONAL_SUBNET_NAME"
 )
 
 var _ = Describe("Nutanix Subnets [PR-Blocking]", func() {
@@ -48,7 +48,7 @@ var _ = Describe("Nutanix Subnets [PR-Blocking]", func() {
 	)
 
 	BeforeEach(func() {
-		testHelper = newTestHelper()
+		testHelper = newTestHelper(e2eConfig)
 		clusterName = testHelper.generateTestClusterName(specName)
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -71,7 +71,7 @@ var _ = Describe("Nutanix Subnets [PR-Blocking]", func() {
 		By("Creating Nutanix Machine Template with multiple subnets", func() {
 			multiNicNMT := testHelper.createDefaultNMT(clusterName, namespace.Name)
 			multiNicNMT.Spec.Template.Spec.Subnets = append(multiNicNMT.Spec.Template.Spec.Subnets,
-				testHelper.getNutanixResourceIdentifierFromEnv(additionalSubnetEnvVarKey),
+				testHelper.getNutanixResourceIdentifierFromE2eConfig(additionalSubnetVarKey),
 			)
 			nmtSubnets = multiNicNMT.Spec.Template.Spec.Subnets
 			testHelper.createNutanixMachineTemplate(ctx, createNutanixMachineTemplateParams{
@@ -89,7 +89,6 @@ var _ = Describe("Nutanix Subnets [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 

--- a/test/e2e/nutanix_client.go
+++ b/test/e2e/nutanix_client.go
@@ -21,14 +21,24 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 
 	prismGoClient "github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix"
 	prismGoClientV3 "github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 
 	nutanixClientHelper "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/client"
+)
+
+const (
+	nutanixEndpointVarKey = "NUTANIX_ENDPOINT"
+	nutanixPortVarKey     = "NUTANIX_PORT"
+	nutanixInsecureVarKey = "NUTANIX_INSECURE"
+	nutanixUsernameVarKey = "NUTANIX_USER"
+	nutanixPasswordVarKey = "NUTANIX_PASSWORD"
 )
 
 var (
@@ -38,43 +48,74 @@ var (
 )
 
 func init() {
-	flag.StringVar(&nutanixEndpoint, "e2e.nutanixEndpoint", os.Getenv("NUTANIX_ENDPOINT"), "the Nutanix Prism Central used for e2e tests")
-	flag.StringVar(&nutanixPort, "e2e.nutanixPort", os.Getenv("NUTANIX_PORT"), "the Nutanix Prism Central port used for e2e tests")
-	flag.StringVar(&nutanixInsecure, "e2e.nutanixInsecure", os.Getenv("NUTANIX_INSECURE"), "Ignore certificate checks for e2e tests")
+	flag.StringVar(&nutanixEndpoint, "e2e.nutanixEndpoint", os.Getenv(nutanixEndpointVarKey), "the Nutanix Prism Central used for e2e tests")
+	flag.StringVar(&nutanixPort, "e2e.nutanixPort", os.Getenv(nutanixPortVarKey), "the Nutanix Prism Central port used for e2e tests")
+	flag.StringVar(&nutanixInsecure, "e2e.nutanixInsecure", os.Getenv(nutanixInsecureVarKey), "Ignore certificate checks for e2e tests")
 }
 
-type nutanixCredentials struct {
-	nutanixUsername string
-	nutanixPassword string
+func fetchCredentialParameter(key string, config clusterctl.E2EConfig, allowEmpty bool) string {
+	value := os.Getenv(key)
+
+	if value == "" && config.HasVariable(key) {
+		value = config.GetVariable(key)
+	}
+
+	if allowEmpty && value == "" {
+		return value
+	}
+	Expect(value).ToNot(BeEmpty(), "expected parameter %s to be set", key)
+	return value
 }
 
-func getNutanixCredentialsFromEnvironment() nutanixCredentials {
-	nutanixUsername := os.Getenv(nutanixUserKey)
-	Expect(nutanixUsername).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixUserKey)
-	nutanixPassword := os.Getenv(nutanixPasswordKey)
-	Expect(nutanixPassword).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixPasswordKey)
-	return nutanixCredentials{
-		nutanixUsername: nutanixUsername,
-		nutanixPassword: nutanixPassword,
+type baseAuthCredentials struct {
+	username string
+	password string
+}
+
+func getBaseAuthCredentials(e2eConfig clusterctl.E2EConfig) baseAuthCredentials {
+	return baseAuthCredentials{
+		username: fetchCredentialParameter(nutanixUsernameVarKey, e2eConfig, false),
+		password: fetchCredentialParameter(nutanixPasswordVarKey, e2eConfig, false),
 	}
 }
 
-func initNutanixClient() (*prismGoClientV3.Client, error) {
-	insecureBool, err := strconv.ParseBool(nutanixInsecure)
+func getNutanixCredentials(e2eConfig clusterctl.E2EConfig) (*prismGoClient.Credentials, error) {
+	up := getBaseAuthCredentials(e2eConfig)
+	if nutanixEndpoint == "" {
+		nutanixEndpoint = fetchCredentialParameter(nutanixEndpointVarKey, e2eConfig, false)
+	}
+	if nutanixPort == "" {
+		nutanixPort = fetchCredentialParameter(nutanixPortVarKey, e2eConfig, true)
+	}
+	if nutanixInsecure == "" {
+		nutanixInsecure = fetchCredentialParameter(nutanixInsecureVarKey, e2eConfig, true)
+	}
+
+	var insecureBool bool
+	var err error
+
+	if nutanixInsecure != "" {
+		insecureBool, err = strconv.ParseBool(nutanixInsecure)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert value for environment variable %s to bool: %v", nutanixInsecureVarKey, err)
+		}
+	}
+	return &prismGoClient.Credentials{
+		Insecure: insecureBool,
+		Port:     nutanixPort,
+		Endpoint: nutanixEndpoint,
+		Username: up.username,
+		Password: up.password,
+	}, nil
+}
+
+func initNutanixClient(e2eConfig clusterctl.E2EConfig) (*prismGoClientV3.Client, error) {
+	creds, err := getNutanixCredentials(e2eConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	c := getNutanixCredentialsFromEnvironment()
-	creds := prismGoClient.Credentials{
-		Insecure: insecureBool,
-		Port:     nutanixPort,
-		Endpoint: nutanixEndpoint,
-		Username: c.nutanixUsername,
-		Password: c.nutanixPassword,
-	}
-
-	nutanixClient, err := nutanixClientHelper.Client(creds, nutanixClientHelper.ClientOptions{})
+	nutanixClient, err := nutanixClientHelper.Client(*creds, nutanixClientHelper.ClientOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 	)
 
 	BeforeEach(func() {
-		testHelper = newTestHelper()
+		testHelper = newTestHelper(e2eConfig)
 		clusterName = testHelper.generateTestClusterName(specName)
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
@@ -69,7 +69,6 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 
@@ -101,7 +100,6 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 
@@ -120,10 +118,10 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 		})
 
 		By("Creating secret using e2e credentials", func() {
-			nutanixCreds := getNutanixCredentialsFromEnvironment()
+			up := getBaseAuthCredentials(*e2eConfig)
 			testHelper.createSecret(createSecretParams{
-				username:    nutanixCreds.nutanixUsername,
-				password:    nutanixCreds.nutanixPassword,
+				username:    up.username,
+				password:    up.password,
 				namespace:   namespace,
 				clusterName: clusterName,
 			})
@@ -182,7 +180,6 @@ var _ = Describe("Nutanix client [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				}, clusterResources)
 		})
 

--- a/test/e2e/projects_test.go
+++ b/test/e2e/projects_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Nutanix projects [PR-Blocking]", func() {
 	)
 
 	BeforeEach(func() {
-		testHelper = newTestHelper()
+		testHelper = newTestHelper(e2eConfig)
 		nutanixProjectName = os.Getenv(nutanixProjectNameEnv)
 		Expect(nutanixProjectName).ToNot(BeEmpty(), "expected environment variable %s to be set", nutanixProjectNameEnv)
 		clusterName = testHelper.generateTestClusterName(specName)
@@ -90,7 +90,6 @@ var _ = Describe("Nutanix projects [PR-Blocking]", func() {
 					clusterctlConfigPath:  clusterctlConfigPath,
 					artifactFolder:        artifactFolder,
 					bootstrapClusterProxy: bootstrapClusterProxy,
-					e2eConfig:             *e2eConfig,
 				},
 				clusterResources,
 			)
@@ -137,7 +136,6 @@ var _ = Describe("Nutanix projects [PR-Blocking]", func() {
 				clusterctlConfigPath:  clusterctlConfigPath,
 				artifactFolder:        artifactFolder,
 				bootstrapClusterProxy: bootstrapClusterProxy,
-				e2eConfig:             *e2eConfig,
 			}, clusterResources)
 
 		By("Checking project assigned condition is true", func() {

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -55,14 +55,11 @@ const (
 	defaultSystemDiskSize = "40Gi"
 	defaultBootType       = "legacy"
 
-	nutanixUserKey     = "NUTANIX_USER"
-	nutanixPasswordKey = "NUTANIX_PASSWORD"
-
-	categoryKeyEnvVarKey   = "NUTANIX_ADDITIONAL_CATEGORY_KEY"
-	categoryValueEnvVarKey = "NUTANIX_ADDITIONAL_CATEGORY_VALUE"
-	imageEnvVarKey         = "NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME"
-	clusterEnvVarKey       = "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME"
-	subnetEnvVarKey        = "NUTANIX_SUBNET_NAME"
+	categoryKeyVarKey   = "NUTANIX_ADDITIONAL_CATEGORY_KEY"
+	categoryValueVarKey = "NUTANIX_ADDITIONAL_CATEGORY_VALUE"
+	imageVarKey         = "NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME"
+	clusterVarKey       = "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME"
+	subnetVarKey        = "NUTANIX_SUBNET_NAME"
 
 	nameType = "name"
 )
@@ -84,6 +81,7 @@ type testHelperInterface interface {
 	getNutanixClusterByName(ctx context.Context, input getNutanixClusterByNameInput) *infrav1.NutanixCluster
 	getNutanixVMsForCluster(clusterName, namespace string) []*prismGoClientV3.VMIntentResponse
 	getNutanixResourceIdentifierFromEnv(envVarKey string) infrav1.NutanixResourceIdentifier
+	getNutanixResourceIdentifierFromE2eConfig(variableKey string) infrav1.NutanixResourceIdentifier
 	stripNutanixIDFromProviderID(providerID string) string
 	verifyCategoryExists(categoryKey, categoyValue string)
 	verifyCategoriesNutanixMachines(clusterName, namespace string, expectedCategories map[string]string)
@@ -95,14 +93,16 @@ type testHelperInterface interface {
 
 type testHelper struct {
 	nutanixClient *prismGoClientV3.Client
+	e2eConfig     *clusterctl.E2EConfig
 }
 
-func newTestHelper() testHelperInterface {
-	c, err := initNutanixClient()
+func newTestHelper(e2eConfig *clusterctl.E2EConfig) testHelperInterface {
+	c, err := initNutanixClient(*e2eConfig)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	return testHelper{
 		nutanixClient: c,
+		e2eConfig:     e2eConfig,
 	}
 }
 
@@ -151,10 +151,10 @@ func (t testHelper) createDefaultNMT(clusterName, namespace string) *infrav1.Nut
 					VCPUsPerSocket: defaultVCPUsPerSocket,
 					VCPUSockets:    defaultVCPUSockets,
 					MemorySize:     resource.MustParse(defaultMemorySize),
-					Image:          t.getNutanixResourceIdentifierFromEnv(imageEnvVarKey),
-					Cluster:        t.getNutanixResourceIdentifierFromEnv(clusterEnvVarKey),
+					Image:          t.getNutanixResourceIdentifierFromE2eConfig(imageVarKey),
+					Cluster:        t.getNutanixResourceIdentifierFromE2eConfig(clusterVarKey),
 					Subnets: []infrav1.NutanixResourceIdentifier{
-						t.getNutanixResourceIdentifierFromEnv(subnetEnvVarKey),
+						t.getNutanixResourceIdentifierFromE2eConfig(subnetVarKey),
 					},
 					SystemDiskSize: resource.MustParse(defaultSystemDiskSize),
 				},
@@ -204,7 +204,6 @@ type deployClusterParams struct {
 	clusterctlConfigPath  string
 	artifactFolder        string
 	bootstrapClusterProxy framework.ClusterProxy
-	e2eConfig             clusterctl.E2EConfig
 }
 
 func (t testHelper) deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult) {
@@ -216,7 +215,7 @@ func (t testHelper) deployCluster(params deployClusterParams, clusterResources *
 		Flavor:                   params.flavor,
 		Namespace:                params.namespace.Name,
 		ClusterName:              params.clusterName,
-		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		KubernetesVersion:        t.e2eConfig.GetVariable(KubernetesVersion),
 		ControlPlaneMachineCount: pointer.Int64Ptr(1),
 		WorkerMachineCount:       pointer.Int64Ptr(1),
 	}
@@ -224,9 +223,9 @@ func (t testHelper) deployCluster(params deployClusterParams, clusterResources *
 	t.createClusterFromConfig(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 		ClusterProxy:                 params.bootstrapClusterProxy,
 		ConfigCluster:                cc,
-		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
-		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
-		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+		WaitForClusterIntervals:      t.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: t.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    t.e2eConfig.GetIntervals("", "wait-worker-nodes"),
 	}, clusterResources)
 }
 
@@ -239,7 +238,7 @@ func (t testHelper) deployClusterAndWait(params deployClusterParams, clusterReso
 		Flavor:                   params.flavor,
 		Namespace:                params.namespace.Name,
 		ClusterName:              params.clusterName,
-		KubernetesVersion:        params.e2eConfig.GetVariable(KubernetesVersion),
+		KubernetesVersion:        t.e2eConfig.GetVariable(KubernetesVersion),
 		ControlPlaneMachineCount: pointer.Int64Ptr(1),
 		WorkerMachineCount:       pointer.Int64Ptr(1),
 	}
@@ -247,9 +246,9 @@ func (t testHelper) deployClusterAndWait(params deployClusterParams, clusterReso
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 		ClusterProxy:                 params.bootstrapClusterProxy,
 		ConfigCluster:                cc,
-		WaitForClusterIntervals:      params.e2eConfig.GetIntervals("", "wait-cluster"),
-		WaitForControlPlaneIntervals: params.e2eConfig.GetIntervals("", "wait-control-plane"),
-		WaitForMachineDeployments:    params.e2eConfig.GetIntervals("", "wait-worker-nodes"),
+		WaitForClusterIntervals:      t.e2eConfig.GetIntervals("", "wait-cluster"),
+		WaitForControlPlaneIntervals: t.e2eConfig.GetIntervals("", "wait-control-plane"),
+		WaitForMachineDeployments:    t.e2eConfig.GetIntervals("", "wait-worker-nodes"),
 	}, clusterResources)
 }
 
@@ -333,6 +332,16 @@ func (t testHelper) getNutanixResourceIdentifierFromEnv(envVarKey string) infrav
 	return infrav1.NutanixResourceIdentifier{
 		Type: nameType,
 		Name: pointer.StringPtr(envVarValue),
+	}
+}
+
+func (t testHelper) getNutanixResourceIdentifierFromE2eConfig(variableKey string) infrav1.NutanixResourceIdentifier {
+	Expect(t.e2eConfig.HasVariable(variableKey)).To(BeTrue(), "expected e2econfig variable %s to exist", variableKey)
+	variableValue := t.e2eConfig.GetVariable(variableKey)
+	Expect(variableValue).ToNot(BeEmpty(), "expected e2econfig variable %s to be set", variableKey)
+	return infrav1.NutanixResourceIdentifier{
+		Type: nameType,
+		Name: pointer.StringPtr(variableValue),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to read configuration parameters from e2econfig instead of env vars. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
make test-e2e

```
Ran 10 of 20 Specs in 1607.823 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS
```

**Special notes for your reviewer**:
N/A 

**Release note**:
None