### PR TITLE
Resolved category delete corner case

### DIFF
--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -244,7 +244,8 @@ func (r *NutanixClusterReconciler) reconcileCategories(rctx *nctx.ClusterContext
 
 func (r *NutanixClusterReconciler) reconcileCategoriesDelete(rctx *nctx.ClusterContext) error {
 	klog.Infof("%s Reconciling deletion of categories for cluster %s", rctx.LogPrefix, rctx.Cluster.Name)
-	if conditions.IsTrue(rctx.NutanixCluster, infrav1.ClusterCategoryCreatedCondition) {
+	if conditions.IsTrue(rctx.NutanixCluster, infrav1.ClusterCategoryCreatedCondition) ||
+		conditions.GetReason(rctx.NutanixCluster, infrav1.ClusterCategoryCreatedCondition) == infrav1.DeletionFailed {
 		defaultCategories := getDefaultCAPICategoryIdentifiers(rctx.Cluster.Name)
 		err := deleteCategories(rctx.NutanixClient, defaultCategories)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This PR fixes the issue that a workload cluster was getting deleted even if the category assigned to the VMs in prism fails to delete.
After this PR, if deletion of categories assigned to VMs fails during workload cluster deletion, then k8s objects such as cluster and nutanix cluster do not get deleted.

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

Following is the process:

1. create a CAPI cluster
2. Go to the prism and assign category associated with CAPI cluster VMs to some other VM, let's say TestVM.
3. Now try to delete the CAPI cluster.
    You will see that the cluster deletion process is stuck. This is because category assigned to CAPI cluster VMs is not  
     getting deleted (because of step 3). 
4. Now remove the CAPI cluster category from TestVM
    You will see that the cluster deletion process now gets completed successfully as the category associated with the cluster 
    VMs was successfully deleted.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```