### PR TITLE
add machine templates and configuration for health-remediation e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,8 @@ cluster-e2e-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-no-nmt.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-project.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-ccm --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-ccm.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation.yaml
 
 cluster-templates: $(KUSTOMIZE) ## Generate cluster templates for all flavors
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/base > $(TEMPLATES_DIR)/cluster-template.yaml

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -85,6 +85,8 @@ providers:
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-project.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-ccm.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/secret.yaml
+  - ../bases/nmt.yaml
+  - ../bases/crs.yaml
+  - ../bases/md.yaml
+  - ./mhc.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/mhc.yaml
@@ -1,0 +1,21 @@
+---
+# Source: https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-kcp-remediation/mhc.yaml
+
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label cluster.x-k8s.io/control-plane=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+  namespace: "${NAMESPACE}"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/secret.yaml
+  - ../bases/nmt.yaml
+  - ../bases/crs.yaml
+  - ../bases/md.yaml
+  - ./mhc.yaml
+
+patchesStrategicMerge:
+  - ./md.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/md.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/md.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-wmd"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    metadata:
+      labels:
+        "e2e.remediation.label": ""

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/mhc.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/mhc.yaml
@@ -1,0 +1,21 @@
+---
+# Source: https://github.com/kubernetes-sigs/cluster-api/blob/main/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-md-remediation/mhc.yaml
+
+# MachineHealthCheck object with
+# - a selector that targets all the machines with label e2e.remediation.label=""
+# - unhealthyConditions triggering remediation after 10s the condition is set
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-mhc-0"
+  namespace: "${NAMESPACE}"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      e2e.remediation.label: ""
+  unhealthyConditions:
+    - type: e2e.remediation.condition
+      status: "False"
+      timeout: 10s

--- a/test/e2e/mhc_remediations_test.go
+++ b/test/e2e/mhc_remediations_test.go
@@ -25,7 +25,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When testing unhealthy machines remediation [health-remediation]", func() {
+var _ = Describe("When testing unhealthy machines remediation", Label("health-remediation"), func() {
 	capi_e2e.MachineRemediationSpec(ctx, func() capi_e2e.MachineRemediationSpecInput {
 		return capi_e2e.MachineRemediationSpecInput{
 			E2EConfig:             e2eConfig,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the required config files to run health-remediation e2e tests.
Tests:
- Verify if unhealthy worker machines are remediated
- Verify if unhealthy control plane machines are remediated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
```
LABEL_FILTERS="health-remediation" make test-e2e 
```

```
Ran 2 of 21 Specs in 680.693 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 19 Skipped
PASS
```

**Special notes for your reviewer**:
N/A

**Release note**:
None