### PR TITLE
Fix e2e test for non-existing project

### DIFF
--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -404,29 +404,38 @@ func (t testHelper) verifyConditionOnNutanixCluster(params verifyConditionParams
 }
 
 func (t testHelper) verifyConditionOnNutanixMachines(params verifyConditionParams) {
-	nutanixMachines := t.getNutanixMachinesForCluster(ctx, params.clusterName, params.namespace.Name, params.bootstrapClusterProxy)
-	for _, m := range nutanixMachines.Items {
-		Eventually(
-			func() []clusterv1.Condition {
-				machine := t.getNutanixMachineForCluster(ctx, params.clusterName, params.namespace.Name, m.Name, params.bootstrapClusterProxy)
-				return machine.Status.Conditions
-			},
-			defaultTimeout,
-			defaultInterval,
-		).Should(
-			ContainElement(
-				gstruct.MatchFields(
-					gstruct.IgnoreExtras,
-					gstruct.Fields{
-						"Type":     Equal(params.expectedCondition.Type),
-						"Reason":   Equal(params.expectedCondition.Reason),
-						"Severity": Equal(params.expectedCondition.Severity),
-						"Status":   Equal(params.expectedCondition.Status),
-					},
-				),
+	Eventually(
+		func() []infrav1.NutanixMachine {
+			nutanixMachines := t.getNutanixMachinesForCluster(ctx, params.clusterName, params.namespace.Name, params.bootstrapClusterProxy)
+			return nutanixMachines.Items
+		},
+		defaultTimeout,
+		defaultInterval,
+	).Should(
+		ContainElement(
+			gstruct.MatchFields(
+				gstruct.IgnoreExtras,
+				gstruct.Fields{
+					"Status": gstruct.MatchFields(
+						gstruct.IgnoreExtras,
+						gstruct.Fields{
+							"Conditions": ContainElement(
+								gstruct.MatchFields(
+									gstruct.IgnoreExtras,
+									gstruct.Fields{
+										"Type":     Equal(params.expectedCondition.Type),
+										"Reason":   Equal(params.expectedCondition.Reason),
+										"Severity": Equal(params.expectedCondition.Severity),
+										"Status":   Equal(params.expectedCondition.Status),
+									},
+								),
+							),
+						},
+					),
+				},
 			),
-		)
-	}
+		),
+	)
 }
 
 type verifyFailureMessageOnClusterMachinesParams struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Change logic of verifyConditionOnNutanixCluster to fix non-existing project e2e test bug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
```
LABEL_FILTERS="projects" make test-e2e
```

```
Ran 2 of 21 Specs in 397.516 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 19 Skipped
```

**Special notes for your reviewer**:
N/A

**Release note**:
NONE