### PR TITLE
added labels to Nutanix-specific e2e tests

### DIFF
--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Nutanix categories", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
 	})
 
-	It("Create a cluster with default cluster categories (no additional categories)", func() {
+	It("Create a cluster with default cluster categories (no additional categories)", Label("nutanix", "categories"), func() {
 		Expect(namespace).NotTo(BeNil())
 		flavor := clusterctl.DefaultFlavor
 		expectedCategoryKey := testHelper.getExpectedClusterCategoryKey(clusterName)
@@ -105,7 +105,7 @@ var _ = Describe("Nutanix categories", func() {
 		By("PASSED!")
 	})
 
-	It("Create a cluster with additional categories", func() {
+	It("Create a cluster with additional categories", Label("nutanix", "categories"), func() {
 		Expect(namespace).NotTo(BeNil())
 		flavor := "additional-categories"
 
@@ -135,7 +135,7 @@ var _ = Describe("Nutanix categories", func() {
 		By("PASSED!")
 	})
 
-	It("Create a cluster linked to non-existing categories (should fail)", func() {
+	It("Create a cluster linked to non-existing categories (should fail)", Label("nutanix", "categories"), func() {
 		flavor = "no-nmt"
 		Expect(namespace).NotTo(BeNil())
 

--- a/test/e2e/ccm_test.go
+++ b/test/e2e/ccm_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Nutanix flavor CCM", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
 	})
 
-	It("Create a cluster with Nutanix CCM", func() {
+	It("Create a cluster with Nutanix CCM", Label("nutanix", "ccm"), func() {
 		const flavor = "ccm"
 
 		Expect(namespace).NotTo(BeNil())

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Nutanix Subnets", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
 	})
 
-	It("Create a cluster where machines have multiple subnets attached to the machines", func() {
+	It("Create a cluster where machines have multiple subnets attached to the machines", Label("nutanix", "subnets"), func() {
 		const (
 			flavor = "no-nmt"
 		)

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Nutanix client", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
 	})
 
-	It("Create a cluster without credentialRef (use default credentials)", func() {
+	It("Create a cluster without credentialRef (use default credentials)", Label("nutanix", "client"), func() {
 		flavor = "no-credential-ref"
 		Expect(namespace).NotTo(BeNil())
 
@@ -87,7 +87,7 @@ var _ = Describe("Nutanix client", func() {
 		By("PASSED!")
 	})
 
-	It("Create a cluster without secret and add it later", func() {
+	It("Create a cluster without secret and add it later", Label("nutanix", "client"), func() {
 		flavor = "no-secret"
 		Expect(namespace).NotTo(BeNil())
 
@@ -154,7 +154,7 @@ var _ = Describe("Nutanix client", func() {
 		By("PASSED!")
 	})
 
-	It("Create a cluster with invalid credentials (should fail)", func() {
+	It("Create a cluster with invalid credentials (should fail)", Label("nutanix", "client"), func() {
 		const (
 			flavor = "no-secret"
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add labels to the CAPX specific e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
```
LABEL_FILTERS="nutanix" make test-e2e
```

```
Ran 8 of 21 Specs in 1170.555 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 13 Skipped
PASS
```

**Special notes for your reviewer**:
N/A 

**Release note**:
N/A