### PR TITLE
fix e2e tests labeled with 'cluster-upgrade-conformance'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,7 @@ cluster-e2e-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-upgrades --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-upgrades.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in.yaml
 
 cluster-templates: $(KUSTOMIZE) ## Generate cluster templates for all flavors
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/base > $(TEMPLATES_DIR)/cluster-template.yaml
@@ -331,7 +332,8 @@ test-e2e: docker-build-e2e $(GINKGO_BIN) cluster-e2e-templates cluster-templates
 	    $(GINKGO_ARGS) ./test/e2e -- \
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \
 	    -e2e.config="$(E2E_CONF_FILE)" \
-	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER)
+	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \
+		--ginkgo.timeout="24h"
 
 .PHONY: list-e2e
 list-e2e: docker-build-e2e $(GINKGO_BIN) cluster-e2e-templates cluster-templates ## Run the end-to-end tests

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -187,7 +187,7 @@ func (r *NutanixMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}()
 
 	// Handle deleted machines
-	if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !ntxMachine.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(rctx)
 	}
 
@@ -200,11 +200,11 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	vmName := rctx.NutanixMachine.Name
 	klog.Infof("%s Handling NutanixMachine deletion of VM: %s", rctx.LogPrefix, vmName)
 	conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, capiv1.DeletingReason, capiv1.ConditionSeverityInfo, "")
-	//Check if VMUUID is absent
+	// Check if VMUUID is absent
 	if rctx.NutanixMachine.Status.VmUUID == "" {
 		klog.Warningf("%s VMUUID was not found in spec for VM %s. Skipping delete", rctx.LogPrefix, vmName)
 	} else {
-		//Search for VM by UUID
+		// Search for VM by UUID
 		vmUUID := rctx.NutanixMachine.Status.VmUUID
 		vm, err := findVMByUUID(client, vmUUID)
 		// Error while finding VM
@@ -257,7 +257,6 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 }
 
 func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (reconcile.Result, error) {
-
 	if rctx.NutanixMachine.Status.FailureReason != nil || rctx.NutanixMachine.Status.FailureMessage != nil {
 		klog.Errorf("Nutanix Machine has failed. Will not reconcile %s", rctx.NutanixMachine.Name)
 		return reconcile.Result{}, nil
@@ -353,7 +352,6 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 // reconcileNode makes sure the NutanixMachine corresponding workload cluster node
 // is ready and set its spec.providerID
 func (r *NutanixMachineReconciler) reconcileNode(rctx *nctx.MachineContext) error {
-
 	klog.Infof("%s Reconcile the workload cluster node to set its spec.providerID", rctx.LogPrefix)
 
 	clusterKey := apitypes.NamespacedName{
@@ -421,7 +419,6 @@ func (r *NutanixMachineReconciler) reconcileNode(rctx *nctx.MachineContext) erro
 
 // GetOrCreateVM creates a VM and is invoked by the NutanixMachineReconciler
 func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nutanixClientV3.VMIntentResponse, error) {
-
 	var err error
 	var vm *nutanixClientV3.VMIntentResponse
 	vmName := rctx.NutanixMachine.Name
@@ -495,7 +492,8 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 				SubnetReference: &nutanixClientV3.Reference{
 					UUID: utils.StringPtr(subnetUUID),
 					Kind: utils.StringPtr("subnet"),
-				}})
+				},
+			})
 		}
 
 		// Create Disk Spec for systemdisk to be set later in VM Spec
@@ -545,7 +543,8 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 			DiskList:              diskList,
 			GuestCustomization: &nutanixClientV3.GuestCustomization{
 				IsOverridable: utils.BoolPtr(true),
-				CloudInit:     &nutanixClientV3.GuestCustomizationCloudInit{UserData: utils.StringPtr(bsdataEncoded)}},
+				CloudInit:     &nutanixClientV3.GuestCustomizationCloudInit{UserData: utils.StringPtr(bsdataEncoded)},
+			},
 		}
 		vmSpec.ClusterReference = &nutanixClientV3.Reference{
 			Kind: utils.StringPtr("cluster"),
@@ -714,7 +713,6 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 }
 
 func (r *NutanixMachineReconciler) addVMToProject(rctx *nctx.MachineContext, vmMetadata *nutanixClientV3.Metadata) error {
-
 	vmName := rctx.NutanixMachine.Name
 	projectRef := rctx.NutanixMachine.Spec.Project
 	if projectRef == nil {

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
 var _ = Describe("When upgrading a workload cluster and testing K8S conformance", Label("cluster-upgrade-conformance", "slow", "network"), func() {
@@ -69,7 +68,6 @@ var _ = Describe("When upgrading a workload cluster with a single control plane 
 			SkipConformanceTests:     true,
 			ControlPlaneMachineCount: pointer.Int64(1),
 			WorkerMachineCount:       pointer.Int64(1),
-			Flavor:                   pointer.String(clusterctl.DefaultFlavor),
 		}
 	})
 })
@@ -87,7 +85,6 @@ var _ = Describe("When upgrading a workload cluster with a HA control plane", La
 			SkipConformanceTests:     true,
 			ControlPlaneMachineCount: pointer.Int64(3),
 			WorkerMachineCount:       pointer.Int64(1),
-			Flavor:                   pointer.String(clusterctl.DefaultFlavor),
 		}
 	})
 })

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -148,6 +148,7 @@ providers:
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-upgrades.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus
@@ -169,8 +170,10 @@ variables:
   WORKER_MACHINE_COUNT: 3
   NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
   NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME: "ubuntu-2004-kube-v1.23.8.qcow2"
-  CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO: "ubuntu-2004-kube-v1.24.10.qcow2"
-  WORKERS_MACHINE_TEMPLATE_UPGRADE_TO: "ubuntu-2004-kube-v1.24.10.qcow2"
+  CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO: "cluster-upgrade-conformance"
+  WORKERS_MACHINE_TEMPLATE_UPGRADE_TO: "cluster-upgrade-conformance"
+  NUTANIX_MACHINE_TEMPLATE_IMAGE_UPGRADE_TO: "ubuntu-2004-kube-v1.24.10.qcow2"
+  NUTANIX_MACHINE_TEMPLATE_IMAGE_UPGRADE_FROM: "ubuntu-2004-kube-v1.23.8.qcow2"
   NUTANIX_SUBNET_NAME: ""
   # NOTE: 'NUTANIX_ADDITIONAL_SUBNET_NAME' is required for multi network interface e2e tests
   NUTANIX_ADDITIONAL_SUBNET_NAME: ""

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/cluster-with-kcp.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-kcp"
+  namespace: "${NAMESPACE}"
+spec:
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 0

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../cluster-template-upgrades
+
+patchesStrategicMerge:
+  - ./cluster-with-kcp.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/kustomization.yaml
@@ -1,7 +1,7 @@
 bases:
   - ../bases/cluster-with-kcp.yaml
   - ../bases/secret.yaml
-  - ../bases/nmt.yaml
   - ../bases/crs.yaml
   - ../bases/md.yaml
   - ../bases/mhc.yaml
+  - ./nmt.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/nmt.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-mt-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://${CLUSTER_NAME}-m1"
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
+      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
+      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=8Gi}"
+      systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
+      image:
+        type: name
+        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_UPGRADE_FROM}"
+      cluster:
+        type: name
+        name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
+      subnet:
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "cluster-upgrade-conformance"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://cluster-upgrade-conformance"
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
+      vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
+      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=8Gi}"
+      systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
+      image:
+        type: name
+        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_UPGRADE_TO}"
+      cluster:
+        type: name
+        name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
+      subnet:
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes the e2e tests with the 'cluster-upgrade-conformance' label
- Fixes machine deletion problem surfaced by the e2e tests (ntxMachine deletion timestamp needs to be checked instead of the machine)
- Increases ginkgo timeout to increase the default of 1h.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
`make LABEL_FILTERS="cluster-upgrade-conformance" make test-e2e-calico`

**Special notes for your reviewer**:
Calico is preferred as CNI for the conformance. Otherwise some of the 'cluster-upgrade-conformance' tests produce additional failures.

**Release note**:
NONE