### PR TITLE
Modify Calico e2e Yaml manifests

### DIFF
--- a/test/e2e/data/cni/calico/calico.yaml
+++ b/test/e2e/data/cni/calico/calico.yaml
@@ -1,6 +1,7 @@
 ---
 # From: https://projectcalico.docs.tigera.io/v3.22/manifests/calico.yaml
 # Source: calico/templates/calico-config.yaml
+# Modified original file in order to use quay.io instead of docker.io
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1
@@ -4059,7 +4060,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.22.0
+          image: quay.io/calico/cni:v3.22.0
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4086,7 +4087,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.22.0
+          image: quay.io/calico/cni:v3.22.0
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4127,7 +4128,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.22.0
+          image: quay.io/calico/pod2daemon-flexvol:v3.22.0
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -4138,7 +4139,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.22.0
+          image: quay.io/calico/node:v3.22.0
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4357,7 +4358,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.22.0
+          image: quay.io/calico/kube-controllers:v3.22.0
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
**What this PR does / why we need it**:
Modified Calico CNI configuration to use images from quay.io instead of docker.io. This to prevent image pull errors during e2e runs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Calico pods in cluster:
```
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Pulling    64s   kubelet            Pulling image "quay.io/calico/cni:v3.22.0"
```
Quickstart e2e:
```
LABEL_FILTERS="prblocker" make test-e2e-calico

Ran 1 of 21 Specs in 820.216 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS
```

**Special notes for your reviewer**:

N/A

**Release note**:
None