### PR TITLE
Skipping clusterctl-upgrade e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 LABEL_FILTERS ?=
 JUNIT_REPORT_FILE ?= "junit.e2e_suite.1.xml"
-GINKGO_SKIP ?=
+GINKGO_SKIP ?= "clusterctl-Upgrade"
 GINKGO_NODES  ?= 1
 E2E_CONF_FILE  ?= ${E2E_DIR}/config/nutanix.yaml
 ARTIFACTS ?= ${REPO_ROOT}/_artifacts
@@ -147,7 +147,7 @@ TEST_CLUSTER_NAME=mycluster
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)
-_SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),-skip="$(arg)")
+_SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),--skip="$(arg)")
 endif
 .PHONY: all
 all: build

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -25,6 +25,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
+// clusterctl upgrade test is being skipped. See 'GINKGO_SKIP' parameter in `Makefile`
 var _ = Describe("When testing clusterctl upgrades [clusterctl-Upgrade]", Label("clusterctl-upgrade", "slow", "network"), func() {
 	capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{


### PR DESCRIPTION
**What this PR does / why we need it**:
Skips the clusterctl-upgrade e2e test. This test will be re-enabled once all the CAPX and CI dependencies are in place.
The test is skipped by adding "clusterctl-Upgrade" to the GINKGO_SKIP parameter in the Makefile. Users can still choose to override the skip parameter.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
```
LABEL_FILTERS=   make test-e2e-calico
```
```
Will run 20 of 21 specs.  <-- skipped test is the  clusterctl-upgrade one
------------------------------
```

**Special notes for your reviewer**:
N/A

**Release note**:
None