### PR TITLE
fixed the data format to fit regex format

### DIFF
--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -65,8 +65,8 @@ var (
 )
 
 func init() {
-	minMachineSystemDiskSize = resource.MustParse("20Gib")
-	minMachineMemorySize = resource.MustParse("2Gib")
+	minMachineSystemDiskSize = resource.MustParse("20Gi")
+	minMachineMemorySize = resource.MustParse("2Gi")
 }
 
 // NutanixMachineReconciler reconciles a NutanixMachine object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:
Test Case 1:
Setting  following test fails
<pre>
NUTANIX_SYSTEMDISK_SIZE: "18Gi"
</pre>
log has following error 
<pre>
I0919 22:09:59.178731       1 nutanixmachine_controller.go:195] NutanixMachine[namespace: quick-start-ywi9e5, name: quick-start-qbh3mp-mt-0-824jp] Patched NutanixMachine. Spec: {ProviderID:nutanix://quick-start-qbh3mp-m1 VCPUsPerSocket:1 VCPUSockets:2 MemorySize:{i:{value:4294967296 scale:0} d:{Dec:<nil>} s:4Gi Format:BinarySI} Image:{Type:name UUID:<nil> Name:0xc000446b70} Cluster:{Type:name UUID:<nil> Name:0xc000446b80} Subnets:[{Type:name UUID:<nil> Name:0xc000446b90}] AdditionalCategories:[] Project:<nil> BootType:legacy SystemDiskSize:{i:{value:19327352832 scale:0} d:{Dec:<nil>} s:18Gi Format:BinarySI} BootstrapRef:&ObjectReference{Kind:Secret,Namespace:quick-start-ywi9e5,Name:quick-start-qbh3mp-kcp-p5rnv,UID:,APIVersion:v1,ResourceVersion:,FieldPath:,}}. Status: {Ready:false Addresses:[] VmUUID: NodeRef:nil Conditions:[{Type:PrismClientInit Status:True Severity: LastTransitionTime:2022-09-19 22:09:58 +0000 UTC Reason: Message:}] FailureReason:0xc000532100 FailureMessage:0xc000532120}.
1.663625399178896e+09	ERROR	Reconciler error	{"controller": "nutanixmachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "NutanixMachine", "nutanixMachine": {"name":"quick-start-qbh3mp-mt-0-824jp","namespace":"quick-start-ywi9e5"}, "namespace": "quick-start-ywi9e5", "name": "quick-start-qbh3mp-mt-0-824jp", "reconcileID": "d8019420-6771-4a85-a5d0-b3e3ca76d8ce", "error": "The minimum systemDiskSize is 20480Mib but given 18432Mib"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234
</pre>
or 
<pre>
NUTANIX_MACHINE_MEMORY_SIZE: "1Gi"
</pre>
log has following error
<pre>
E0919 22:23:48.143035       1 nutanixmachine_controller.go:335] NutanixMachine[namespace: quick-start-saaner, name: quick-start-0kmisg-mt-0-6zxk7] Failed to create VM quick-start-0kmisg-mt-0-6zxk7.
I0919 22:23:48.171697       1 nutanixmachine_controller.go:195] NutanixMachine[namespace: quick-start-saaner, name: quick-start-0kmisg-mt-0-6zxk7] Patched NutanixMachine. Spec: {ProviderID:nutanix://quick-start-0kmisg-m1 VCPUsPerSocket:1 VCPUSockets:2 MemorySize:{i:{value:1073741824 scale:0} d:{Dec:<nil>} s:1Gi Format:BinarySI} Image:{Type:name UUID:<nil> Name:0xc000a886e0} Cluster:{Type:name UUID:<nil> Name:0xc000a886f0} Subnets:[{Type:name UUID:<nil> Name:0xc000a88700}] AdditionalCategories:[] Project:<nil> BootType:legacy SystemDiskSize:{i:{value:42949672960 scale:0} d:{Dec:<nil>} s: Format:BinarySI} BootstrapRef:&ObjectReference{Kind:Secret,Namespace:quick-start-saaner,Name:quick-start-0kmisg-kcp-z72mc,UID:,APIVersion:v1,ResourceVersion:,FieldPath:,}}. Status: {Ready:false Addresses:[] VmUUID: NodeRef:nil Conditions:[{Type:PrismClientInit Status:True Severity: LastTransitionTime:2022-09-19 22:23:47 +0000 UTC Reason: Message:}] FailureReason:0xc00047dfb0 FailureMessage:0xc00088e010}.
1.663626228171922e+09	ERROR	Reconciler error	{"controller": "nutanixmachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "NutanixMachine", "nutanixMachine": {"name":"quick-start-0kmisg-mt-0-6zxk7","namespace":"quick-start-saaner"}, "namespace": "quick-start-saaner", "name": "quick-start-0kmisg-mt-0-6zxk7", "reconcileID": "f06c6f15-bad0-4919-b420-f207fd4af657", "error": "The minimum memorySize is 2048Mib but given 1024Mib"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234
</pre>

Test case 2:
<pre>
 make test-e2e-calico LABEL_FILTERS=prblocker
CNI="/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/cni/calico/calico.yaml" /Library/Developer/CommandLineTools/usr/bin/make test-e2e
KO_DOCKER_REPO=ko.local /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/ko-v0.11.2 build -B --platform=linux/amd64 -t e2e -L .
2022/09/19 14:44:28 Using base gcr.io/distroless/static:nonroot@sha256:2a9e2b4fa771d31fe3346a873be845bfc2159695b9f90ca08e950497006ccc2e for github.com/nutanix-cloud-native/cluster-api-provider-nutanix
2022/09/19 14:44:29 Building github.com/nutanix-cloud-native/cluster-api-provider-nutanix for linux/amd64
2022/09/19 14:44:35 Loading ko.local/cluster-api-provider-nutanix:f8a5e15dcfec14e76eecd32c45f8c4644d5b3b9def83d583fc81426ef0bc1635
2022/09/19 14:44:36 Loaded ko.local/cluster-api-provider-nutanix:f8a5e15dcfec14e76eecd32c45f8c4644d5b3b9def83d583fc81426ef0bc1635
2022/09/19 14:44:36 Adding tag e2e
2022/09/19 14:44:36 Added tag e2e
ko.local/cluster-api-provider-nutanix:f8a5e15dcfec14e76eecd32c45f8c4644d5b3b9def83d583fc81426ef0bc1635
docker tag ko.local/cluster-api-provider-nutanix:e2e ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template.yaml 
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-credential-ref.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-ccm --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-ccm.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1alpha4/cluster-template --load-restrictor LoadRestrictionsNone > /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1alpha4/cluster-template.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build templates/base > templates/cluster-template.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build templates/csi > templates/cluster-template-csi.yaml
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build templates/ccm > templates/cluster-template-ccm.yaml
mkdir -p /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/ginkgo-v2.1.4 -v \
		--trace \
		--progress \
		--tags=e2e \
		--label-filter="prblocker" \
		--skip=""clusterctl-Upgrade"" \
		--nodes=1 \
		--no-color=false \
		--output-dir="/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" \
		--junit-report="junit.e2e_suite.1.xml" \
		--timeout="24h" \
		--always-emit-ginkgo-writer \
		 ./test/e2e -- \
		-e2e.artifacts-folder="/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" \
		-e2e.config="/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml" \
		-e2e.skip-resource-cleanup=false \
		-e2e.use-existing-cluster=false
Running Suite: capx-e2e - /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e
==========================================================================================================================
Random Seed: 1663623888

Will run 1 of 21 specs
------------------------------
[SynchronizedBeforeSuite] 
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
[SynchronizedBeforeSuite] TOP-LEVEL
  /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
STEP: Initializing a runtime.Scheme with all the GVK relevant for this test 09/19/22 14:44:56.698
STEP: Loading the e2e test configuration from "/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml" 09/19/22 14:44:56.698
STEP: Creating a clusterctl local repository into "/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" 09/19/22 14:44:56.7
STEP: Reading the ClusterResourceSet manifest /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/cni/calico/calico.yaml 09/19/22 14:44:56.701
STEP: Setting up the bootstrap cluster 09/19/22 14:45:05.353
STEP: Creating the bootstrap cluster 09/19/22 14:45:05.353
INFO: Creating a kind cluster with name "test-v7il1b"
Creating cluster "test-v7il1b" ...
 • Ensuring node image (kindest/node:v1.23.10) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.23.10) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
INFO: The kubeconfig file for the kind cluster is /var/folders/l3/8dxq0z892n992ffkmb33003r0000gn/T/e2e-kind1791248715
INFO: Loading image: "ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e"
INFO: Image ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e is present in local container image cache
INFO: Loading image: "registry.k8s.io/cluster-api/cluster-api-controller:v1.2.0"
INFO: Image registry.k8s.io/cluster-api/cluster-api-controller:v1.2.0 is present in local container image cache
INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.0"
INFO: Image registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.0 is present in local container image cache
INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.0"
INFO: Image registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.0 is present in local container image cache
STEP: Initializing the bootstrap cluster 09/19/22 14:46:40.964
INFO: clusterctl init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure nutanix --config /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts/repository/clusterctl-config.yaml --kubeconfig /var/folders/l3/8dxq0z892n992ffkmb33003r0000gn/T/e2e-kind1791248715
INFO: Waiting for provider controllers to be running
STEP: Waiting for deployment capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager to be available 09/19/22 14:48:01.724
INFO: Creating log watcher for controller capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager, pod capi-kubeadm-bootstrap-controller-manager-7775897d58-7pb8f, container manager
STEP: Waiting for deployment capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager to be available 09/19/22 14:48:01.785
INFO: Creating log watcher for controller capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager, pod capi-kubeadm-control-plane-controller-manager-6958fd6555-lmk75, container manager
STEP: Waiting for deployment capi-system/capi-controller-manager to be available 09/19/22 14:48:01.852
INFO: Creating log watcher for controller capi-system/capi-controller-manager, pod capi-controller-manager-ff7f6b7ff-t4kxb, container manager
STEP: Waiting for deployment capx-system/capx-controller-manager to be available 09/19/22 14:48:01.937
INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-b79444b9-pn5xw, container kube-rbac-proxy
INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-b79444b9-pn5xw, container manager
[SynchronizedBeforeSuite] TOP-LEVEL
  /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
------------------------------
[SynchronizedBeforeSuite] PASSED [185.452 seconds]
[SynchronizedBeforeSuite] 
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118

  Begin Captured GinkgoWriter Output >>
    [SynchronizedBeforeSuite] TOP-LEVEL
      /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
    STEP: Initializing a runtime.Scheme with all the GVK relevant for this test 09/19/22 14:44:56.698
    STEP: Loading the e2e test configuration from "/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml" 09/19/22 14:44:56.698
    STEP: Creating a clusterctl local repository into "/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" 09/19/22 14:44:56.7
    STEP: Reading the ClusterResourceSet manifest /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/cni/calico/calico.yaml 09/19/22 14:44:56.701
    STEP: Setting up the bootstrap cluster 09/19/22 14:45:05.353
    STEP: Creating the bootstrap cluster 09/19/22 14:45:05.353
    INFO: Creating a kind cluster with name "test-v7il1b"
    INFO: The kubeconfig file for the kind cluster is /var/folders/l3/8dxq0z892n992ffkmb33003r0000gn/T/e2e-kind1791248715
    INFO: Loading image: "ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e"
    INFO: Image ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e is present in local container image cache
    INFO: Loading image: "registry.k8s.io/cluster-api/cluster-api-controller:v1.2.0"
    INFO: Image registry.k8s.io/cluster-api/cluster-api-controller:v1.2.0 is present in local container image cache
    INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.0"
    INFO: Image registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.0 is present in local container image cache
    INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.0"
    INFO: Image registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.0 is present in local container image cache
    STEP: Initializing the bootstrap cluster 09/19/22 14:46:40.964
    INFO: clusterctl init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure nutanix --config /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts/repository/clusterctl-config.yaml --kubeconfig /var/folders/l3/8dxq0z892n992ffkmb33003r0000gn/T/e2e-kind1791248715
    INFO: Waiting for provider controllers to be running
    STEP: Waiting for deployment capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager to be available 09/19/22 14:48:01.724
    INFO: Creating log watcher for controller capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager, pod capi-kubeadm-bootstrap-controller-manager-7775897d58-7pb8f, container manager
    STEP: Waiting for deployment capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager to be available 09/19/22 14:48:01.785
    INFO: Creating log watcher for controller capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager, pod capi-kubeadm-control-plane-controller-manager-6958fd6555-lmk75, container manager
    STEP: Waiting for deployment capi-system/capi-controller-manager to be available 09/19/22 14:48:01.852
    INFO: Creating log watcher for controller capi-system/capi-controller-manager, pod capi-controller-manager-ff7f6b7ff-t4kxb, container manager
    STEP: Waiting for deployment capx-system/capx-controller-manager to be available 09/19/22 14:48:01.937
    INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-b79444b9-pn5xw, container kube-rbac-proxy
    INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-b79444b9-pn5xw, container manager
    [SynchronizedBeforeSuite] TOP-LEVEL
      /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSS
------------------------------
When following the Cluster API quick-start
  Should create a workload cluster [prblocker, slow, network]
  /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:78
[BeforeEach] When following the Cluster API quick-start
  /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:63
STEP: Creating a namespace for hosting the "quick-start" test spec 09/19/22 14:48:02.151
INFO: Creating namespace quick-start-ccr1no
INFO: Creating event watcher for namespace "quick-start-ccr1no"
[It] Should create a workload cluster
  /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:78
STEP: Creating a workload cluster 09/19/22 14:48:02.228
INFO: Creating the workload cluster with name "quick-start-7iy50e" using the "(default)" template (Kubernetes v1.23.10, 1 control-plane machines, 1 worker machines)
INFO: Getting the cluster template yaml
INFO: clusterctl config cluster quick-start-7iy50e --infrastructure (default) --kubernetes-version v1.23.10 --control-plane-machine-count 1 --worker-machine-count 1 --flavor (default)
INFO: Applying the cluster template yaml to the cluster
configmap/cni-quick-start-7iy50e-crs-cni created
secret/quick-start-7iy50e created
clusterresourceset.addons.cluster.x-k8s.io/quick-start-7iy50e-crs-cni created
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/quick-start-7iy50e-kcfg-0 created
cluster.cluster.x-k8s.io/quick-start-7iy50e created
machinedeployment.cluster.x-k8s.io/quick-start-7iy50e-wmd created
machinehealthcheck.cluster.x-k8s.io/quick-start-7iy50e-mhc created
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/quick-start-7iy50e-kcp created
nutanixcluster.infrastructure.cluster.x-k8s.io/quick-start-7iy50e created
nutanixmachinetemplate.infrastructure.cluster.x-k8s.io/quick-start-7iy50e-mt-0 created

INFO: Waiting for the cluster infrastructure to be provisioned
STEP: Waiting for cluster to enter the provisioned phase 09/19/22 14:48:08.867
INFO: Waiting for control plane to be initialized
INFO: Waiting for the first control plane machine managed by quick-start-ccr1no/quick-start-7iy50e-kcp to be provisioned
STEP: Waiting for one control plane node to exist 09/19/22 14:48:49.065
INFO: Waiting for control plane to be ready
INFO: Waiting for control plane quick-start-ccr1no/quick-start-7iy50e-kcp to be ready (implies underlying nodes to be ready as well)
STEP: Waiting for the control plane to be ready 09/19/22 14:49:29.182
STEP: Checking all the the control plane machines are in the expected failure domains 09/19/22 14:49:59.234
INFO: Waiting for the machine deployments to be provisioned
STEP: Waiting for the workload nodes to exist 09/19/22 14:49:59.317
STEP: Checking all the machines controlled by quick-start-7iy50e-wmd are in the "<None>" failure domain 09/19/22 14:50:29.394
INFO: Waiting for the machine pools to be provisioned
STEP: PASSED! 09/19/22 14:50:29.499
[AfterEach] When following the Cluster API quick-start
  /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:109
STEP: Dumping logs from the "quick-start-7iy50e" workload cluster 09/19/22 14:50:29.499
Failed to get logs for Machine quick-start-7iy50e-kcp-fb298, Cluster quick-start-ccr1no/quick-start-7iy50e: error creating container exec: Error response from daemon: No such container: quick-start-7iy50e-kcp-fb298
Failed to get logs for Machine quick-start-7iy50e-wmd-868b5987bf-l8f6p, Cluster quick-start-ccr1no/quick-start-7iy50e: error creating container exec: Error response from daemon: No such container: quick-start-7iy50e-wmd-868b5987bf-l8f6p
STEP: Dumping all the Cluster API resources in the "quick-start-ccr1no" namespace 09/19/22 14:50:29.76
STEP: Deleting cluster quick-start-ccr1no/quick-start-7iy50e 09/19/22 14:50:30.127
STEP: Deleting cluster quick-start-7iy50e 09/19/22 14:50:30.176
INFO: Waiting for the Cluster quick-start-ccr1no/quick-start-7iy50e to be deleted
STEP: Waiting for cluster quick-start-7iy50e to be deleted 09/19/22 14:50:30.225
STEP: Deleting namespace used for hosting the "quick-start" test spec 09/19/22 14:51:00.289
INFO: Deleting namespace quick-start-ccr1no
------------------------------
• [SLOW TEST] [178.194 seconds]
When following the Cluster API quick-start [prblocker, slow, network]
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/capx_quick_start_test.go:28
  Should create a workload cluster
  /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:78

  Begin Captured GinkgoWriter Output >>
    [BeforeEach] When following the Cluster API quick-start
      /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:63
    STEP: Creating a namespace for hosting the "quick-start" test spec 09/19/22 14:48:02.151
    INFO: Creating namespace quick-start-ccr1no
    INFO: Creating event watcher for namespace "quick-start-ccr1no"
    [It] Should create a workload cluster
      /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:78
    STEP: Creating a workload cluster 09/19/22 14:48:02.228
    INFO: Creating the workload cluster with name "quick-start-7iy50e" using the "(default)" template (Kubernetes v1.23.10, 1 control-plane machines, 1 worker machines)
    INFO: Getting the cluster template yaml
    INFO: clusterctl config cluster quick-start-7iy50e --infrastructure (default) --kubernetes-version v1.23.10 --control-plane-machine-count 1 --worker-machine-count 1 --flavor (default)
    INFO: Applying the cluster template yaml to the cluster
    INFO: Waiting for the cluster infrastructure to be provisioned
    STEP: Waiting for cluster to enter the provisioned phase 09/19/22 14:48:08.867
    INFO: Waiting for control plane to be initialized
    INFO: Waiting for the first control plane machine managed by quick-start-ccr1no/quick-start-7iy50e-kcp to be provisioned
    STEP: Waiting for one control plane node to exist 09/19/22 14:48:49.065
    INFO: Waiting for control plane to be ready
    INFO: Waiting for control plane quick-start-ccr1no/quick-start-7iy50e-kcp to be ready (implies underlying nodes to be ready as well)
    STEP: Waiting for the control plane to be ready 09/19/22 14:49:29.182
    STEP: Checking all the the control plane machines are in the expected failure domains 09/19/22 14:49:59.234
    INFO: Waiting for the machine deployments to be provisioned
    STEP: Waiting for the workload nodes to exist 09/19/22 14:49:59.317
    STEP: Checking all the machines controlled by quick-start-7iy50e-wmd are in the "<None>" failure domain 09/19/22 14:50:29.394
    INFO: Waiting for the machine pools to be provisioned
    STEP: PASSED! 09/19/22 14:50:29.499
    [AfterEach] When following the Cluster API quick-start
      /Users/deepak.muley/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.2.0-beta.0.0.20220823125924-6e30f66cc3df/e2e/quick_start.go:109
    STEP: Dumping logs from the "quick-start-7iy50e" workload cluster 09/19/22 14:50:29.499
    STEP: Dumping all the Cluster API resources in the "quick-start-ccr1no" namespace 09/19/22 14:50:29.76
    STEP: Deleting cluster quick-start-ccr1no/quick-start-7iy50e 09/19/22 14:50:30.127
    STEP: Deleting cluster quick-start-7iy50e 09/19/22 14:50:30.176
    INFO: Waiting for the Cluster quick-start-ccr1no/quick-start-7iy50e to be deleted
    STEP: Waiting for cluster quick-start-7iy50e to be deleted 09/19/22 14:50:30.225
    STEP: Deleting namespace used for hosting the "quick-start" test spec 09/19/22 14:51:00.289
    INFO: Deleting namespace quick-start-ccr1no
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSS
------------------------------
[SynchronizedAfterSuite] 
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170
[SynchronizedAfterSuite] TOP-LEVEL
  /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170
[SynchronizedAfterSuite] TOP-LEVEL
  /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170
STEP: Dumping logs from the bootstrap cluster 09/19/22 14:51:00.346
Failed to get logs for the bootstrap cluster node test-v7il1b-control-plane: exit status 1
STEP: Tearing down the management cluster 09/19/22 14:51:01.859
------------------------------
[SynchronizedAfterSuite] PASSED [11.370 seconds]
[SynchronizedAfterSuite] 
/Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170

  Begin Captured GinkgoWriter Output >>
    [SynchronizedAfterSuite] TOP-LEVEL
      /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170
    [SynchronizedAfterSuite] TOP-LEVEL
      /Users/deepak.muley/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:170
    STEP: Dumping logs from the bootstrap cluster 09/19/22 14:51:00.346
    STEP: Tearing down the management cluster 09/19/22 14:51:01.859
  << End Captured GinkgoWriter Output
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] TOP-LEVEL
  autogenerated by Ginkgo
------------------------------
[ReportAfterSuite] PASSED [0.005 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo

  Begin Captured GinkgoWriter Output >>
    [ReportAfterSuite] TOP-LEVEL
      autogenerated by Ginkgo
  << End Captured GinkgoWriter Output
------------------------------

Ran 1 of 21 Specs in 375.019 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS

Ginkgo ran 1 suite in 6m23.663963331s
Test Suite Passed
</pre>

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```