### PR TITLE
Add a link to opendocs getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+The Cluster API Provider Nutanix Cloud Infrastructure (CAPX) documentation has been moved to [opendocs.nutanix.com](https://opendocs.nutanix.com/). Refer to [https://opendocs.nutanix.com/capx/latest/getting_started](https://opendocs.nutanix.com/capx/latest/getting_started/) for the latest version of the getting started guide.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a link to opendocs in the getting started guide. This is required since the official CAPI documentation still points to the getting started guide in main branch. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
NONE