### PR TITLE
Add CSI e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ cluster-e2e-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-md-remediation.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-remediation.yaml
 	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in.yaml
+	$(KUSTOMIZE) build $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-csi --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-csi.yaml
 
 cluster-templates: $(KUSTOMIZE) ## Generate cluster templates for all flavors
 	$(KUSTOMIZE) build $(TEMPLATES_DIR)/base > $(TEMPLATES_DIR)/cluster-template.yaml

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -149,6 +149,7 @@ providers:
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template-csi.yaml"
 
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus
@@ -190,6 +191,14 @@ variables:
   ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
+  # NOTE: Following parameters are required for CSI flavor testing
+  WEBHOOK_CA: ""
+  WEBHOOK_CERT: ""
+  WEBHOOK_KEY: ""
+  NUTANIX_STORAGE_CONTAINER: ""
+  NUTANIX_PRISM_ELEMENT_CLUSTER_IP: ""
+  NUTANIX_PRISM_ELEMENT_CLUSTER_USERNAME: ""
+  NUTANIX_PRISM_ELEMENT_CLUSTER_PASSWORD: ""
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
   # NOTE: We test the latest release with a previous contract.

--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -1,0 +1,224 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi", "slow", "network"), func() {
+	const (
+		specName = "cluster-csi"
+
+		nutanixWebhookCAKey        = "WEBHOOK_CA"
+		nutanixWebhookCertKey      = "WEBHOOK_CERT"
+		nutanixWebhookKeyKey       = "WEBHOOK_KEY"
+		nutanixStorageContainerKey = "NUTANIX_STORAGE_CONTAINER"
+		nutanixPEIPKey             = "NUTANIX_PRISM_ELEMENT_CLUSTER_IP"
+		nutanixPEUsernameKey       = "NUTANIX_PRISM_ELEMENT_CLUSTER_USERNAME"
+		nutanixPEPasswordKey       = "NUTANIX_PRISM_ELEMENT_CLUSTER_PASSWORD"
+		nutanixPEPort              = "9440"
+
+		csiNamespaceName  = "ntnx-system"
+		csiDeploymentName = "nutanix-csi-controller"
+		csiProvisioner    = "csi.nutanix.com"
+	)
+
+	var (
+		namespace        *corev1.Namespace
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+		testHelper       testHelperInterface
+		workloadClient   client.Client
+
+		csiSecretName       = util.RandomString(10)
+		csiStorageClassName = util.RandomString(10)
+
+		nutanixStorageContainer string
+		nutanixPEIP             string
+		nutanixPEUsername       string
+		nutanixPEPassword       string
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper(e2eConfig)
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = &clusterctl.ApplyClusterTemplateAndWaitResult{}
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+
+		nutanixWebhookCA := testHelper.getVariableFromE2eConfig(nutanixWebhookCAKey)
+		Expect(nutanixWebhookCA).ToNot(BeEmpty())
+		nutanixWebhookCert := testHelper.getVariableFromE2eConfig(nutanixWebhookCertKey)
+		Expect(nutanixWebhookCert).ToNot(BeEmpty())
+		nutanixWebhookKey := testHelper.getVariableFromE2eConfig(nutanixWebhookKeyKey)
+		Expect(nutanixWebhookKey).ToNot(BeEmpty())
+		nutanixPEIP = testHelper.getVariableFromE2eConfig(nutanixPEIPKey)
+		Expect(nutanixPEIP).ToNot(BeEmpty())
+		nutanixPEUsername = testHelper.getVariableFromE2eConfig(nutanixPEUsernameKey)
+		Expect(nutanixPEUsername).ToNot(BeEmpty())
+		nutanixPEPassword = testHelper.getVariableFromE2eConfig(nutanixPEPasswordKey)
+		Expect(nutanixPEPassword).ToNot(BeEmpty())
+		nutanixStorageContainer = testHelper.getVariableFromE2eConfig(nutanixStorageContainerKey)
+		Expect(nutanixStorageContainer).ToNot(BeEmpty())
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster with Nutanix CSI and use Nutanix Volumes to create PV", func() {
+		const flavor = "csi"
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		testHelper.deployClusterAndWait(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+			}, clusterResources)
+
+		By("Fetching workload client")
+		workloadProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)
+		workloadClient = workloadProxy.GetClient()
+
+		By("Creating CSI secret")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      csiSecretName,
+				Namespace: csiNamespaceName,
+			},
+			Data: map[string][]byte{
+				"key": []byte(fmt.Sprintf("%s:%s:%s:%s", nutanixPEIP, nutanixPEPort, nutanixPEUsername, nutanixPEPassword)),
+			},
+		}
+		Eventually(func() error {
+			return workloadClient.Create(ctx, secret)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if CSI namespace exists")
+		csiNamespace := &corev1.Namespace{}
+		csiNamespaceKey := client.ObjectKey{
+			Name: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiNamespaceKey, csiNamespace)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if CSI deployment exists")
+		csiDeployment := &appsv1.Deployment{}
+		csiDeploymentKey := client.ObjectKey{
+			Name:      csiDeploymentName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiDeploymentKey, csiDeployment)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI Storage class")
+		sc := &storagev1.StorageClass{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "storage.k8s.io/v1",
+				Kind:       "StorageClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: csiStorageClassName,
+				Annotations: map[string]string{
+					"storageclass.kubernetes.io/is-default-class": "true",
+				},
+			},
+			Provisioner: csiProvisioner,
+			Parameters: map[string]string{
+				"csi.storage.k8s.io/provisioner-secret-name":            csiSecretName,
+				"csi.storage.k8s.io/provisioner-secret-namespace":       csiNamespaceName,
+				"csi.storage.k8s.io/node-publish-secret-name":           csiSecretName,
+				"csi.storage.k8s.io/node-publish-secret-namespace":      csiNamespaceName,
+				"csi.storage.k8s.io/controller-expand-secret-name":      csiSecretName,
+				"csi.storage.k8s.io/controller-expand-secret-namespace": csiNamespaceName,
+				"csi.storage.k8s.io/fstype":                             "ext4",
+				"flashMode":                                             "DISABLED",
+				"storageContainer":                                      nutanixStorageContainer,
+				"chapAuth":                                              "ENABLED",
+				"storageType":                                           "NutanixVolumes",
+				"description":                                           "CAPX e2e-test",
+			},
+		}
+		Eventually(func() error {
+			return workloadClient.Create(ctx, sc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI PVC")
+		pvcName := util.RandomString(10)
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: csiNamespaceName,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &csiStorageClassName,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			return workloadClient.Create(ctx, pvc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking CSI PVC status is bound")
+		csiPvc := &corev1.PersistentVolumeClaim{}
+		csiPvcKey := client.ObjectKey{
+			Name:      pvcName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiPvcKey, csiPvc)).To(Succeed())
+			g.Expect(csiPvc.Status.Phase).To(Equal(corev1.ClaimBound))
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Deleting CSI PVC")
+		Expect(workloadClient.Delete(ctx, csiPvc)).To(Succeed())
+
+		By("PASSED!")
+	})
+})

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "${CLUSTER_NAME}-kcp"
+  namespace: "${NAMESPACE}"
+spec:
+  kubeadmConfigSpec:
+    preKubeadmCommands:
+      - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - apt update
+      - apt install -y nfs-common open-iscsi lvm2 xfsprogs
+      - systemctl enable --now iscsid

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kct.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kct.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-kcfg-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      preKubeadmCommands:
+        - echo "before kubeadm call" > /var/log/prekubeadm.log
+        - apt update
+        - apt install -y nfs-common open-iscsi lvm2 xfsprogs
+        - systemctl enable --now iscsid

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kustomization.yaml
@@ -1,0 +1,14 @@
+bases:
+  - ../../../../../../templates/csi/
+  - ../bases/crs.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /metadata/labels/cni
+        value: "${CLUSTER_NAME}-crs-cni"
+    target:
+      kind: Cluster
+
+patchesStrategicMerge:
+  - ./kcp.yaml
+  - ./kct.yaml

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -185,6 +186,8 @@ func initScheme() *runtime.Scheme {
 	sc := runtime.NewScheme()
 	framework.TryAddDefaultSchemes(sc)
 	err := infrav1.AddToScheme(sc)
+	Expect(err).NotTo(HaveOccurred())
+	err = storagev1.AddToScheme(sc)
 	Expect(err).NotTo(HaveOccurred())
 	return sc
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e test for Nutanix CSI. 
The test will:
- Create a CAPX cluster with the CSI flavour
- Create a storage class
- Create a PVC
- Check if PVC is bound 

Following variables are added:
  - WEBHOOK_CA
  - WEBHOOK_CERT
  - WEBHOOK_KEY
  - NUTANIX_STORAGE_CONTAINER
  - NUTANIX_PRISM_ELEMENT_CLUSTER_IP
  - NUTANIX_PRISM_ELEMENT_CLUSTER_USERNAME
  - NUTANIX_PRISM_ELEMENT_CLUSTER_PASSWORD

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:

```
LABEL_FILTERS="capx-feature-test"  make test-e2e-calico
```

```
Ran 11 of 22 Specs in 1704.064 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 11 Skipped
```

**Special notes for your reviewer**:
Make sure you set the correct env variables before running the CSI test.

**Release note**:
NONE