### PR TITLE
Update makefile with a release-manifests target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,8 +74,7 @@ jobs:
         NEW_IMG: ghcr.io/${{ github.repository }}/controller:${{ steps.meta.outputs.version }}
       run: |
         (cd config/manager && kustomize edit set image controller=$NEW_IMG)
-        kustomize build config/default > infrastructure-components.yaml
-        make cluster-templates
+        make release-manifests
 
     - name: generate image info
       env:
@@ -95,6 +94,6 @@ jobs:
         generate_release_notes: true
         append_body: true
         files: |
-          infrastructure-components.yaml
-          metadata.yaml
-          templates/cluster-template*.yaml
+          out/infrastructure-components.yaml
+          out/metadata.yaml
+          out/cluster-template*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,9 @@ _artifacts
 
 # vscode directories
 .vscode
+
+# Makefile default RELEASE_DIR
+out
+
+# github.com
+github.com

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ E2E_FRAMEWORK_DIR := $(TEST_DIR)/framework
 CAPD_DIR := $(TEST_DIR)/infrastructure/docker
 GO_INSTALL := $(REPO_ROOT)/scripts/go_install.sh
 NUTANIX_E2E_TEMPLATES := ${E2E_DIR}/data/infrastructure-nutanix
+RELEASE_DIR ?= $(REPO_ROOT)/out
 
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
@@ -175,6 +176,13 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+.PHONY: release-manifests
+release-manifests: manifests cluster-templates
+	mkdir -p $(RELEASE_DIR)
+	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+	cp $(TEMPLATES_DIR)/cluster-template*.yaml $(RELEASE_DIR)
+	cp $(REPO_ROOT)/metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: generate
 generate: controller-gen conversion-gen ## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject method implementations and API conversion implementations.


### PR DESCRIPTION
The target generates infrastructure-components.yaml and cluster templates and puts them in the `RELEASE_DIR` that defaults to `out`.