### PR TITLE
prepare for 1.0 GA release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         draft: false
-        prerelease: true
+        prerelease: false
         body_path: ${{ github.workspace }}-CHANGELOG.txt
         generate_release_notes: true
         append_body: true

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,6 +21,9 @@ releaseSeries:
   - major: 0
     minor: 5
     contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1
   - major: 0
     minor: 0
     contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update metadata for 1.0 release
- Update release action for GA


**Release note**:
```release-note
NONE
```