### PR TITLE
fix issue where status is not updates on machines after move operation

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -30,7 +30,7 @@ const (
 )
 
 const (
-	//PrismCentralClientCondition indicates the status of the client used to connect to Prism Central
+	// PrismCentralClientCondition indicates the status of the client used to connect to Prism Central
 	PrismCentralClientCondition capiv1.ConditionType = "PrismClientInit"
 
 	PrismCentralClientInitializationFailed = "PrismClientInitFailed"
@@ -45,8 +45,11 @@ const (
 	// VMAddressesAssignedCondition shows the status of the process of assigning the VM addresses
 	VMAddressesAssignedCondition capiv1.ConditionType = "VMAddressesAssigned"
 
-	VMAddressesFailed = "VMAddressesFailed"
-	VMBootTypeInvalid = "VMBootTypeInvalid"
+	VMAddressesFailed             = "VMAddressesFailed"
+	VMBootTypeInvalid             = "VMBootTypeInvalid"
+	ClusterInfrastructureNotReady = "ClusterInfrastructureNotReady"
+	BootstrapDataNotReady         = "BootstrapDataNotReady"
+	ControlplaneNotInitialized    = "ControlplaneNotInitialized"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/nutanix-cloud-native/prism-go-client v0.3.0
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
@@ -70,7 +71,6 @@ require (
 	github.com/google/go-github/v45 v45.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect


### PR DESCRIPTION

**What this PR does / why we need it**:
Uses ProviderId as fallback in case VMUUID is empty on the status object. Also updates to the Cluster object will trigger reconcile on NutanixMachine objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Ran capx feature test e2e:
```
Ran 11 of 24 Specs in 2911.272 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 13 Skipped
PASS
```

**Special notes for your reviewer**:
N/A

**Release note**:
None