### PR TITLE
Update kube-vip to version 0.5.6

### DIFF
--- a/templates/base/cluster-with-kcp.yaml
+++ b/templates/base/cluster-with-kcp.yaml
@@ -78,7 +78,7 @@ spec:
           spec:
             containers:
               - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.5.5
+                image: ghcr.io/kube-vip/kube-vip:v0.5.6
                 imagePullPolicy: IfNotPresent
                 args:
                   - manager

--- a/templates/cluster-template-ccm.yaml
+++ b/templates/cluster-template-ccm.yaml
@@ -382,7 +382,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.5
+              image: ghcr.io/kube-vip/kube-vip:v0.5.6
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1482,7 +1482,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.5
+              image: ghcr.io/kube-vip/kube-vip:v0.5.6
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -151,7 +151,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.5
+              image: ghcr.io/kube-vip/kube-vip:v0.5.6
               imagePullPolicy: IfNotPresent
               args:
                 - manager


### PR DESCRIPTION
**What this PR does / why we need it**:

Update kube-vip to version 0.5.6

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://github.com/kube-vip/kube-vip/releases/tag/v0.5.6

**How Has This Been Tested?**:

make test-e2e-calico

```
Ran 12 of 23 Specs in 1563.425 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 11 Skipped
PASS
```

**Release note**:
```release-note
Update kube-vip to version 0.5.6
```