### PR TITLE
prepare for 1.1 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,9 @@ releaseSeries:
   - major: 1
     minor: 0
     contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
   - major: 0
     minor: 0
     contract: v1beta1

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -137,7 +137,17 @@ providers:
         files:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template.yaml"
-      - name: v1.0.0 # next; use manifest from source files
+      - name: v1.0.0
+        type: "url"
+        value: https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/download/v1.0.0/infrastructure-components.yaml
+        contract: v1beta1
+        replacements:
+          - old: "imagePullPolicy: Always"
+            new: "imagePullPolicy: IfNotPresent"
+        files:
+          - sourcePath: "../../../metadata.yaml"
+          - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template.yaml"
+      - name: v1.1.0 # next; use manifest from source files
         type: kustomize
         value: "../../../config/default"
         contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

prepare repo for 1.1.0 release
- update metadata
- update e2e version list


**Release note**:
```release-note
NONE
```