### PR TITLE
Update kube-vip to v0.5.7

### DIFF
--- a/templates/base/cluster-with-kcp.yaml
+++ b/templates/base/cluster-with-kcp.yaml
@@ -81,7 +81,7 @@ spec:
           spec:
             containers:
               - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.5.6
+                image: ghcr.io/kube-vip/kube-vip:v0.5.7
                 imagePullPolicy: IfNotPresent
                 args:
                   - manager

--- a/templates/cluster-template-ccm.yaml
+++ b/templates/cluster-template-ccm.yaml
@@ -410,7 +410,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.6
+              image: ghcr.io/kube-vip/kube-vip:v0.5.7
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1490,7 +1490,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.6
+              image: ghcr.io/kube-vip/kube-vip:v0.5.7
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -159,7 +159,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.5.6
+              image: ghcr.io/kube-vip/kube-vip:v0.5.7
               imagePullPolicy: IfNotPresent
               args:
                 - manager


### PR DESCRIPTION
**What this PR does / why we need it**:

Update kube-vip to v0.5.7

**How Has This Been Tested?**:

LABEL_FILTERS="capx-feature-test" make test-e2e-calico
```
Ran 12 of 23 Specs in 1525.784 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 11 Skipped
PASS
```

**Release note**:
```release-note
Update kube-vip to v0.5.7
```