### PR TITLE
Add uuid cluster creation testing and capxhelpers

### DIFF
--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -75,7 +75,6 @@ type NutanixMachineReconciler struct {
 	SecretInformer    coreinformers.SecretInformer
 	ConfigMapInformer coreinformers.ConfigMapInformer
 	Scheme            *runtime.Scheme
-	capxHelpers       Helpers
 }
 
 func NewNutanixMachineReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme) *NutanixMachineReconciler {
@@ -84,7 +83,6 @@ func NewNutanixMachineReconciler(client client.Client, secretInformer coreinform
 		SecretInformer:    secretInformer,
 		ConfigMapInformer: configMapInformer,
 		Scheme:            scheme,
-		capxHelpers:       &CapxHelpers{},
 	}
 }
 
@@ -225,7 +223,7 @@ func (r *NutanixMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	v3Client, err := r.capxHelpers.CreateNutanixClient(r.SecretInformer, r.ConfigMapInformer, ntxCluster)
+	v3Client, err := CreateNutanixClient(r.SecretInformer, r.ConfigMapInformer, ntxCluster)
 	if err != nil {
 		conditions.MarkFalse(ntxMachine, infrav1.PrismCentralClientCondition, infrav1.PrismCentralClientInitializationFailed, capiv1.ConditionSeverityError, err.Error())
 		return ctrl.Result{Requeue: true}, fmt.Errorf("client auth error: %v", err)
@@ -266,11 +264,11 @@ func (r *NutanixMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (reconcile.Result, error) {
 	ctx := rctx.Context
-	client := rctx.NutanixClient
+	nc := rctx.NutanixClient
 	vmName := rctx.NutanixMachine.Name
 	klog.Infof("%s Handling NutanixMachine deletion of VM: %s", rctx.LogPrefix, vmName)
 	conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, capiv1.DeletingReason, capiv1.ConditionSeverityInfo, "")
-	vmUUID, err := r.capxHelpers.GetVMUUID(ctx, rctx.NutanixMachine)
+	vmUUID, err := GetVMUUID(ctx, rctx.NutanixMachine)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get VM UUID during delete: %v", err)
 		klog.Errorf("%s %v", rctx.LogPrefix, err)
@@ -281,7 +279,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		klog.Warningf("%s VMUUID was not found in spec for VM %s. Skipping delete", rctx.LogPrefix, vmName)
 	} else {
 		// Search for VM by UUID
-		vm, err := r.capxHelpers.FindVMByUUID(ctx, client, vmUUID)
+		vm, err := FindVMByUUID(ctx, nc, vmUUID)
 		// Error while finding VM
 		if err != nil {
 			errorMsg := fmt.Errorf("%v: error finding vm %s with uuid %s: %v", rctx.LogPrefix, vmName, vmUUID, err)
@@ -299,7 +297,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 				return reconcile.Result{}, errorMsg
 			}
 			klog.Infof("%s VM %s with UUID %s was found.", rctx.LogPrefix, *vm.Spec.Name, vmUUID)
-			lastTaskUUID, err := r.capxHelpers.GetTaskUUIDFromVM(vm)
+			lastTaskUUID, err := GetTaskUUIDFromVM(vm)
 			if err != nil {
 				errorMsg := fmt.Errorf("error occurred fetching task UUID from vm: %v", err)
 				klog.Error(errorMsg)
@@ -307,7 +305,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 				return reconcile.Result{}, errorMsg
 			}
 			klog.Infof("%s checking if VM %s with UUID %s has in progress tasks", rctx.LogPrefix, vmName, vmUUID)
-			taskInProgress, err := r.capxHelpers.HasTaskInProgress(ctx, rctx.NutanixClient, lastTaskUUID)
+			taskInProgress, err := HasTaskInProgress(ctx, rctx.NutanixClient, lastTaskUUID)
 			if err != nil {
 				klog.Warningf("%s error occurred while checking task %s for VM %s... err: %v ....Trying to delete VM", rctx.LogPrefix, lastTaskUUID, vmName, vmUUID, err)
 			}
@@ -317,9 +315,9 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 			}
 			klog.Infof("%s No running tasks anymore... Initiating delete for vm %s with UUID %s", rctx.LogPrefix, vmName, vmUUID)
 			// Delete the VM since the VM was found (err was nil)
-			deleteTaskUUID, err := r.capxHelpers.DeleteVM(ctx, client, vmName, vmUUID)
+			deleteTaskUUID, err := DeleteVM(ctx, nc, vmName, vmUUID)
 			if err != nil {
-				errorMsg := fmt.Errorf("Failed to delete VM %s with UUID %s: %v", vmName, vmUUID, err)
+				errorMsg := fmt.Errorf("failed to delete VM %s with UUID %s: %v", vmName, vmUUID, err)
 				conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1.ConditionSeverityWarning, errorMsg.Error())
 				klog.Errorf("%s %v", rctx.LogPrefix, errorMsg)
 				return reconcile.Result{}, err
@@ -413,14 +411,14 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 	klog.Infof("%s Assigning IP addresses to VM with name: %s, vmUUID: %s", rctx.LogPrefix, rctx.NutanixMachine.Name, rctx.NutanixMachine.Status.VmUUID)
 	err = r.assignAddressesToMachine(rctx, vm)
 	if err != nil {
-		errorMsg := fmt.Errorf("Failed to assign addresses to VM %s with UUID %s...: %v", rctx.NutanixMachine.Name, rctx.NutanixMachine.Status.VmUUID, err)
+		errorMsg := fmt.Errorf("failed to assign addresses to VM %s with UUID %s...: %v", rctx.NutanixMachine.Name, rctx.NutanixMachine.Status.VmUUID, err)
 		klog.Error(errorMsg)
 		conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMAddressesAssignedCondition, infrav1.VMAddressesFailed, capiv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errorMsg
 	}
 	conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMAddressesAssignedCondition)
 	// Update the NutanixMachine Spec.ProviderID
-	rctx.NutanixMachine.Spec.ProviderID = r.capxHelpers.GenerateProviderID(rctx.NutanixMachine.Status.VmUUID)
+	rctx.NutanixMachine.Spec.ProviderID = GenerateProviderID(rctx.NutanixMachine.Status.VmUUID)
 	rctx.NutanixMachine.Status.Ready = true
 	klog.Infof("%s Created VM %s for cluster %s, update NutanixMachine spec.providerID to %s, and machinespec %+v, vmUuid: %s",
 		rctx.LogPrefix, rctx.NutanixMachine.Name, rctx.NutanixCluster.Name, rctx.NutanixMachine.Spec.ProviderID,
@@ -500,33 +498,33 @@ func (r *NutanixMachineReconciler) reconcileNode(rctx *nctx.MachineContext) (rec
 
 func (r *NutanixMachineReconciler) validateMachineConfig(rctx *nctx.MachineContext) error {
 	if len(rctx.NutanixMachine.Spec.Subnets) == 0 {
-		return fmt.Errorf("atleast one subnet is needed to create the VM %s.", rctx.NutanixMachine.Name)
+		return fmt.Errorf("atleast one subnet is needed to create the VM %s", rctx.NutanixMachine.Name)
 	}
 
 	diskSize := rctx.NutanixMachine.Spec.SystemDiskSize
 	// Validate disk size
 	if diskSize.Cmp(minMachineSystemDiskSize) < 0 {
-		diskSizeMib := r.capxHelpers.GetMibValueOfQuantity(diskSize)
-		minMachineSystemDiskSizeMib := r.capxHelpers.GetMibValueOfQuantity(minMachineSystemDiskSize)
-		return fmt.Errorf("The minimum systemDiskSize is %vMib but given %vMib", minMachineSystemDiskSizeMib, diskSizeMib)
+		diskSizeMib := GetMibValueOfQuantity(diskSize)
+		minMachineSystemDiskSizeMib := GetMibValueOfQuantity(minMachineSystemDiskSize)
+		return fmt.Errorf("minimum systemDiskSize is %vMib but given %vMib", minMachineSystemDiskSizeMib, diskSizeMib)
 	}
 
 	memorySize := rctx.NutanixMachine.Spec.MemorySize
 	// Validate memory size
 	if memorySize.Cmp(minMachineMemorySize) < 0 {
-		memorySizeMib := r.capxHelpers.GetMibValueOfQuantity(memorySize)
-		minMachineMemorySizeMib := r.capxHelpers.GetMibValueOfQuantity(minMachineMemorySize)
-		return fmt.Errorf("The minimum memorySize is %vMib but given %vMib", minMachineMemorySizeMib, memorySizeMib)
+		memorySizeMib := GetMibValueOfQuantity(memorySize)
+		minMachineMemorySizeMib := GetMibValueOfQuantity(minMachineMemorySize)
+		return fmt.Errorf("minimum memorySize is %vMib but given %vMib", minMachineMemorySizeMib, memorySizeMib)
 	}
 
 	vcpusPerSocket := rctx.NutanixMachine.Spec.VCPUsPerSocket
 	if vcpusPerSocket < int32(minVCPUsPerSocket) {
-		return fmt.Errorf("The minimum vcpus per socket is %v but given %v", minVCPUsPerSocket, vcpusPerSocket)
+		return fmt.Errorf("minimum vcpus per socket is %v but given %v", minVCPUsPerSocket, vcpusPerSocket)
 	}
 
 	vcpuSockets := rctx.NutanixMachine.Spec.VCPUSockets
 	if vcpuSockets < int32(minVCPUSockets) {
-		return fmt.Errorf("The minimum vcpu sockets is %v but given %v", minVCPUSockets, vcpuSockets)
+		return fmt.Errorf("minimum vcpu sockets is %v but given %v", minVCPUSockets, vcpuSockets)
 	}
 
 	return nil
@@ -538,10 +536,10 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 	var vm *nutanixClientV3.VMIntentResponse
 	ctx := rctx.Context
 	vmName := rctx.NutanixMachine.Name
-	client := rctx.NutanixClient
+	nc := rctx.NutanixClient
 
 	// Check if the VM already exists
-	vm, err = r.capxHelpers.FindVM(ctx, client, rctx.NutanixMachine)
+	vm, err = FindVM(ctx, nc, rctx.NutanixMachine)
 	if err != nil {
 		klog.Errorf("%s error occurred finding VM %s by name or uuid %s: %v", rctx.LogPrefix, vmName, err)
 		return nil, err
@@ -561,32 +559,32 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		}
 
 		// Get PE UUID
-		peUUID, err := r.capxHelpers.GetPEUUID(ctx, client, rctx.NutanixMachine.Spec.Cluster.Name, rctx.NutanixMachine.Spec.Cluster.UUID)
+		peUUID, err := GetPEUUID(ctx, nc, rctx.NutanixMachine.Spec.Cluster.Name, rctx.NutanixMachine.Spec.Cluster.UUID)
 		if err != nil {
-			errorMsg := fmt.Errorf("Failed to get the Prism Element Cluster UUID to create the VM %s. %v", vmName, err)
+			errorMsg := fmt.Errorf("failed to get the Prism Element Cluster UUID to create the VM %s. %v", vmName, err)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
 			klog.Errorf("%s %v", rctx.LogPrefix, errorMsg)
 			return nil, err
 		}
 
 		// Get Subnet UUIDs
-		subnetUUIDs, err := r.capxHelpers.GetSubnetUUIDList(ctx, client, rctx.NutanixMachine.Spec.Subnets, peUUID)
+		subnetUUIDs, err := GetSubnetUUIDList(ctx, nc, rctx.NutanixMachine.Spec.Subnets, peUUID)
 		if err != nil {
-			errorMsg := fmt.Errorf("Failed to get the subnet UUIDs to create the VM %s. %v", vmName, err)
+			errorMsg := fmt.Errorf("failed to get the subnet UUIDs to create the VM %s. %v", vmName, err)
 			klog.Errorf("%s %v", rctx.LogPrefix, vmName, err)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
 			return nil, err
 		}
 
 		// Get Image UUID
-		imageUUID, err := r.capxHelpers.GetImageUUID(
+		imageUUID, err := GetImageUUID(
 			ctx,
-			client,
+			nc,
 			rctx.NutanixMachine.Spec.Image.Name,
 			rctx.NutanixMachine.Spec.Image.UUID,
 		)
 		if err != nil {
-			errorMsg := fmt.Errorf("Failed to get the image UUID to create the VM %s. %v", vmName, err)
+			errorMsg := fmt.Errorf("failed to get the image UUID to create the VM %s. %v", vmName, err)
 			klog.Errorf("%s %v", rctx.LogPrefix, errorMsg)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
 			return nil, err
@@ -609,7 +607,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		vmInput := nutanixClientV3.VMIntentInput{}
 		vmSpec := nutanixClientV3.VM{Name: utils.StringPtr(vmName)}
 
-		nicList := []*nutanixClientV3.VMNic{}
+		nicList := make([]*nutanixClientV3.VMNic, 0)
 		for _, subnetUUID := range subnetUUIDs {
 			nicList = append(nicList, &nutanixClientV3.VMNic{
 				SubnetReference: &nutanixClientV3.Reference{
@@ -621,8 +619,8 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 
 		// Create Disk Spec for systemdisk to be set later in VM Spec
 		diskSize := rctx.NutanixMachine.Spec.SystemDiskSize
-		diskSizeMib := r.capxHelpers.GetMibValueOfQuantity(diskSize)
-		systemDisk, err := r.capxHelpers.CreateSystemDiskSpec(imageUUID, diskSizeMib)
+		diskSizeMib := GetMibValueOfQuantity(diskSize)
+		systemDisk, err := CreateSystemDiskSpec(imageUUID, diskSizeMib)
 		if err != nil {
 			errorMsg := fmt.Errorf("error occurred while creating system disk spec: %v", err)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
@@ -633,7 +631,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		}
 
 		// Set Categories to VM Sepc before creating VM
-		categories, err := r.capxHelpers.GetCategoryVMSpec(ctx, client, r.getMachineCategoryIdentifiers(rctx))
+		categories, err := GetCategoryVMSpec(ctx, nc, r.getMachineCategoryIdentifiers(rctx))
 		if err != nil {
 			errorMsg := fmt.Errorf("error occurred while creating category spec for vm %s: %v", vmName, err)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
@@ -657,7 +655,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		}
 
 		memorySize := rctx.NutanixMachine.Spec.MemorySize
-		memorySizeMib := r.capxHelpers.GetMibValueOfQuantity(memorySize)
+		memorySizeMib := GetMibValueOfQuantity(memorySize)
 
 		vmSpec.Resources = &nutanixClientV3.VMResources{
 			PowerState:            utils.StringPtr("ON"),
@@ -690,9 +688,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		vmInput.Metadata = vmMetadataPtr
 
 		// Create the actual VM/Machine
-		vmResponse, err := client.V3.CreateVM(ctx, &vmInput)
+		vmResponse, err := nc.V3.CreateVM(ctx, &vmInput)
 		if err != nil {
-			errorMsg := fmt.Errorf("Failed to create VM %s. error: %v", vmName, err)
+			errorMsg := fmt.Errorf("failed to create VM %s. error: %v", vmName, err)
 			rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)
 			klog.Errorf("%s %v", rctx.LogPrefix, errorMsg)
 			return nil, err
@@ -702,7 +700,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 			rctx.NutanixMachine.Name, vmUuid, *vmResponse.Status.State)
 		klog.Infof("%s Getting task uuid for VM %s", rctx.LogPrefix,
 			rctx.NutanixMachine.Name)
-		lastTaskUUID, err := r.capxHelpers.GetTaskUUIDFromVM(vmResponse)
+		lastTaskUUID, err := GetTaskUUIDFromVM(vmResponse)
 		if err != nil {
 			errorMsg := fmt.Errorf("%s error occurred fetching task UUID from vm %s after creation: %v", rctx.LogPrefix, rctx.NutanixMachine.Name, err)
 			klog.Error(errorMsg)
@@ -710,7 +708,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		}
 		klog.Infof("%s Waiting for task %s to get completed for VM %s", rctx.LogPrefix,
 			lastTaskUUID, rctx.NutanixMachine.Name)
-		err = nutanixClient.WaitForTaskCompletion(ctx, client, lastTaskUUID)
+		err = nutanixClient.WaitForTaskCompletion(ctx, nc, lastTaskUUID)
 		if err != nil {
 			errorMsg := fmt.Errorf("%s  error occurred while waiting for task %s to start: %v", rctx.LogPrefix, lastTaskUUID, err)
 			klog.Error(errorMsg)
@@ -719,7 +717,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		}
 		klog.Infof("%s Fetching VM after creation %s", rctx.LogPrefix,
 			lastTaskUUID, rctx.NutanixMachine.Name)
-		vm, err = r.capxHelpers.FindVMByUUID(ctx, client, vmUuid)
+		vm, err = FindVMByUUID(ctx, nc, vmUuid)
 		if err != nil {
 			errorMsg := fmt.Errorf("%s  error occurred while getting VM %s after creation: %v", rctx.LogPrefix, rctx.NutanixMachine.Name, err)
 			klog.Error(errorMsg)
@@ -805,7 +803,7 @@ func (r *NutanixMachineReconciler) assignAddressesToMachine(rctx *nctx.MachineCo
 }
 
 func (r *NutanixMachineReconciler) getMachineCategoryIdentifiers(rctx *nctx.MachineContext) []*infrav1.NutanixCategoryIdentifier {
-	categoryIdentifiers := r.capxHelpers.GetDefaultCAPICategoryIdentifiers(rctx.Cluster.Name)
+	categoryIdentifiers := GetDefaultCAPICategoryIdentifiers(rctx.Cluster.Name)
 	additionalCategories := rctx.NutanixMachine.Spec.AdditionalCategories
 	if len(additionalCategories) > 0 {
 		for _, at := range additionalCategories {
@@ -827,7 +825,7 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 			return errorMsg
 		}
 
-		// Only modify VM spec if boot type is UEFI. Otherwise assume default Legacy mode
+		// Only modify VM spec if boot type is UEFI. Otherwise, assume default Legacy mode
 		if bootType == string(infrav1.NutanixIdentifierBootTypeUEFI) {
 			vmSpec.Resources.BootConfig = &nutanixClientV3.VMBootConfig{
 				BootType: utils.StringPtr(strings.ToUpper(bootType)),
@@ -851,7 +849,7 @@ func (r *NutanixMachineReconciler) addVMToProject(rctx *nctx.MachineContext, vmM
 		conditions.MarkFalse(rctx.NutanixMachine, infrav1.ProjectAssignedCondition, infrav1.ProjectAssignationFailed, capiv1.ConditionSeverityError, errorMsg.Error())
 		return errorMsg
 	}
-	projectUUID, err := r.capxHelpers.GetProjectUUID(rctx.Context, rctx.NutanixClient, projectRef.Name, projectRef.UUID)
+	projectUUID, err := GetProjectUUID(rctx.Context, rctx.NutanixClient, projectRef.Name, projectRef.UUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("%s error occurred while searching for project for VM %s: %v", rctx.LogPrefix, vmName, err)
 		klog.Error(errorMsg)

--- a/main.go
+++ b/main.go
@@ -117,21 +117,20 @@ func main() {
 	go cmInformer.Run(ctx.Done())
 	cache.WaitForCacheSync(ctx.Done(), cmInformer.HasSynced)
 
-	if err = (&controllers.NutanixClusterReconciler{
-		Client:            mgr.GetClient(),
-		SecretInformer:    secretInformer,
-		ConfigMapInformer: configMapInformer,
-		Scheme:            mgr.GetScheme(),
-	}).SetupWithManager(ctx, mgr); err != nil {
+	if err = (controllers.NewNutanixClusterReconciler(mgr.GetClient(),
+		secretInformer,
+		configMapInformer,
+		mgr.GetScheme(),
+	)).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NutanixCluster")
 		os.Exit(1)
 	}
-	if err = (&controllers.NutanixMachineReconciler{
-		Client:            mgr.GetClient(),
-		SecretInformer:    secretInformer,
-		ConfigMapInformer: configMapInformer,
-		Scheme:            mgr.GetScheme(),
-	}).SetupWithManager(ctx, mgr); err != nil {
+	if err = (controllers.NewNutanixMachineReconciler(
+		mgr.GetClient(),
+		secretInformer,
+		configMapInformer,
+		mgr.GetScheme(),
+	)).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NutanixMachine")
 		os.Exit(1)
 	}

--- a/test/e2e/basic_uuid_test.go
+++ b/test/e2e/basic_uuid_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+var _ = Describe("Nutanix Basic Creation with UUID", Label("capx-feature-test", "uuid", "slow", "network"), func() {
+	const (
+		specName = "cluster-uuid"
+	)
+
+	var (
+		namespace        *corev1.Namespace
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+		testHelper       testHelperInterface
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper(e2eConfig)
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster by passing UUIDs", func() {
+		flavor = "no-nmt"
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating Nutanix Machine Template with UUIDs", func() {
+			uuidNMT := testHelper.createUUIDNMT(ctx, clusterName, namespace.Name)
+			testHelper.createCapiObject(ctx, createCapiObjectParams{
+				creator:    bootstrapClusterProxy.GetClient(),
+				capiObject: uuidNMT,
+			})
+		})
+
+		By("Creating a workload cluster", func() {
+			testHelper.deployClusterAndWait(
+				deployClusterParams{
+					clusterName:           clusterName,
+					namespace:             namespace,
+					flavor:                flavor,
+					clusterctlConfigPath:  clusterctlConfigPath,
+					artifactFolder:        artifactFolder,
+					bootstrapClusterProxy: bootstrapClusterProxy,
+				}, clusterResources)
+		})
+
+		By("PASSED!")
+	})
+})

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -102,7 +102,6 @@ type testHelperInterface interface {
 type testHelper struct {
 	nutanixClient *prismGoClientV3.Client
 	e2eConfig     *clusterctl.E2EConfig
-	capxHelpers   controllers.Helpers
 }
 
 func newTestHelper(e2eConfig *clusterctl.E2EConfig) testHelperInterface {
@@ -112,7 +111,6 @@ func newTestHelper(e2eConfig *clusterctl.E2EConfig) testHelperInterface {
 	return testHelper{
 		nutanixClient: c,
 		e2eConfig:     e2eConfig,
-		capxHelpers:   &controllers.CapxHelpers{},
 	}
 }
 
@@ -178,13 +176,13 @@ func (t testHelper) createUUIDNMT(ctx context.Context, clusterName, namespace st
 	clusterVarValue := t.getVariableFromE2eConfig(clusterVarKey)
 	subnetVarValue := t.getVariableFromE2eConfig(subnetVarKey)
 
-	clusterUUID, err := t.capxHelpers.GetPEUUID(ctx, t.nutanixClient, &clusterVarValue, nil)
+	clusterUUID, err := controllers.GetPEUUID(ctx, t.nutanixClient, &clusterVarValue, nil)
 	Expect(err).ToNot(HaveOccurred())
 
-	imageUUID, err := t.capxHelpers.GetImageUUID(ctx, t.nutanixClient, &imageVarValue, nil)
+	imageUUID, err := controllers.GetImageUUID(ctx, t.nutanixClient, &imageVarValue, nil)
 	Expect(err).ToNot(HaveOccurred())
 
-	subnetUUID, err := t.capxHelpers.GetSubnetUUID(ctx, t.nutanixClient, clusterUUID, &subnetVarValue, nil)
+	subnetUUID, err := controllers.GetSubnetUUID(ctx, t.nutanixClient, clusterUUID, &subnetVarValue, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 	return &infrav1.NutanixMachineTemplate{
@@ -223,7 +221,7 @@ func (t testHelper) createUUIDNMT(ctx context.Context, clusterName, namespace st
 
 func (t testHelper) createUUIDProjectNMT(ctx context.Context, clusterName, namespace string) *infrav1.NutanixMachineTemplate {
 	projectVarValue := t.getVariableFromE2eConfig(nutanixProjectNameEnv)
-	projectUUID, err := t.capxHelpers.GetProjectUUID(ctx, t.nutanixClient, &projectVarValue, nil)
+	projectUUID, err := controllers.GetProjectUUID(ctx, t.nutanixClient, &projectVarValue, nil)
 	Expect(err).ToNot(HaveOccurred())
 
 	nmt := t.createUUIDNMT(ctx, clusterName, namespace)

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	"github.com/nutanix-cloud-native/cluster-api-provider-nutanix/controllers"
 )
 
 const (
@@ -73,6 +74,8 @@ type testHelperInterface interface {
 	createDefaultNutanixCluster(clusterName, namespace, controlPlaneEndpointIP string, controlPlanePort int32) *infrav1.NutanixCluster
 	createCapiObject(ctx context.Context, params createCapiObjectParams)
 	createSecret(params createSecretParams)
+	createUUIDNMT(ctx context.Context, clusterName, namespace string) *infrav1.NutanixMachineTemplate
+	createUUIDProjectNMT(ctx context.Context, clusterName, namespace string) *infrav1.NutanixMachineTemplate
 	deployCluster(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult)
 	deployClusterAndWait(params deployClusterParams, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult)
 	generateNMTName(clusterName string) string
@@ -99,6 +102,7 @@ type testHelperInterface interface {
 type testHelper struct {
 	nutanixClient *prismGoClientV3.Client
 	e2eConfig     *clusterctl.E2EConfig
+	capxHelpers   controllers.Helpers
 }
 
 func newTestHelper(e2eConfig *clusterctl.E2EConfig) testHelperInterface {
@@ -108,6 +112,7 @@ func newTestHelper(e2eConfig *clusterctl.E2EConfig) testHelperInterface {
 	return testHelper{
 		nutanixClient: c,
 		e2eConfig:     e2eConfig,
+		capxHelpers:   &controllers.CapxHelpers{},
 	}
 }
 
@@ -166,6 +171,67 @@ func (t testHelper) createDefaultNMT(clusterName, namespace string) *infrav1.Nut
 			},
 		},
 	}
+}
+
+func (t testHelper) createUUIDNMT(ctx context.Context, clusterName, namespace string) *infrav1.NutanixMachineTemplate {
+	imageVarValue := t.getVariableFromE2eConfig(imageVarKey)
+	clusterVarValue := t.getVariableFromE2eConfig(clusterVarKey)
+	subnetVarValue := t.getVariableFromE2eConfig(subnetVarKey)
+
+	clusterUUID, err := t.capxHelpers.GetPEUUID(ctx, t.nutanixClient, &clusterVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	imageUUID, err := t.capxHelpers.GetImageUUID(ctx, t.nutanixClient, &imageVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	subnetUUID, err := t.capxHelpers.GetSubnetUUID(ctx, t.nutanixClient, clusterUUID, &subnetVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &infrav1.NutanixMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.generateNMTName(clusterName),
+			Namespace: namespace,
+		},
+		Spec: infrav1.NutanixMachineTemplateSpec{
+			Template: infrav1.NutanixMachineTemplateResource{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID:     t.generateNMTProviderID(clusterName),
+					BootType:       defaultBootType,
+					VCPUsPerSocket: defaultVCPUsPerSocket,
+					VCPUSockets:    defaultVCPUSockets,
+					MemorySize:     resource.MustParse(defaultMemorySize),
+					Image: infrav1.NutanixResourceIdentifier{
+						Type: infrav1.NutanixIdentifierUUID,
+						UUID: pointer.StringPtr(imageUUID),
+					},
+					Cluster: infrav1.NutanixResourceIdentifier{
+						Type: infrav1.NutanixIdentifierUUID,
+						UUID: pointer.StringPtr(clusterUUID),
+					},
+					Subnets: []infrav1.NutanixResourceIdentifier{
+						{
+							Type: infrav1.NutanixIdentifierUUID,
+							UUID: pointer.StringPtr(subnetUUID),
+						},
+					},
+					SystemDiskSize: resource.MustParse(defaultSystemDiskSize),
+				},
+			},
+		},
+	}
+}
+
+func (t testHelper) createUUIDProjectNMT(ctx context.Context, clusterName, namespace string) *infrav1.NutanixMachineTemplate {
+	projectVarValue := t.getVariableFromE2eConfig(nutanixProjectNameEnv)
+	projectUUID, err := t.capxHelpers.GetProjectUUID(ctx, t.nutanixClient, &projectVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	nmt := t.createUUIDNMT(ctx, clusterName, namespace)
+	nmt.Spec.Template.Spec.Project = &infrav1.NutanixResourceIdentifier{
+		Type: infrav1.NutanixIdentifierUUID,
+		UUID: &projectUUID,
+	}
+	return nmt
 }
 
 func (t testHelper) createDefaultNutanixCluster(clusterName, namespace, controlPlaneEndpointIP string, controlPlanePort int32) *infrav1.NutanixCluster {


### PR DESCRIPTION

**What this PR does / why we need it**:
- Adds e2e test for testing cluster creation via UUIDs
- Adds Helpers interface for CAPX functions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
CAPX feature e2e:
```
Ran 14 of 25 Specs in 1917.475 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 11 Skipped
PASS
```

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Add e2e test for testing cluster creation via UUIDs
- Adds Helpers interface for CAPX functions
```