### PR TITLE
inject hostname through metadata

### DIFF
--- a/templates/base/cluster-with-kcp.yaml
+++ b/templates/base/cluster-with-kcp.yaml
@@ -161,6 +161,7 @@ spec:
           - ${NUTANIX_SSH_AUTHORIZED_KEY}
     preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
       - echo "after kubeadm call" > /var/log/postkubeadm.log
@@ -192,6 +193,7 @@ spec:
             - ${NUTANIX_SSH_AUTHORIZED_KEY}
       preKubeadmCommands:
         - echo "before kubeadm call" > /var/log/prekubeadm.log
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       postKubeadmCommands:
         - echo "after kubeadm call" > /var/log/postkubeadm.log
       verbosity: 10

--- a/templates/cluster-template-ccm.yaml
+++ b/templates/cluster-template-ccm.yaml
@@ -281,6 +281,7 @@ spec:
       - echo "after kubeadm call" > /var/log/postkubeadm.log
       preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       users:
       - lockPassword: false
         name: capiuser
@@ -482,6 +483,7 @@ spec:
     - echo "after kubeadm call" > /var/log/postkubeadm.log
     preKubeadmCommands:
     - echo "before kubeadm call" > /var/log/prekubeadm.log
+    - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
     useExperimentalRetryJoin: true
     users:
     - lockPassword: false

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1363,6 +1363,7 @@ spec:
       - echo "after kubeadm call" > /var/log/postkubeadm.log
       preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       users:
       - lockPassword: false
         name: capiuser
@@ -1561,6 +1562,7 @@ spec:
     - echo "after kubeadm call" > /var/log/postkubeadm.log
     preKubeadmCommands:
     - echo "before kubeadm call" > /var/log/prekubeadm.log
+    - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
     useExperimentalRetryJoin: true
     users:
     - lockPassword: false

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -33,6 +33,7 @@ spec:
       - echo "after kubeadm call" > /var/log/postkubeadm.log
       preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       users:
       - lockPassword: false
         name: capiuser
@@ -230,6 +231,7 @@ spec:
     - echo "after kubeadm call" > /var/log/postkubeadm.log
     preKubeadmCommands:
     - echo "before kubeadm call" > /var/log/prekubeadm.log
+    - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
     useExperimentalRetryJoin: true
     users:
     - lockPassword: false

--- a/test/e2e/data/infrastructure-nutanix/v1alpha4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1alpha4/bases/cluster-with-kcp.yaml
@@ -199,6 +199,7 @@ spec:
           - ${NUTANIX_SSH_AUTHORIZED_KEY}
     preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
       - echo "after kubeadm call" > /var/log/postkubeadm.log
@@ -229,6 +230,7 @@ spec:
             - ${NUTANIX_SSH_AUTHORIZED_KEY}
       preKubeadmCommands:
         - echo "before kubeadm call" > /var/log/prekubeadm.log
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       postKubeadmCommands:
         - echo "after kubeadm call" > /var/log/postkubeadm.log
       verbosity: 10

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
@@ -8,6 +8,7 @@ spec:
   kubeadmConfigSpec:
     preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       - apt update
       - apt install -y nfs-common open-iscsi lvm2 xfsprogs
       - systemctl enable --now iscsid

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kct.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kct.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       preKubeadmCommands:
         - echo "before kubeadm call" > /var/log/prekubeadm.log
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
         - apt update
         - apt install -y nfs-common open-iscsi lvm2 xfsprogs
         - systemctl enable --now iscsid


### PR DESCRIPTION
**What this PR does / why we need it**:

inject the hostname into cloud-init metadata to push the info inside each VM
use cloud-init macro to retrieve metadata.hostname and set the hostname inside each OS during boot


**Which issue(s) this PR fixes**:

deployment of a CAPI cluster failed on non Nutanix IPAM network with all VM keeping `localhost` hostname


**How Has This Been Tested?**:

deploy a CAPX cluster on a non IPAM network => OK

e2e tests => OK

```
make test-e2e-calico

Ran 24 of 25 Specs in 7978.692 seconds
SUCCESS! -- 24 Passed | 0 Failed | 0 Pending | 1 Skipped
PASS
```

**Release note**:
```release-note
inject hostname through metadata
```