### PR TITLE
update CAPI version for e2e tests

### DIFF
--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -13,11 +13,11 @@ images:
     loadBehavior: mustLoad
   # ## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
   # Cluster API v1beta1 Preloads
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.2.0
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.2.0
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.2.0
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.2
     loadBehavior: tryLoad
 
 providers:
@@ -42,9 +42,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.2.0
+      - name: v1.3.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -73,9 +73,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.2.0
+      - name: v1.3.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -104,9 +104,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.2.0
+      - name: v1.3.2
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -223,7 +223,7 @@ variables:
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
   # NOTE: We test the latest release with a previous contract.
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.4/clusterctl-{OS}-{ARCH}"
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-{OS}-{ARCH}"
   #INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
   #INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
   INIT_WITH_KUBERNETES_VERSION: "v1.23.6"

--- a/test/e2e/data/shared/metadata.yaml
+++ b/test/e2e/data/shared/metadata.yaml
@@ -8,7 +8,7 @@ releaseSeries:
     minor: 4
     contract: v1alpha4
   - major: 1
-    minor: 2
+    minor: 3
     contract: v1beta1
   - major: 0
     minor: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows e2e to run with latest CAPI version (1.3.2). Currently 1.2.0 is used.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:

e2e test results:
```
an 24 of 25 Specs in 8225.111 seconds
SUCCESS! -- 24 Passed | 0 Failed | 0 Pending | 1 Skipped
PASS
```

**Special notes for your reviewer**:
N/A

**Release note**:
NONE