### PR TITLE
Change default max-concurrent-reconciles to 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,16 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+RUN_VALIDATION_TESTS_ONLY?=false # for CI please set EXPORT_RESULT to true
 LABEL_FILTERS ?=
+ifeq ($(RUN_VALIDATION_TESTS_ONLY), true)
+		LABEL_FILTER_ARGS = "only-for-validation"
+else
+		LABEL_FILTER_ARGS = "!only-for-validation"
+endif
+ifneq ($(LABEL_FILTERS),)
+		LABEL_FILTER_ARGS += "&& $(LABEL_FILTERS)"
+endif
 JUNIT_REPORT_FILE ?= "junit.e2e_suite.1.xml"
 GINKGO_SKIP ?= "clusterctl-Upgrade"
 GINKGO_NODES  ?= 1
@@ -365,7 +374,7 @@ test-e2e: docker-build-e2e $(GINKGO_BIN) cluster-e2e-templates cluster-templates
 		--trace \
 		--progress \
 		--tags=e2e \
-		--label-filter="$(LABEL_FILTERS) && !only-for-validation" \
+		--label-filter=$(LABEL_FILTER_ARGS) \
 		$(_SKIP_ARGS) \
 		--nodes=$(GINKGO_NODES) \
 		--no-color=$(GINKGO_NOCOLOR) \

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ test-e2e: docker-build-e2e $(GINKGO_BIN) cluster-e2e-templates cluster-templates
 		--trace \
 		--progress \
 		--tags=e2e \
-		--label-filter="$(LABEL_FILTERS)" \
+		--label-filter="$(LABEL_FILTERS) && !only-for-validation" \
 		$(_SKIP_ARGS) \
 		--nodes=$(GINKGO_NODES) \
 		--no-color=$(GINKGO_NOCOLOR) \

--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	//"reflect"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,29 +54,37 @@ type NutanixClusterReconciler struct {
 	SecretInformer    coreinformers.SecretInformer
 	ConfigMapInformer coreinformers.ConfigMapInformer
 	Scheme            *runtime.Scheme
+	controllerConfig  *ControllerConfig
 }
 
-func NewNutanixClusterReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme) *NutanixClusterReconciler {
+func NewNutanixClusterReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme, copts ...ControllerConfigOpts) (*NutanixClusterReconciler, error) {
+	controllerConf := &ControllerConfig{}
+	for _, opt := range copts {
+		if err := opt(controllerConf); err != nil {
+			return nil, err
+		}
+	}
 	return &NutanixClusterReconciler{
 		Client:            client,
 		SecretInformer:    secretInformer,
 		ConfigMapInformer: configMapInformer,
 		Scheme:            scheme,
-	}
+		controllerConfig:  controllerConf,
+	}, nil
 }
 
 // SetupWithManager sets up the NutanixCluster controller with the Manager.
 func (r *NutanixClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	log := ctrl.LoggerFrom(ctx)
-	controller, err := ctrl.NewControllerManagedBy(mgr).
-		// Watch the controlled, infrastructure resource.
-		For(&infrav1.NutanixCluster{}).
+	c, err := ctrl.NewControllerManagedBy(mgr).
+		For(&infrav1.NutanixCluster{}). // Watch the controlled, infrastructure resource.
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.controllerConfig.MaxConcurrentReconciles}).
 		Build(r)
 	if err != nil {
 		return err
 	}
 
-	if err = controller.Watch(
+	if err = c.Watch(
 		// Watch the CAPI resource that owns this infrastructure resource.
 		&source.Kind{Type: &capiv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -113,7 +113,7 @@ func (r *NutanixMachineReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			&source.Kind{Type: &infrav1.NutanixCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapNutanixClusterToNutanixMachines(ctx)),
 		).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.controllerConfig.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -76,19 +77,29 @@ type NutanixMachineReconciler struct {
 	SecretInformer    coreinformers.SecretInformer
 	ConfigMapInformer coreinformers.ConfigMapInformer
 	Scheme            *runtime.Scheme
+	controllerConfig  *ControllerConfig
 }
 
-func NewNutanixMachineReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme) *NutanixMachineReconciler {
+func NewNutanixMachineReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme, copts ...ControllerConfigOpts) (*NutanixMachineReconciler, error) {
+	controllerConf := &ControllerConfig{}
+	for _, opt := range copts {
+		if err := opt(controllerConf); err != nil {
+			return nil, err
+		}
+	}
+
 	return &NutanixMachineReconciler{
 		Client:            client,
 		SecretInformer:    secretInformer,
 		ConfigMapInformer: configMapInformer,
 		Scheme:            scheme,
-	}
+		controllerConfig:  controllerConf,
+	}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *NutanixMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *NutanixMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, copts ...ControllerConfigOpts) error {
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.NutanixMachine{}).
 		// Watch the CAPI resource that owns this infrastructure resource.
@@ -102,6 +113,7 @@ func (r *NutanixMachineReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			&source.Kind{Type: &infrav1.NutanixCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapNutanixClusterToNutanixMachines(ctx)),
 		).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(r)
 }
 

--- a/controllers/options.go
+++ b/controllers/options.go
@@ -1,0 +1,22 @@
+package controllers
+
+import "errors"
+
+// ControllerConfig is the configuration for cluster and machine controllers
+type ControllerConfig struct {
+	MaxConcurrentReconciles int
+}
+
+// ControllerConfigOpts is a function that can be used to configure the controller config
+type ControllerConfigOpts func(*ControllerConfig) error
+
+// WithMaxConcurrentReconciles sets the maximum number of concurrent reconciles
+func WithMaxConcurrentReconciles(max int) ControllerConfigOpts {
+	return func(c *ControllerConfig) error {
+		if max < 1 {
+			return errors.New("max concurrent reconciles must be greater than 0")
+		}
+		c.MaxConcurrentReconciles = max
+		return nil
+	}
+}

--- a/controllers/options_test.go
+++ b/controllers/options_test.go
@@ -1,0 +1,39 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithMaxConcurrentReconciles(t *testing.T) {
+	tests := []struct {
+		name                    string
+		MaxConcurrentReconciles int
+		expectError             bool
+	}{
+		{
+			name:                    "TestWithMaxConcurrentReconcilesSetTo0",
+			MaxConcurrentReconciles: 0,
+			expectError:             true,
+		},
+		{
+			name:                    "TestWithMaxConcurrentReconcilesSetTo10",
+			MaxConcurrentReconciles: 10,
+			expectError:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithMaxConcurrentReconciles(tt.MaxConcurrentReconciles)
+			config := &ControllerConfig{}
+			err := opt(config)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.MaxConcurrentReconciles, config.MaxConcurrentReconciles)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.2
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
@@ -92,6 +93,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -108,7 +108,7 @@ var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas 
 
 		Expect(clusterResources.MachineDeployments[0].Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 
-		By("Scaling the MachineDeployment out to 3")
+		By("Scaling the MachineDeployment out to 50")
 		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
 			ClusterProxy:              input.BootstrapClusterProxy,
 			Cluster:                   clusterResources.Cluster,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -20,9 +20,19 @@ limitations under the License.
 package e2e
 
 import (
-	. "github.com/onsi/ginkgo/v2"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-out-in", "slow", "network"), func() {
@@ -34,5 +44,91 @@ var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
 		}
+	})
+})
+
+// Label `only-for-validation` is used to run this test only for validation and not as part of the regular test suite.
+var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas to 1", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
+	// MachineDeploymentScaleSpec implements a test that verifies that MachineDeployment scale operations are successful.
+	var inputGetter = func() capi_e2e.MachineDeploymentScaleSpecInput {
+		return capi_e2e.MachineDeploymentScaleSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	}
+	var (
+		specName = "md-scale-up-down-50-nodes"
+
+		input            capi_e2e.MachineDeploymentScaleSpecInput
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersion)))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should successfully scale a MachineDeployment up and down upon changes to the MachineDeployment replica count", func() {
+		By("Creating a workload cluster")
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   input.Flavor,
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			ControlPlaneWaiters:          input.ControlPlaneWaiters,
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		Expect(clusterResources.MachineDeployments[0].Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+
+		By("Scaling the MachineDeployment out to 3")
+		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			MachineDeployment:         clusterResources.MachineDeployments[0],
+			Replicas:                  50,
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+		By("Scaling the MachineDeployment down to 1")
+		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			MachineDeployment:         clusterResources.MachineDeployments[0],
+			Replicas:                  1,
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
 	})
 })

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -48,7 +48,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-
 })
 
 // Label `only-for-validation` is used to run this test only for validation and not as part of the regular test suite.
-var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas to 1", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
+var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
 	// MachineDeploymentScaleSpec implements a test that verifies that MachineDeployment scale operations are successful.
 	var inputGetter = func() capi_e2e.MachineDeploymentScaleSpecInput {
 		return capi_e2e.MachineDeploymentScaleSpecInput{
@@ -60,7 +60,7 @@ var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas 
 		}
 	}
 	var (
-		specName = "md-scale-up-down-50-nodes"
+		specName = "md-scale-up-down-10-20-10-nodes"
 
 		input            capi_e2e.MachineDeploymentScaleSpecInput
 		namespace        *corev1.Namespace
@@ -98,7 +98,7 @@ var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas 
 				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
 				ControlPlaneMachineCount: pointer.Int64Ptr(1),
-				WorkerMachineCount:       pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(10),
 			},
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
@@ -106,22 +106,22 @@ var _ = Describe("When testing MachineDeployment scale up/down from 50 replicas 
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, clusterResources)
 
-		Expect(clusterResources.MachineDeployments[0].Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+		Expect(clusterResources.MachineDeployments[0].Spec.Replicas).To(Equal(pointer.Int32Ptr(10)))
 
-		By("Scaling the MachineDeployment out to 50")
+		By("Scaling the MachineDeployment out to 20")
 		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
 			ClusterProxy:              input.BootstrapClusterProxy,
 			Cluster:                   clusterResources.Cluster,
 			MachineDeployment:         clusterResources.MachineDeployments[0],
-			Replicas:                  50,
+			Replicas:                  20,
 			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		})
-		By("Scaling the MachineDeployment down to 1")
+		By("Scaling the MachineDeployment down to 10")
 		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
 			ClusterProxy:              input.BootstrapClusterProxy,
 			Cluster:                   clusterResources.Cluster,
 			MachineDeployment:         clusterResources.MachineDeployments[0],
-			Replicas:                  1,
+			Replicas:                  10,
 			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		})
 		By("PASSED!")


### PR DESCRIPTION
Change Max Concurrent Reconciles set to 10 for Cluster and Machine reconciliation. To validate the impact of this change on the behavior of the controller, this PR adds a Ginkgo suite with a label `only-for-validation`, which by default gets ignored when running e2e tests. This ensures the test can be manually run using the label but doesn't overwhelm the CI environment by causing resource starvation. To trigger the validation tests, `RUN_VALIDATION_TESTS_ONLY` must be set to `true` as shown in examples below.

To verify the impact of changes, we timed the runs for the added scale up/down validation test with and without the max reconcile tweaks. Here are the results:
* Running with max reconciles set to 10 (i.e. This PR)
```
$ time RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico
Ginkgo ran 1 suite in 7m22.064857212s
Test Suite Passed
RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico  54.47s user 19.21s system 15% cpu 7:52.70 total
```
* Running without max reconciles being set at all (i.e. as in the current HEAD of the main branch prior to this PR)
```
$ time RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico
Ginkgo ran 1 suite in 13m30.780343883s
Test Suite Passed
RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico  56.56s user 21.88s system 9% cpu 14:03.76 total
```

**How has this been tested?**
Added a new e2e test with a label `only-for-validation`. This test scales the MachineDeployment replicas from 10 to 20 and back to 10 again to ensure no weird regressions occur. These replicas are set to 20 as it was deemed a reasonable number to exercise the default max-concurrent-reconcile value of 10.
```
$ RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico
...
When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again
  Should successfully scale a MachineDeployment up and down upon changes to the MachineDeployment replica count [md-scale-up-down, slow, network, only-for-validation]
STEP: Creating a namespace for hosting the "md-scale-up-down-10-20-10-nodes" test spec 02/01/23 22:20:10.375
STEP: Creating a workload cluster 02/01/23 22:20:10.396
STEP: Waiting for cluster to enter the provisioned phase 02/01/23 22:20:12.529
STEP: Waiting for one control plane node to exist 02/01/23 22:20:32.562
STEP: Waiting for the control plane to be ready 02/01/23 22:21:22.648
STEP: Checking all the the control plane machines are in the expected failure domains 02/01/23 22:21:42.667
STEP: Waiting for the workload nodes to exist 02/01/23 22:21:42.694
STEP: Checking all the machines controlled by md-scale-up-down-10-20-10-nodes-el5rr2-wmd are in the "<None>" failure domain 02/01/23 22:22:22.773
STEP: Scaling the MachineDeployment out to 20 02/01/23 22:22:22.813
STEP: Scaling the MachineDeployment down to 10 02/01/23 22:23:23.162
STEP: PASSED! 02/01/23 22:23:53.409
...
Ran 1 of 26 Specs in 393.119 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 25 Skipped
PASS

Ginkgo ran 1 suite in 6m43.219978625s
Test Suite Passed
```
Running the regular CAPX feature tests to ensure that existing e2e tests don't notice any unexpected behavior with the change.
```
$ RUN_VALIDATION_TESTS_ONLY=true make test-e2e-calico
...
Ran 14 of 26 Specs in 2461.006 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 12 Skipped
--- PASS: TestE2E (2461.02s)
```