### PR TITLE
Revert "Revert "Change default max-concurrent-reconciles to 10 (#208)…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,16 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+RUN_VALIDATION_TESTS_ONLY?=false # for CI please set EXPORT_RESULT to true
 LABEL_FILTERS ?=
+ifeq ($(RUN_VALIDATION_TESTS_ONLY), true)
+		LABEL_FILTER_ARGS = "only-for-validation"
+else
+		LABEL_FILTER_ARGS = "!only-for-validation"
+endif
+ifneq ($(LABEL_FILTERS),)
+		LABEL_FILTER_ARGS += "&& $(LABEL_FILTERS)"
+endif
 JUNIT_REPORT_FILE ?= "junit.e2e_suite.1.xml"
 GINKGO_SKIP ?= "clusterctl-Upgrade"
 GINKGO_NODES  ?= 1
@@ -365,7 +374,7 @@ test-e2e: docker-build-e2e $(GINKGO_BIN) cluster-e2e-templates cluster-templates
 		--trace \
 		--progress \
 		--tags=e2e \
-		--label-filter="$(LABEL_FILTERS)" \
+		--label-filter=$(LABEL_FILTER_ARGS) \
 		$(_SKIP_ARGS) \
 		--nodes=$(GINKGO_NODES) \
 		--no-color=$(GINKGO_NOCOLOR) \

--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	//"reflect"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,29 +54,37 @@ type NutanixClusterReconciler struct {
 	SecretInformer    coreinformers.SecretInformer
 	ConfigMapInformer coreinformers.ConfigMapInformer
 	Scheme            *runtime.Scheme
+	controllerConfig  *ControllerConfig
 }
 
-func NewNutanixClusterReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme) *NutanixClusterReconciler {
+func NewNutanixClusterReconciler(client client.Client, secretInformer coreinformers.SecretInformer, configMapInformer coreinformers.ConfigMapInformer, scheme *runtime.Scheme, copts ...ControllerConfigOpts) (*NutanixClusterReconciler, error) {
+	controllerConf := &ControllerConfig{}
+	for _, opt := range copts {
+		if err := opt(controllerConf); err != nil {
+			return nil, err
+		}
+	}
 	return &NutanixClusterReconciler{
 		Client:            client,
 		SecretInformer:    secretInformer,
 		ConfigMapInformer: configMapInformer,
 		Scheme:            scheme,
-	}
+		controllerConfig:  controllerConf,
+	}, nil
 }
 
 // SetupWithManager sets up the NutanixCluster controller with the Manager.
 func (r *NutanixClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	log := ctrl.LoggerFrom(ctx)
-	controller, err := ctrl.NewControllerManagedBy(mgr).
-		// Watch the controlled, infrastructure resource.
-		For(&infrav1.NutanixCluster{}).
+	c, err := ctrl.NewControllerManagedBy(mgr).
+		For(&infrav1.NutanixCluster{}). // Watch the controlled, infrastructure resource.
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.controllerConfig.MaxConcurrentReconciles}).
 		Build(r)
 	if err != nil {
 		return err
 	}
 
-	if err = controller.Watch(
+	if err = c.Watch(
 		// Watch the CAPI resource that owns this infrastructure resource.
 		&source.Kind{Type: &capiv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(

--- a/controllers/options.go
+++ b/controllers/options.go
@@ -1,0 +1,22 @@
+package controllers
+
+import "errors"
+
+// ControllerConfig is the configuration for cluster and machine controllers
+type ControllerConfig struct {
+	MaxConcurrentReconciles int
+}
+
+// ControllerConfigOpts is a function that can be used to configure the controller config
+type ControllerConfigOpts func(*ControllerConfig) error
+
+// WithMaxConcurrentReconciles sets the maximum number of concurrent reconciles
+func WithMaxConcurrentReconciles(max int) ControllerConfigOpts {
+	return func(c *ControllerConfig) error {
+		if max < 1 {
+			return errors.New("max concurrent reconciles must be greater than 0")
+		}
+		c.MaxConcurrentReconciles = max
+		return nil
+	}
+}

--- a/controllers/options_test.go
+++ b/controllers/options_test.go
@@ -1,0 +1,39 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithMaxConcurrentReconciles(t *testing.T) {
+	tests := []struct {
+		name                    string
+		MaxConcurrentReconciles int
+		expectError             bool
+	}{
+		{
+			name:                    "TestWithMaxConcurrentReconcilesSetTo0",
+			MaxConcurrentReconciles: 0,
+			expectError:             true,
+		},
+		{
+			name:                    "TestWithMaxConcurrentReconcilesSetTo10",
+			MaxConcurrentReconciles: 10,
+			expectError:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithMaxConcurrentReconciles(tt.MaxConcurrentReconciles)
+			config := &ControllerConfig{}
+			err := opt(config)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.MaxConcurrentReconciles, config.MaxConcurrentReconciles)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.2
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
@@ -92,6 +93,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -20,9 +20,19 @@ limitations under the License.
 package e2e
 
 import (
-	. "github.com/onsi/ginkgo/v2"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-out-in", "slow", "network"), func() {
@@ -34,5 +44,91 @@ var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
 		}
+	})
+})
+
+// Label `only-for-validation` is used to run this test only for validation and not as part of the regular test suite.
+var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
+	// MachineDeploymentScaleSpec implements a test that verifies that MachineDeployment scale operations are successful.
+	var inputGetter = func() capi_e2e.MachineDeploymentScaleSpecInput {
+		return capi_e2e.MachineDeploymentScaleSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	}
+	var (
+		specName = "md-scale-up-down-10-20-10-nodes"
+
+		input            capi_e2e.MachineDeploymentScaleSpecInput
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersion)))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should successfully scale a MachineDeployment up and down upon changes to the MachineDeployment replica count", func() {
+		By("Creating a workload cluster")
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   input.Flavor,
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(10),
+			},
+			ControlPlaneWaiters:          input.ControlPlaneWaiters,
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		Expect(clusterResources.MachineDeployments[0].Spec.Replicas).To(Equal(pointer.Int32Ptr(10)))
+
+		By("Scaling the MachineDeployment out to 20")
+		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			MachineDeployment:         clusterResources.MachineDeployments[0],
+			Replicas:                  20,
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+		By("Scaling the MachineDeployment down to 10")
+		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			MachineDeployment:         clusterResources.MachineDeployments[0],
+			Replicas:                  10,
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
 	})
 })


### PR DESCRIPTION
Revert the revert done in (#214)

In #214 we reverted an earlier commit to diagnose if that commit was the cause of our failing E2E tests as it happened to synchronize with when our E2Es started failing. We are now reverting that revert as we have concluded that the change we reverted was not the cause of our internal e2es failing.

This reverts commit eacd258f5aa130d08954ba50d4beb2a4c1c35ec1.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```