### PR TITLE
Change the VM Name to that of Machine instead of NutanixMachine

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -94,7 +94,7 @@ func GenerateProviderID(uuid string) string {
 }
 
 // GetVMUUID returns the UUID of the VM with the given name
-func GetVMUUID(ctx context.Context, nutanixMachine *infrav1.NutanixMachine) (string, error) {
+func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
 	vmUUID := nutanixMachine.Status.VmUUID
 	if vmUUID != "" {
 		if _, err := uuid.Parse(vmUUID); err != nil {
@@ -116,9 +116,8 @@ func GetVMUUID(ctx context.Context, nutanixMachine *infrav1.NutanixMachine) (str
 }
 
 // FindVM retrieves the VM with the given uuid or name
-func FindVM(ctx context.Context, client *nutanixClientV3.Client, nutanixMachine *infrav1.NutanixMachine) (*nutanixClientV3.VMIntentResponse, error) {
-	vmName := nutanixMachine.Name
-	vmUUID, err := GetVMUUID(ctx, nutanixMachine)
+func FindVM(ctx context.Context, client *nutanixClientV3.Client, nutanixMachine *infrav1.NutanixMachine, vmName string) (*nutanixClientV3.VMIntentResponse, error) {
+	vmUUID, err := GetVMUUID(nutanixMachine)
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +134,13 @@ func FindVM(ctx context.Context, client *nutanixClientV3.Client, nutanixMachine 
 			klog.Error(errorMsg)
 			return nil, fmt.Errorf(errorMsg)
 		}
-		if *vm.Spec.Name != vmName {
-			errorMsg := fmt.Sprintf("found VM with UUID %s but name did not match %s. error: %v", vmUUID, vmName, err)
+		// Check if the VM name matches the Machine name or the NutanixMachine name.
+		// Earlier, we were creating VMs with the same name as the NutanixMachine name.
+		// Now, we create VMs with the same name as the Machine name in line with other CAPI providers.
+		// This check is to ensure that we are deleting the correct VM for both cases as older CAPX VMs
+		// will have the NutanixMachine name as the VM name.
+		if *vm.Spec.Name != vmName && *vm.Spec.Name != nutanixMachine.Name {
+			errorMsg := fmt.Sprintf("found VM with UUID %s but name %s did not match %s. error: %v", vmUUID, *vm.Spec.Name, vmName, err)
 			klog.Errorf(errorMsg)
 			return nil, fmt.Errorf(errorMsg)
 		}

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -614,7 +614,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 
 	// Generate metadata for the VM
 	vmUUID := uuid.New()
-	metadata := fmt.Sprintf("{\"hostname\": \"%s\", \"vmUUID\": \"%s\"}", rctx.Machine.Name, vmUUID)
+	metadata := fmt.Sprintf("{\"hostname\": \"%s\", \"uuid\": \"%s\"}", rctx.Machine.Name, vmUUID)
 	// Encode the metadata by base64
 	metadataEncoded := base64.StdEncoding.EncodeToString([]byte(metadata))
 


### PR DESCRIPTION
CAPI expects the underlying compute machines to be named after the machines and not provider machines. This is particularly important in cases where we do not have control over cloud-init e.g. bottlerocket or RHCOS. Until this PR
is merged, we are technically not CAPI compliant.

**How has this been tested?**
Given the nature of this change we had to validate the change for both greenfield and brownfield scenarios.
- Greenfield (i.e. Do our E2E tests pass with this change?): Yes
```
$ LABEL_FILTERS="capx-feature-test"  make test-e2e-calico
Ran 14 of 26 Specs in 1923.520 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS
```
- Brownfield (Will this change work for existing CAPX clusters?): Yes; Thanks @yannickstruyf3 for validating
1. Create a CAPX cluster with a CAPX build from the main branch
```
$ kubectl get machines
NAME                             CLUSTER     NODENAME               PROVIDERID                                       PHASE     AGE     VERSION
test-name-kcp-czfv2              test-name   test-name-mt-0-k7hpr   nutanix://189fb7b2-e98a-434a-9d3f-9be8dc09674e   Running   9m13s   v1.25.6
test-name-kcp-fbk5f              test-name   test-name-mt-0-n6n8f   nutanix://af6b734e-397b-4d96-9ba9-8adb78a75d35   Running   82s     v1.25.6
test-name-kcp-ldmhq              test-name   test-name-mt-0-ml9m7   nutanix://6c8cc616-aa52-468d-b355-01205d7d294b   Running   4m18s   v1.25.6
test-name-wmd-866757d899-76lcd   test-name   test-name-mt-0-28j62   nutanix://ca9d3f9b-6624-45dc-b3b6-9f8dd0656409   Running   11m     v1.25.6
test-name-wmd-866757d899-pjvgm   test-name   test-name-mt-0-6djdl   nutanix://b5dc5929-0412-4b9c-92b9-d4f49beefae2   Running   11m     v1.25.6
test-name-wmd-866757d899-v8w8h   test-name   test-name-mt-0-7llxr   nutanix://4a36178f-931a-4516-b660-9623ef415111   Running   11m     v1.25.6
```
2. Upgrade the CAPX version on the cluster to the version from this branch and ensure cluster is healthy i.e. existing nodes are okay
3. Add a node and ensure the new node comes up with a name matching updated naming scheme
```
$ kubectl get machines
NAME                             CLUSTER     NODENAME                         PROVIDERID                                       PHASE     AGE     VERSION
test-name-kcp-czfv2              test-name   test-name-mt-0-k7hpr             nutanix://189fb7b2-e98a-434a-9d3f-9be8dc09674e   Running   21m     v1.25.6
test-name-kcp-fbk5f              test-name   test-name-mt-0-n6n8f             nutanix://af6b734e-397b-4d96-9ba9-8adb78a75d35   Running   13m     v1.25.6
test-name-kcp-ldmhq              test-name   test-name-mt-0-ml9m7             nutanix://6c8cc616-aa52-468d-b355-01205d7d294b   Running   16m     v1.25.6
test-name-wmd-866757d899-76lcd   test-name   test-name-mt-0-28j62             nutanix://ca9d3f9b-6624-45dc-b3b6-9f8dd0656409   Running   23m     v1.25.6
test-name-wmd-866757d899-gth7v   test-name   test-name-wmd-866757d899-gth7v   nutanix://259ac161-ad27-45f9-ae67-9d6085a518da   Running   6m14s   v1.25.6
test-name-wmd-866757d899-pjvgm   test-name   test-name-mt-0-6djdl             nutanix://b5dc5929-0412-4b9c-92b9-d4f49beefae2   Running   23m     v1.25.6
test-name-wmd-866757d899-v8w8h   test-name   test-name-mt-0-7llxr             nutanix://4a36178f-931a-4516-b660-9623ef415111   Running   23m     v1.25.6
```
4. Upgrade the kubernetes version and ensure rolling upgrade sets all nodes to updated naming scheme
```
NAME                             CLUSTER     NODENAME                         PROVIDERID                                       PHASE     AGE     VERSION
test-name-kcp-8d9fx              test-name   test-name-kcp-8d9fx              nutanix://2f4b4dda-2461-418c-a79e-0df510905066   Running   18m     v1.26.1
test-name-kcp-brtbn              test-name   test-name-kcp-brtbn              nutanix://f99ca959-9c24-46bb-9575-a491be8338ef   Running   21m     v1.26.1
test-name-kcp-pt56z              test-name   test-name-kcp-pt56z              nutanix://6e7c9ea0-a53e-40be-aa4a-c289334cfa8a   Running   24m     v1.26.1
test-name-wmd-578c54c488-cr462   test-name   test-name-wmd-578c54c488-cr462   nutanix://b61cbbef-d8be-43c1-8b60-df7bf15384bd   Running   6m52s   v1.26.1
test-name-wmd-578c54c488-hf4b6   test-name   test-name-wmd-578c54c488-hf4b6   nutanix://e837a2ad-f8ae-46cf-a6cd-bb749003751b   Running   2m18s   v1.26.1
test-name-wmd-578c54c488-j8nlx   test-name   test-name-wmd-578c54c488-j8nlx   nutanix://ab0d36ad-9e25-4a77-9776-f5ae38a370e6   Running   14m     v1.26.1
test-name-wmd-578c54c488-khg87   test-name   test-name-wmd-578c54c488-khg87   nutanix://366b8082-990c-4f8e-b629-f499a8ce8017   Running   4m15s   v1.26.1
```