### PR TITLE
Ensure Optional types are tagged with omitempty json notation

### DIFF
--- a/api/v1alpha4/nutanix_types.go
+++ b/api/v1alpha4/nutanix_types.go
@@ -19,6 +19,9 @@ package v1alpha4
 // NutanixIdentifierType is an enumeration of different resource identifier types.
 type NutanixIdentifierType string
 
+// NutanixBootType is an enumeration of different boot types.
+type NutanixBootType string
+
 const (
 	// NutanixIdentifierUUID is a resource identifier identifying the object by UUID.
 	NutanixIdentifierUUID NutanixIdentifierType = "uuid"
@@ -26,11 +29,11 @@ const (
 	// NutanixIdentifierName is a resource identifier identifying the object by Name.
 	NutanixIdentifierName NutanixIdentifierType = "name"
 
-	// NutanixIdentifierBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
-	NutanixIdentifierBootTypeLegacy NutanixIdentifierType = "legacy"
+	// NutanixBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
+	NutanixBootTypeLegacy NutanixBootType = "legacy"
 
-	// NutanixIdentifierBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
-	NutanixIdentifierBootTypeUEFI NutanixIdentifierType = "uefi"
+	// NutanixBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
+	NutanixBootTypeUEFI NutanixBootType = "uefi"
 
 	// DefaultCAPICategoryPrefix is the default category prefix used for CAPI clusters.
 	DefaultCAPICategoryPrefix = "kubernetes-io-cluster-"

--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -71,14 +71,14 @@ type NutanixMachineSpec struct {
 	Subnets []NutanixResourceIdentifier `json:"subnet"`
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
-	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
+	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories,omitempty"`
 	// Add the machine resources to a Prism Central project
 	// +optional
-	Project *NutanixResourceIdentifier `json:"project"`
+	Project *NutanixResourceIdentifier `json:"project,omitempty"`
 	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:=legacy;uefi
-	BootType string `json:"bootType"`
+	BootType NutanixBootType `json:"bootType,omitempty"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -426,7 +426,7 @@ func autoConvert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *N
 	out.Subnets = *(*[]v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]v1beta1.NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
 	out.Project = (*v1beta1.NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
-	out.BootType = in.BootType
+	out.BootType = v1beta1.NutanixBootType(in.BootType)
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil
@@ -446,7 +446,7 @@ func autoConvert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *v
 	out.Subnets = *(*[]NutanixResourceIdentifier)(unsafe.Pointer(&in.Subnets))
 	out.AdditionalCategories = *(*[]NutanixCategoryIdentifier)(unsafe.Pointer(&in.AdditionalCategories))
 	out.Project = (*NutanixResourceIdentifier)(unsafe.Pointer(in.Project))
-	out.BootType = in.BootType
+	out.BootType = NutanixBootType(in.BootType)
 	out.SystemDiskSize = in.SystemDiskSize
 	out.BootstrapRef = (*v1.ObjectReference)(unsafe.Pointer(in.BootstrapRef))
 	return nil

--- a/api/v1beta1/nutanix_types.go
+++ b/api/v1beta1/nutanix_types.go
@@ -19,6 +19,9 @@ package v1beta1
 // NutanixIdentifierType is an enumeration of different resource identifier types.
 type NutanixIdentifierType string
 
+// NutanixBootType is an enumeration of different boot types.
+type NutanixBootType string
+
 const (
 	// NutanixIdentifierUUID is a resource identifier identifying the object by UUID.
 	NutanixIdentifierUUID NutanixIdentifierType = "uuid"
@@ -26,11 +29,11 @@ const (
 	// NutanixIdentifierName is a resource identifier identifying the object by Name.
 	NutanixIdentifierName NutanixIdentifierType = "name"
 
-	// NutanixIdentifierBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
-	NutanixIdentifierBootTypeLegacy NutanixIdentifierType = "legacy"
+	// NutanixBootTypeLegacy is a resource identifier identifying the legacy boot type for virtual machines.
+	NutanixBootTypeLegacy NutanixBootType = "legacy"
 
-	// NutanixIdentifierBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
-	NutanixIdentifierBootTypeUEFI NutanixIdentifierType = "uefi"
+	// NutanixBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
+	NutanixBootTypeUEFI NutanixBootType = "uefi"
 
 	// DefaultCAPICategoryPrefix is the default category prefix used for CAPI clusters.
 	DefaultCAPICategoryPrefix = "kubernetes-io-cluster-"

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -71,14 +71,14 @@ type NutanixMachineSpec struct {
 	Subnets []NutanixResourceIdentifier `json:"subnet"`
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
-	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories"`
+	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories,omitempty"`
 	// Add the machine resources to a Prism Central project
 	// +optional
-	Project *NutanixResourceIdentifier `json:"project"`
+	Project *NutanixResourceIdentifier `json:"project,omitempty"`
 	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:=legacy;uefi
-	BootType string `json:"bootType"`
+	BootType NutanixBootType `json:"bootType,omitempty"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM
 	// The minimum systemDiskSize is 20Gi bytes

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -831,17 +831,17 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 	bootType := rctx.NutanixMachine.Spec.BootType
 	// Defaults to legacy if boot type is not set.
 	if bootType != "" {
-		if bootType != string(infrav1.NutanixIdentifierBootTypeLegacy) && bootType != string(infrav1.NutanixIdentifierBootTypeUEFI) {
-			errorMsg := fmt.Errorf("%s boot type must be %s or %s but was %s", rctx.LogPrefix, string(infrav1.NutanixIdentifierBootTypeLegacy), string(infrav1.NutanixIdentifierBootTypeUEFI), bootType)
+		if bootType != infrav1.NutanixBootTypeLegacy && bootType != infrav1.NutanixBootTypeUEFI {
+			errorMsg := fmt.Errorf("%s boot type must be %s or %s but was %s", rctx.LogPrefix, string(infrav1.NutanixBootTypeLegacy), string(infrav1.NutanixBootTypeUEFI), bootType)
 			klog.Error(errorMsg)
 			conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.VMBootTypeInvalid, capiv1.ConditionSeverityError, errorMsg.Error())
 			return errorMsg
 		}
 
 		// Only modify VM spec if boot type is UEFI. Otherwise, assume default Legacy mode
-		if bootType == string(infrav1.NutanixIdentifierBootTypeUEFI) {
+		if bootType == infrav1.NutanixBootTypeUEFI {
 			vmSpec.Resources.BootConfig = &nutanixClientV3.VMBootConfig{
-				BootType: utils.StringPtr(strings.ToUpper(bootType)),
+				BootType: utils.StringPtr(strings.ToUpper(string(bootType))),
 			}
 		}
 	}


### PR DESCRIPTION
Kubebuilder is inconsistent in how it uses json annotations for some things (name of the field) and kubebuilder annotations for other things (type validation). In reality, this creates an indirect dependency on specifying both because serialization will complain upon validation that an 'optional' type that was not omitted can not be of type 'null'.  This also makes NutanixBootType a separate type so users don't confuse legacy and UEFI values with Name and UUID which are the more common NutanixIdentifierType values.

**How has this been tested?**
```
$ LABEL_FILTERS="capx-feature-test"  make test-e2e-calico
Ran 14 of 26 Specs in 2194.487 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS
```
See full logs: https://app.warp.dev/block/axpXIujDlaFxOrrDyGqTfu
