### PR TITLE
fix image url in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
         echo "## Images" >> ${{ github.workspace }}-CHANGELOG.txt
         echo "|Name|Link|" >> ${{ github.workspace }}-CHANGELOG.txt
         echo "|-|-|" >> ${{ github.workspace }}-CHANGELOG.txt
-        echo "|CAPX|[$NEW_IMG]($NEW_IMG)|" >> ${{ github.workspace }}-CHANGELOG.txt
+        echo "|CAPX|[$NEW_IMG](https://$NEW_IMG)|" >> ${{ github.workspace }}-CHANGELOG.txt
 
     - name: create release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
**What this PR does / why we need it**:

fix url associated to controller image


**Release note**:

```release-note
NONE
```