### PR TITLE
configure manager as default container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,6 +69,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: "manager"
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures the CAPX manager as default container. Users will not be required to select a specific container when using kubectl to fetch logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Use kubectl to fetch CAPX logs without providing container name

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE