### PR TITLE
Update CAPI e2e components to v1.4.1

### DIFF
--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -13,11 +13,11 @@ images:
     loadBehavior: mustLoad
   # ## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
   # Cluster API v1beta1 Preloads
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.2
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.1
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.2
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.4.1
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.2
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.4.1
     loadBehavior: tryLoad
 
 providers:
@@ -42,9 +42,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.3.2
+      - name: v1.4.1
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/core-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.1/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -73,9 +73,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.3.2
+      - name: v1.4.1
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/bootstrap-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.1/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -104,9 +104,9 @@ providers:
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
-      - name: v1.3.2
+      - name: v1.4.1
         # Use manifest from source files
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.2/control-plane-components.yaml"
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.1/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         files:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the e2e CAPI components to v1.4.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
Run e2e

**Special notes for your reviewer**:
N/A


**Release note**:
NONE