### PR TITLE
Update CAPI dependency to v1.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	sigs.k8s.io/cluster-api v1.3.4
-	sigs.k8s.io/cluster-api/test v1.3.4
+	sigs.k8s.io/cluster-api v1.3.5
+	sigs.k8s.io/cluster-api/test v1.3.5
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1342,10 +1342,10 @@ k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.3.4 h1:YXxcXu+mhzvOPLHfF+OQ27jYzks3zMH3AxbFckER0Ug=
-sigs.k8s.io/cluster-api v1.3.4/go.mod h1:9FNHNItE5c+klfDLNG3+ApSTX0H4yGAumdbFJMnk6Vc=
-sigs.k8s.io/cluster-api/test v1.3.4 h1:T2ZThmIB/EZusMlHPdQ4g9VWiFwB6sIk8w65mMjcvkU=
-sigs.k8s.io/cluster-api/test v1.3.4/go.mod h1:oRc0fAaj3ZPMuV0GTRQbseZ6IrNyDUB8ReKil5lkAtw=
+sigs.k8s.io/cluster-api v1.3.5 h1:Chg56Piv5ip0AFRN83H1I8uIn6qsdk+mr9hdq5Cxkf0=
+sigs.k8s.io/cluster-api v1.3.5/go.mod h1:9FNHNItE5c+klfDLNG3+ApSTX0H4yGAumdbFJMnk6Vc=
+sigs.k8s.io/cluster-api/test v1.3.5 h1:+uY+oMwIK5NOH1S/VPCl5gl9TuUBRRdr/qiji4r1B7I=
+sigs.k8s.io/cluster-api/test v1.3.5/go.mod h1:oRc0fAaj3ZPMuV0GTRQbseZ6IrNyDUB8ReKil5lkAtw=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=


### PR DESCRIPTION
[v1.3.4 has been superseded by v1.3.5 due to](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.3.4) clusterctl release being dynamically linked.