### PR TITLE
Add additional check for task in VM status

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -359,6 +359,9 @@ func GetTaskUUIDFromVM(vm *nutanixClientV3.VMIntentResponse) (string, error) {
 	if vm == nil {
 		return "", fmt.Errorf("cannot extract task uuid from empty vm object")
 	}
+	if vm.Status.ExecutionContext == nil {
+		return "", nil
+	}
 	taskInterface := vm.Status.ExecutionContext.TaskUUID
 	vmName := *vm.Spec.Name
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a check for the last task UUID on the VM object to prevent errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:

```
LABEL_FILTERS='!cluster-upgrade-conformance' make test-e2e-calico
Ran 20 of 32 Specs in 4813.890 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS
```

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
- Add check for the task UUID on the VM objects to prevent errors
```