### PR TITLE
Add OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+- adiantum
+- deepakm-ntnx
+- thunderboltsid
+- tuxtof
+- yannickstruyf3
+approvers:
+- adiantum
+- deepakm-ntnx
+- thunderboltsid
+- tuxtof
+- yannickstruyf3


### PR DESCRIPTION
Prow relies on this file for identifying people that can approve PRs.