### PR TITLE
Add explicit seccompProfile for controller-manager deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -99,6 +99,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
+            capabilities:
+              drop:
+                - ALL
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,8 +74,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      # securityContext:
-      #   runAsNonRoot: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
             - --leader-elect
@@ -96,6 +98,7 @@ spec:
               mountPath: "/etc/nutanix/config"
           securityContext:
             allowPrivilegeEscalation: false
+            privileged: false
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
The seccompProfile field within the securityContext of a Kubernetes Deployment specification defines the seccomp (Secure Computing Mode) profile that should be applied to the containers in the pod. Seccomp is a Linux kernel feature that restricts the system calls that a process can make. This can help reduce an application's attack surface by limiting its interactions with the kernel. 

The PR Changes the seccompProfile to runtime/default: This uses the default seccomp profile provided by the container runtime (Docker, containerd, etc.). This is typically a conservative profile that restricts risky or outdated system calls.

Linux capabilities are a kernel feature used to partition the powerful root privileges into smaller, specific privileges. By default, Docker and other container runtimes grant a set of these capabilities to the containers. Using the drop: [ALL] setting in a capabilities specification instructs Kubernetes to remove all these capabilities, effectively reducing the privileges of the processes running in the container. 