### PR TITLE
Development workflow inprovement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize prepare-local-clusterctl docker-push-kind ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize docker-push-kind ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	clusterctl delete --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} --include-crd || true
 	clusterctl init --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} -v 9
 	# cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}

--- a/clusterctl.yaml
+++ b/clusterctl.yaml
@@ -6,7 +6,7 @@ NUTANIX_PASSWORD: ""
 
 KUBERNETES_VERSION: "v1.21.9"
 NUTANIX_SSH_AUTHORIZED_KEY: ""
-CONTROLPLANE_ENDPOINT_IP: ""
+CONTROL_PLANE_ENDPOINT_IP: ""
 WORKER_MACHINE_COUNT: 2
 
 NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
@@ -19,5 +19,5 @@ KUBEVIP_SVC_ENABLE: "false"
 providers:
   # add a custom provider
   - name: "nutanix"
-    url: "file://$HOME/.cluster-api/overrides/infrastructure-nutanix/v0.0.0/infrastructure-components.yaml"
+    url: "file:///$HOME/.cluster-api/overrides/infrastructure-nutanix/v0.0.0/infrastructure-components.yaml"
     type: "InfrastructureProvider"

--- a/docs/developer_workflow.md
+++ b/docs/developer_workflow.md
@@ -16,6 +16,11 @@ make docker-build
 make kind-create
 </pre>
 
+## Prepare local clusterctl
+<pre>
+make prepare-local-clusterctl
+</pre>
+
 ## Deploy cluster-api-provider-nutanix CRDs on test management cluster
 <pre>
 make deploy


### PR DESCRIPTION
 There are couple drawbacks in current development workflow:
 - couple errors in clusterctl.yml
 - make deploy re-initialise clusterctl.yml each time when somebody trying to deploy the changes to kind cluster

In this PR: 
 - fix errors in clusterctl.yml 
 - separate initialisation  clusterctl.yml from deploy
 - fix dev workflow doc

Tested manually.

```release-note
NONE
```