### PR TITLE
Bump kube-vip from v0.6.0 to v0.6.1

### DIFF
--- a/templates/base/cluster-with-kcp.yaml
+++ b/templates/base/cluster-with-kcp.yaml
@@ -81,7 +81,7 @@ spec:
           spec:
             containers:
               - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.6.0
+                image: ghcr.io/kube-vip/kube-vip:v0.6.1
                 imagePullPolicy: IfNotPresent
                 args:
                   - manager

--- a/templates/cluster-template-ccm.yaml
+++ b/templates/cluster-template-ccm.yaml
@@ -411,7 +411,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.6.0
+              image: ghcr.io/kube-vip/kube-vip:v0.6.1
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1493,7 +1493,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.6.0
+              image: ghcr.io/kube-vip/kube-vip:v0.6.1
               imagePullPolicy: IfNotPresent
               args:
                 - manager

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -160,7 +160,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: ghcr.io/kube-vip/kube-vip:v0.6.0
+              image: ghcr.io/kube-vip/kube-vip:v0.6.1
               imagePullPolicy: IfNotPresent
               args:
                 - manager


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump kube-vip from v0.6.0 to v0.6.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://github.com/kube-vip/kube-vip/releases/tag/v0.6.1

**Release note**:

```release-note
Bump kube-vip to v0.6.1
```