### PR TITLE
add error return when category value cannot be created

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -587,7 +587,9 @@ func getOrCreateCategory(ctx context.Context, client *nutanixClientV3.Client, ca
 			Value:       utils.StringPtr(categoryIdentifier.Value),
 		})
 		if err != nil {
-			log.Error(err, fmt.Sprintf("failed to create category value %s in category key %s", categoryIdentifier.Value, categoryIdentifier.Key))
+			errorMsg := fmt.Errorf("failed to create category value %s in category key %s: %v", categoryIdentifier.Value, categoryIdentifier.Key, err)
+			log.Error(errorMsg, "failed to create category value")
+			return nil, errorMsg
 		}
 	}
 	return categoryValue, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue where error was not returned correctly if category creation failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
- add error return when category value cannot be created
```