### PR TITLE
increase log stacktrace default level to panic

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,3 +30,4 @@ spec:
         - "--leader-elect"
         - "--zap-log-level=${NUTANIX_LOG_LEVEL=info}"
         - "--zap-devel=${NUTANIX_LOG_DEVELOPMENT=true}"
+        - "--zap-stacktrace-level=${NUTANIX_LOG_STACKTRACE_LEVEL=panic}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Set default log stacktrace level to panic. This will prevent stack traces in the log when using log.Error()

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
NONE