### PR TITLE
fix(manager): remove CPU limit and increase memory limit

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -116,8 +116,7 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 40m
-              memory: 60Mi
+              memory: 100Mi
             requests:
               cpu: 30m
               memory: 50Mi


### PR DESCRIPTION
Hello,

This PR removes the CPU limits as it is generally recommended not to enforce them.
It also increases the memory limits from 60Mi to 100Mi to leave some room (I see usage of ~58Mi on some of my instances).


Actual limit was hit with 5 managed clusters and 56 machines

Thx,
Fred