### PR TITLE
Add last git commit hash to build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,8 @@ kind-delete: ## Delete the kind cluster
 
 .PHONY: build
 build: generate fmt ## Build manager binary.
-	go build -o bin/manager main.go
+	GIT_COMMIT_HASH=`git rev-parse HEAD` && \
+	go build -ldflags "-X main.gitCommitHash=$${GIT_COMMIT_HASH}" -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -243,7 +244,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: $(KO) ## Build docker image with the manager.
-	KO_DOCKER_REPO=ko.local $(KO) build -B --platform=${PLATFORMS} -t ${IMG_TAG} -L .
+	GIT_COMMIT_HASH=`git rev-parse HEAD` && \
+	KO_DOCKER_REPO=ko.local GOFLAGS="-ldflags=-X=main.gitCommitHash=$${GIT_COMMIT_HASH}" $(KO) build -B --platform=${PLATFORMS} -t ${IMG_TAG} -L .
 
 .PHONY: docker-push
 docker-push: $(KO) ## Push docker image with the manager.
@@ -330,7 +332,8 @@ cluster-templates: $(KUSTOMIZE) ## Generate cluster templates for all flavors
 
 .PHONY: docker-build-e2e
 docker-build-e2e: $(KO) ## Build docker image with the manager with e2e tag.
-	KO_DOCKER_REPO=ko.local $(KO) build -B --platform=${PLATFORMS_E2E} -t e2e -L .
+	GIT_COMMIT_HASH=`git rev-parse HEAD` && \
+	KO_DOCKER_REPO=ko.local GOFLAGS="-ldflags=-X=main.gitCommitHash=$${GIT_COMMIT_HASH}" $(KO) build -B --platform=${PLATFORMS_E2E} -t e2e -L .
 	docker tag ko.local/cluster-api-provider-nutanix:e2e ${IMG_REPO}:e2e
 
 .PHONY: prepare-local-clusterctl

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.18.3
+  minimum_go_version=go1.21.4
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -4,8 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-wget https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
-rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.21.4.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This ensures we have the git hash of the changes in our CI logs so we can correlate the code changes being executed.

**How has this been tested?**
```
$ make build
...
GIT_COMMIT_HASH=`git rev-parse HEAD` && \
	go build -ldflags "-X main.gitCommitHash=${GIT_COMMIT_HASH}" -o bin/manager main.go
$ ./bin/manager
{"level":"info","ts":"2023-11-28T12:31:44+05:30","logger":"setup","msg":"Initializing Nutanix Cluster API Infrastructure Provider","Git Hash":"d28682b71545d20be2810b0951bfafc0fe1f539a"}


$ make docker-build
GIT_COMMIT_HASH=`git rev-parse HEAD` && \
	KO_DOCKER_REPO=ko.local GOFLAGS="-ldflags=-X=main.gitCommitHash=${GIT_COMMIT_HASH}" /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/hack/tools/bin/ko-v0.11.2 build -B --platform=linux/amd64,linux/arm64,linux/arm -t latest -L .
...
$ docker run ko.local/cluster-api-provider-nutanix:87369c4ed070d9fd458328efbd3d583b05d07411141e37737fa46ae419dd35ef
{"level":"info","ts":"2023-11-28T07:03:14Z","logger":"setup","msg":"Initializing Nutanix Cluster API Infrastructure Provider","Git Hash":"d28682b71545d20be2810b0951bfafc0fe1f539a"}
...

# From the prow artefact manager logs
2023-11-28T07:38:42Z	INFO	setup	Initializing Nutanix Cluster API Infrastructure Provider	{"Git Hash": "2ec6b8ef047b3a8a99ba748a145d4810b62124fa"}
```