### PR TITLE
Cleanup for passing the linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,6 @@ GOLANGCI_LINT_EXTRA_ARGS := --enable gofumpt --build-tags e2e
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint the codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
-	cd $(TEST_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,9 @@ CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/$(CONVERSION_VERIFIER_BIN))
 TILT_PREPARE_BIN := tilt-prepare
 TILT_PREPARE := $(abspath $(TOOLS_BIN_DIR)/$(TILT_PREPARE_BIN))
 
-GOLANGCI_LINT_VER := v1.44.0
+GOLANGCI_LINT_VER := v1.55.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
-GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # CRD_OPTIONS define options to add to the CONTROLLER_GEN
 CRD_OPTIONS ?= "crd:crdVersions=v1"
@@ -553,8 +552,8 @@ $(TILT_PREPARE): $(TOOLS_DIR)/go.mod # Build tilt-prepare from tools folder.
 $(KPROMO):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(KPROMO_PKG) $(KPROMO_BIN) ${KPROMO_VER}
 
-$(GOLANGCI_LINT): # Build golangci-lint from tools folder
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOLANGCI_LINT_PKG) $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
+$(GOLANGCI_LINT): # building golanci-lint from source is not recommended, so we are using the install script
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VER)
 
 ## --------------------------------------
 ## Lint / Verify
@@ -562,11 +561,12 @@ $(GOLANGCI_LINT): # Build golangci-lint from tools folder
 
 ##@ Lint and Verify
 
+GOLANGCI_LINT_EXTRA_ARGS := --enable gofumpt --build-tags e2e
+
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint the codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
 	cd $(TEST_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
-	cd $(TOOLS_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ lint: $(GOLANGCI_LINT) ## Lint the codebase
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
-	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
+	GOLANGCI_LINT_EXTRA_ARGS="$(GOLANGCI_LINT_EXTRA_ARGS) --fix" $(MAKE) lint
 
 ## --------------------------------------
 ## Clean

--- a/api/v1alpha4/conditions.go
+++ b/api/v1alpha4/conditions.go
@@ -30,7 +30,7 @@ const (
 )
 
 const (
-	//PrismCentralClientCondition indicates the status of the client used to connect to Prism Central
+	// PrismCentralClientCondition indicates the status of the client used to connect to Prism Central
 	PrismCentralClientCondition capiv1.ConditionType = "PrismClientInit"
 
 	PrismCentralClientInitializationFailed = "PrismClientInitFailed"

--- a/api/v1alpha4/nutanixcluster_conversion.go
+++ b/api/v1alpha4/nutanixcluster_conversion.go
@@ -31,24 +31,26 @@ func (src *NutanixCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 }
 
 // ConvertFrom converts from the Hub version (v1beta1) to this NutanixCluster.
-func (dst *NutanixCluster) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *NutanixCluster) ConvertFrom(srcRaw conversion.Hub) error { //nolint
 	src := srcRaw.(*infrav1beta1.NutanixCluster)
 	return Convert_v1beta1_NutanixCluster_To_v1alpha4_NutanixCluster(src, dst, nil)
 }
 
 // ConvertTo converts this NutanixClusterList to the Hub version (v1beta1).
-func (src *NutanixClusterList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+func (src *NutanixClusterList) ConvertTo(dstRaw conversion.Hub) error { //nolint
 	dst := dstRaw.(*infrav1beta1.NutanixClusterList)
 	return Convert_v1alpha4_NutanixClusterList_To_v1beta1_NutanixClusterList(src, dst, nil)
 }
 
 // ConvertFrom converts from the Hub version(v1beta1) to this NutanixClusterList.
-func (dst *NutanixClusterList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *NutanixClusterList) ConvertFrom(srcRaw conversion.Hub) error { //nolint
 	src := srcRaw.(*infrav1beta1.NutanixClusterList)
 	return Convert_v1beta1_NutanixClusterList_To_v1alpha4_NutanixClusterList(src, dst, nil)
 }
 
 // Convert_v1alpha4_NutanixClusterSpec_To_v1beta1_NutanixClusterSpec converts NutanixClusterSpec in NutanixClusterResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_NutanixClusterSpec_To_v1beta1_NutanixClusterSpec(in *NutanixClusterSpec, out *infrav1beta1.NutanixClusterSpec, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -56,6 +58,8 @@ func Convert_v1alpha4_NutanixClusterSpec_To_v1beta1_NutanixClusterSpec(in *Nutan
 }
 
 // Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint converts APIEndpoint in NutanixClusterResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint(in *capiv1alpha4.APIEndpoint, out *capiv1beta1.APIEndpoint, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -63,6 +67,8 @@ func Convert_v1alpha4_APIEndpoint_To_v1beta1_APIEndpoint(in *capiv1alpha4.APIEnd
 }
 
 // Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint converts APIEndpoint in NutanixClusterResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(in *capiv1beta1.APIEndpoint, out *capiv1alpha4.APIEndpoint, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -70,6 +76,8 @@ func Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(in *capiv1beta1.APIEndp
 }
 
 // Convert_v1beta1_NutanixClusterSpec_To_v1alpha4_NutanixClusterSpec converts NutanixClusterSpec in NutanixClusterResource from v1beta1 to v1alpha4 version.
+//
+//nolint:all
 func Convert_v1beta1_NutanixClusterSpec_To_v1alpha4_NutanixClusterSpec(in *infrav1beta1.NutanixClusterSpec, out *NutanixClusterSpec, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -77,6 +85,8 @@ func Convert_v1beta1_NutanixClusterSpec_To_v1alpha4_NutanixClusterSpec(in *infra
 }
 
 // Convert_v1alpha4_NutanixClusterStatus_To_v1beta1_NutanixClusterStatus converts NutanixClusterStatus in NutanixClusterResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_NutanixClusterStatus_To_v1beta1_NutanixClusterStatus(in *NutanixClusterStatus, out *infrav1beta1.NutanixClusterStatus, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380

--- a/api/v1alpha4/nutanixmachine_conversion.go
+++ b/api/v1alpha4/nutanixmachine_conversion.go
@@ -47,6 +47,8 @@ func (dst *NutanixMachineList) ConvertFrom(srcRaw conversion.Hub) error { // nol
 }
 
 // Convert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec converts NutanixMachineSpec in NutanixMachineResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *NutanixMachineSpec, out *infrav1beta1.NutanixMachineSpec, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -54,6 +56,8 @@ func Convert_v1alpha4_NutanixMachineSpec_To_v1beta1_NutanixMachineSpec(in *Nutan
 }
 
 // Convert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec converts NutanixMachineSpec in NutanixMachineResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *infrav1beta1.NutanixMachineSpec, out *NutanixMachineSpec, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -61,6 +65,8 @@ func Convert_v1beta1_NutanixMachineSpec_To_v1alpha4_NutanixMachineSpec(in *infra
 }
 
 // Convert_v1alpha4_NutanixMachineStatus_To_v1beta1_NutanixMachineStatus converts NutanixMachineStatus in NutanixMachineResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_NutanixMachineStatus_To_v1beta1_NutanixMachineStatus(in *NutanixMachineStatus, out *infrav1beta1.NutanixMachineStatus, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380

--- a/api/v1alpha4/nutanixmachinetemplate_conversion.go
+++ b/api/v1alpha4/nutanixmachinetemplate_conversion.go
@@ -59,6 +59,8 @@ func (dst *NutanixMachineTemplateList) ConvertFrom(srcRaw conversion.Hub) error 
 }
 
 // Convert_v1alpha4_ObjectMeta_To_v1beta1_ObjectMeta converts ObjectMeta in NutanixMachineTemplateResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_ObjectMeta_To_v1beta1_ObjectMeta(in *capiv1alpha4.ObjectMeta, out *capiv1beta1.ObjectMeta, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -66,6 +68,8 @@ func Convert_v1alpha4_ObjectMeta_To_v1beta1_ObjectMeta(in *capiv1alpha4.ObjectMe
 }
 
 // Convert_v1beta1_ObjectMeta_To_v1alpha4_ObjectMeta converts ObjectMeta in NutanixMachineTemplateResource from v1beta1 to v1alpha4 version.
+//
+//nolint:all
 func Convert_v1beta1_ObjectMeta_To_v1alpha4_ObjectMeta(in *capiv1beta1.ObjectMeta, out *capiv1alpha4.ObjectMeta, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -73,6 +77,8 @@ func Convert_v1beta1_ObjectMeta_To_v1alpha4_ObjectMeta(in *capiv1beta1.ObjectMet
 }
 
 // Convert_v1alpha4_NutanixMachineTemplateResource_To_v1beta1_NutanixMachineTemplateResource converts NutanixMachineTemplateResource in NutanixMachineTemplateResource from v1alpha4 to v1beta1 version.
+//
+//nolint:all
 func Convert_v1alpha4_NutanixMachineTemplateResource_To_v1beta1_NutanixMachineTemplateResource(in *NutanixMachineTemplateResource, out *infrav1beta1.NutanixMachineTemplateResource, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380
@@ -80,6 +86,8 @@ func Convert_v1alpha4_NutanixMachineTemplateResource_To_v1beta1_NutanixMachineTe
 }
 
 // Convert_v1beta1_NutanixMachineTemplateResource_To_v1alpha4_NutanixMachineTemplateResource converts NutanixMachineTemplateResource in NutanixMachineTemplateResource from v1beta1 to v1alpha4 version.
+//
+//nolint:all
 func Convert_v1beta1_NutanixMachineTemplateResource_To_v1alpha4_NutanixMachineTemplateResource(in *infrav1beta1.NutanixMachineTemplateResource, out *NutanixMachineTemplateResource, s apiconversion.Scope) error {
 	// Wrapping the conversion function to avoid compilation errors due to compileErrorOnMissingConversion()
 	// Ref: https://github.com/kubernetes/kubernetes/issues/98380

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -18,7 +18,6 @@ package context
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -69,30 +68,6 @@ func IsControlPlaneMachine(nma *infrav1.NutanixMachine) bool {
 	}
 	_, ok := nma.GetLabels()[capiv1.MachineControlPlaneLabelName]
 	return ok
-}
-
-// ErrNoMachineIPAddr indicates that no valid IP addresses were found in a machine context
-var ErrNoMachineIPAddr = errors.New("no IP addresses found for machine")
-
-// GetMachinePreferredIPAddress returns the preferred IP address associated with the NutanixMachine
-func GetMachinePreferredIPAddress(nma *infrav1.NutanixMachine) (string, error) {
-	var internalIP, externalIP string
-	for _, addr := range nma.Status.Addresses {
-		if addr.Type == capiv1.MachineExternalIP {
-			externalIP = addr.Address
-		} else if addr.Type == capiv1.MachineInternalIP {
-			internalIP = addr.Address
-		}
-	}
-
-	if len(externalIP) > 0 {
-		return externalIP, nil
-	}
-	if len(internalIP) > 0 {
-		return internalIP, nil
-	}
-
-	return "", ErrNoMachineIPAddr
 }
 
 // GetNutanixMachinesInCluster gets a cluster's NutanixMachine resources.

--- a/test/e2e/basic_uuid_test.go
+++ b/test/e2e/basic_uuid_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/capx_quick_start_test.go
+++ b/test/e2e/capx_quick_start_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/test/e2e/capx_regression.go
+++ b/test/e2e/capx_regression.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix
@@ -22,9 +21,10 @@ package e2e
 import (
 	"context"
 
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,18 +32,10 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
 var _ = Describe("Nutanix regression tests", Label("capx-regression-test", "regression", "slow", "network"), func() {
-	const (
-		specName = "capx-regression"
-
-		controlplaneEndpointIPKey       = envVarControlPlaneEndpointIP
-		controlplaneEndpointPortKey     = envVarControlPlaneEndpointPort
-		defaultControlPlaneEndpointPort = 6443
-	)
+	const specName = "capx-regression"
 
 	var (
 		namespace        *corev1.Namespace

--- a/test/e2e/capx_regression.go
+++ b/test/e2e/capx_regression.go
@@ -188,7 +188,7 @@ var _ = Describe("Nutanix regression tests", Label("capx-regression-test", "regr
 			}, e2eConfig.GetIntervals(specName, "wait-delete-cluster")...)
 		})
 
-		//Check if secret is deleted
+		// Check if secret is deleted
 		By("Checking if secret is deleted", func() {
 			err := bootstrapClusterProxy.GetClient().Get(ctx,
 				client.ObjectKey{
@@ -199,7 +199,7 @@ var _ = Describe("Nutanix regression tests", Label("capx-regression-test", "regr
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		//Check if cluster is deleted
+		// Check if cluster is deleted
 		By("Checking if cluster is deleted", func() {
 			err := bootstrapClusterProxy.GetClient().Get(ctx,
 				client.ObjectKey{

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/ccm_test.go
+++ b/test/e2e/ccm_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix, Inc

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -1,8 +1,7 @@
 //go:build e2e
-// +build e2e
 
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1,5 +1,7 @@
+//go:build e2e
+
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -120,7 +120,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
-	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec
+	Expect(os.MkdirAll(artifactFolder, 0o755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,8 +1,7 @@
 //go:build e2e
-// +build e2e
 
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,82 +19,25 @@ limitations under the License.
 package e2e
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
-
-	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
-
-// Test suite flags.
-var (
-	// configPath is the path to the e2e config file.
-	configPath string
-
-	// useExistingCluster instructs the test to use the current cluster instead of creating a new one (default discovery rules apply).
-	useExistingCluster bool
-
-	// artifactFolder is the folder to store e2e test artifacts.
-	artifactFolder string
-
-	// clusterctlConfig is the file which tests will use as a clusterctl config.
-	// If it is not set, a local clusterctl repository (including a clusterctl config) will be created automatically.
-	clusterctlConfig string
-
-	// alsoLogToFile enables additional logging to the 'ginkgo-log.txt' file in the artifact folder.
-	// These logs also contain timestamps.
-	alsoLogToFile bool
-
-	// skipCleanup prevents cleanup of test resources e.g. for debug purposes.
-	skipCleanup bool
-
-	// flavor is used to add clusterResourceSet for CNI usage in e2e tests
-	flavor string
-)
-
-// Test suite global vars.
-var (
-	ctx = ctrl.SetupSignalHandler()
-
-	// e2eConfig to be used for this test, read from configPath.
-	e2eConfig *clusterctl.E2EConfig
-
-	// clusterctlConfigPath to be used for this test, created by generating a clusterctl local repository
-	// with the providers specified in the configPath.
-	clusterctlConfigPath string
-
-	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
-	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
-	bootstrapClusterProvider bootstrap.ClusterProvider
-
-	// bootstrapClusterProxy allows to interact with the bootstrap cluster to be used for the e2e tests.
-	bootstrapClusterProxy framework.ClusterProxy
-)
-
-func init() {
-	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
-	flag.StringVar(&artifactFolder, "e2e.artifacts-folder", "", "folder where e2e test artifact should be stored")
-	flag.BoolVar(&alsoLogToFile, "e2e.also-log-to-file", true, "if true, ginkgo logs are additionally written to the `ginkgo-log.txt` file in the artifacts folder (including timestamps)")
-	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
-	flag.StringVar(&clusterctlConfig, "e2e.clusterctl-config", "", "file which tests will use as a clusterctl config. If it is not set, a local clusterctl repository (including a clusterctl config) will be created automatically.")
-	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
-}
 
 func TestE2E(t *testing.T) {
 	// If running in prow, make sure to use the artifacts folder that will be reported in test grid (ignoring the value provided by flag).

--- a/test/e2e/gpu_test.go
+++ b/test/e2e/gpu_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2023 Nutanix

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix, Inc

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -2,7 +2,7 @@
 // +build e2e
 
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -1,8 +1,7 @@
 //go:build e2e
-// +build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -50,7 +50,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-
 // Label `only-for-validation` is used to run this test only for validation and not as part of the regular test suite.
 var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
 	// MachineDeploymentScaleSpec implements a test that verifies that MachineDeployment scale operations are successful.
-	var inputGetter = func() capi_e2e.MachineDeploymentScaleSpecInput {
+	inputGetter := func() capi_e2e.MachineDeploymentScaleSpecInput {
 		return capi_e2e.MachineDeploymentScaleSpecInput{
 			E2EConfig:             e2eConfig,
 			ClusterctlConfigPath:  clusterctlConfigPath,
@@ -74,7 +74,7 @@ var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas 
 		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
 		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0o750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
 		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersion)))
 

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -1,8 +1,7 @@
 //go:build e2e
-// +build e2e
 
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/mhc_remediations_test.go
+++ b/test/e2e/mhc_remediations_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 /*
-Copyright 2023 Nutanix.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/mhc_remediations_test.go
+++ b/test/e2e/mhc_remediations_test.go
@@ -1,8 +1,7 @@
 //go:build e2e
-// +build e2e
 
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 Nutanix.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/nutanix_client.go
+++ b/test/e2e/nutanix_client.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix

--- a/test/e2e/projects_test.go
+++ b/test/e2e/projects_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2022 Nutanix
@@ -32,13 +31,11 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
-const (
-	nutanixProjectNameEnv  = "NUTANIX_PROJECT_NAME"
-	nonExistingProjectName = "nonExistingProjectNameCAPX"
-)
-
 var _ = Describe("Nutanix projects", Label("capx-feature-test", "projects", "slow", "network"), func() {
-	const specName = "cluster-projects"
+	const (
+		specName               = "cluster-projects"
+		nonExistingProjectName = "nonExistingProjectNameCAPX"
+	)
 
 	var (
 		namespace          *corev1.Namespace


### PR DESCRIPTION
This PR does some linting  related cleanups:
- Fetch Golangci-Lint using binary instead of compiling from source (golangci-lint docs [advise against building from source](https://golangci-lint.run/usage/install/))
- Move some package level vars and consts from `_test.go` files to non `_test.go` files in test package.
- Remove linting on some `_conversion.go` functions as they are infinitely recursive and cause false triggers.