### PR TITLE
Install a local clusterctl executable and use it in make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,12 @@ GOLANGCI_LINT_VER := v1.55.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 
+# Install clusterctl that corresponds to the cluster-api go mod version
+CLUSTERCTL_VER := $(shell go list -m sigs.k8s.io/cluster-api | cut -d" " -f2)
+CLUSTERCTL_RELEASE_URL := https://github.com/kubernetes-sigs/cluster-api/releases/download/$(CLUSTERCTL_VER)/clusterctl-$(shell go env GOOS)-$(shell go env GOARCH)
+CLUSTERCTL_BIN := clusterctl
+CLUSTERCTL := $(abspath $(TOOLS_BIN_DIR)/$(CLUSTERCTL_BIN))
+
 # CRD_OPTIONS define options to add to the CONTROLLER_GEN
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
@@ -529,6 +535,9 @@ $(TILT_PREPARE_BIN): $(TILT_PREPARE) ## Build a local copy of tilt-prepare.
 .PHONY: $(GOLANGCI_LINT_BIN)
 $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint
 
+.PHONY: $(CLUSTERCTL_BIN)
+$(CLUSTERCTL_BIN): $(CLUSTERCTL) ## Build a local copy of clusterctl
+
 $(GINKGO): # Build ginkgo from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GINKGO_PKG) $(GINKGO_BIN) $(GINGKO_VER)
 
@@ -579,6 +588,12 @@ $(KPROMO):
 
 $(GOLANGCI_LINT): # building golanci-lint from source is not recommended, so we are using the install script
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VER)
+
+$(CLUSTERCTL):
+# We don't install clusterctl using the go toolchain, because the upstream Makefile
+# is required to build clusterctl correctly. See https://github.com/kubernetes-sigs/cluster-api/issues/3706
+	curl -sSfL -o $(CLUSTERCTL) $(CLUSTERCTL_RELEASE_URL)
+	chmod u+x $(CLUSTERCTL)
 
 ## --------------------------------------
 ## Lint / Verify

--- a/Makefile
+++ b/Makefile
@@ -294,9 +294,9 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize docker-push-kind ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	clusterctl delete --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} --include-crd || true
-	clusterctl init --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} -v 9
+deploy: manifests kustomize docker-push-kind $(CLUSTERCTL) ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(CLUSTERCTL) delete --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} --include-crd || true
+	$(CLUSTERCTL) init --infrastructure nutanix:${LOCAL_PROVIDER_VERSION} -v 9
 	# cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	# $(KUSTOMIZE) build config/default | kubectl apply -f -
 
@@ -388,12 +388,11 @@ ifeq ($(EXPORT_RESULT), true)
 endif
 
 .PHONY: test-clusterctl-create
-test-clusterctl-create: ## Run the tests using clusterctl
-	which clusterctl
-	clusterctl version
-	clusterctl config repositories | grep nutanix
-	clusterctl generate cluster ${TEST_CLUSTER_NAME} -i nutanix:${LOCAL_PROVIDER_VERSION} --list-variables -v 10
-	clusterctl generate cluster ${TEST_CLUSTER_NAME} -i nutanix:${LOCAL_PROVIDER_VERSION} --target-namespace ${TEST_NAMESPACE}  -v 10 > ./cluster.yaml
+test-clusterctl-create: $(CLUSTERCTL) ## Run the tests using clusterctl
+	$(CLUSTERCTL) version
+	$(CLUSTERCTL) config repositories | grep nutanix
+	$(CLUSTERCTL) generate cluster ${TEST_CLUSTER_NAME} -i nutanix:${LOCAL_PROVIDER_VERSION} --list-variables -v 10
+	$(CLUSTERCTL) generate cluster ${TEST_CLUSTER_NAME} -i nutanix:${LOCAL_PROVIDER_VERSION} --target-namespace ${TEST_NAMESPACE}  -v 10 > ./cluster.yaml
 	kubectl create ns $(TEST_NAMESPACE) || true
 	kubectl apply -f ./cluster.yaml -n $(TEST_NAMESPACE)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
The dev docs rely on the clusterctl executable, as do some make targets. The clusterctl version should correspond to the cluster-api go module dependency version.

I expect this change to make it easier to follow the developer documentation.

If we like this approach for clusterctl, we can also consider it for kind, and even kubectl.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

Here's output of running a make target that depends on clusterctl:


```console
> make --debug test-clusterctl-create
GNU Make 4.3
Built for x86_64-redhat-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'test-clusterctl-create' does not exist.
   File '/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl' does not exist.
  Must remake target '/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl'.
curl -sSfL -o /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/clusterctl-linux-amd64
chmod u+x /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl
  Successfully remade target file '/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl'.
Must remake target 'test-clusterctl-create'.
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl version
clusterctl version: &version.Info{Major:"1", Minor:"3", GitVersion:"v1.3.5", GitCommit:"58770484dee6c99c10e32c06652e9f9643f78e9e", GitTreeState:"clean", BuildDate:"2023-03-02T15:57:13Z", GoVersion:"go1.19.6", Compiler:"gc", Platform:"linux/amd64"}
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl config repositories | grep nutanix
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
nutanix        InfrastructureProvider   file:///$HOME/.cluster-api/overrides/infrastructure-nutanix/v0.0.0/                         infrastructure-components.yaml
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/clusterctl generate cluster mycluster -i nutanix:v1.3.99 --list-variables -v 10
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
Using Override="cluster-template.yaml" Provider="infrastructure-nutanix" Version="v1.3.99"
```


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```