### PR TITLE
Reflect deprecation of .status.nodeRef in the NutanixMachine CRD

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -21,8 +21,11 @@ jobs:
         with:
           go-version: "^1.21"
 
-      - name: Test build
-        run: make manifests generate fmt vet build
+      - name: Verify that generated manifests committed to the repository are up to date
+        run: make verify-manifests
+
+      - name: Build
+        run: make generate fmt vet build
 
       - name: Run unit tests
         run: make unit-test

--- a/Makefile
+++ b/Makefile
@@ -596,6 +596,18 @@ lint: $(GOLANGCI_LINT) ## Lint the codebase
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
 	GOLANGCI_LINT_EXTRA_ARGS="$(GOLANGCI_LINT_EXTRA_ARGS) --fix" $(MAKE) lint
 
+# Make any new verify task a dependency of this target
+.PHONY: verify ## Run all verify targets
+verify: verify-manifests
+
+# Adapted from https://github.com/kubernetes-sigs/cluster-api/blob/f15e8769a2135429911ce6d8f7124b853c0444a1/Makefile#L651-L656
+.PHONY: verify-manifests
+verify-manifests: manifests  ## Verify generated manifests are up to date
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated manifests are out of date in the repository, run make manifests, and commit"; exit 1; \
+	fi
+
 ## --------------------------------------
 ## Clean
 ## --------------------------------------

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -32,10 +32,6 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
-    - description: Corresponding workload cluster node
-      jsonPath: .status.nodeRef.name
-      name: NodeRef
-      type: string
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -309,8 +305,9 @@ spec:
                 description: Will be set in case of failure of Machine instance
                 type: string
               nodeRef:
-                description: NodeRef is a reference to the corresponding workload
-                  cluster Node if it exists.
+                description: 'NodeRef is a reference to the corresponding workload
+                  cluster Node if it exists. Deprecated: Do not use. Will be removed
+                  in a future release.'
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -369,10 +366,6 @@ spec:
     - description: NutanixMachine instance ID
       jsonPath: .spec.providerID
       name: ProviderID
-      type: string
-    - description: Corresponding workload cluster node
-      jsonPath: .status.nodeRef.name
-      name: NodeRef
       type: string
     name: v1beta1
     schema:
@@ -669,8 +662,9 @@ spec:
                 description: Will be set in case of failure of Machine instance
                 type: string
               nodeRef:
-                description: NodeRef is a reference to the corresponding workload
-                  cluster Node if it exists.
+                description: 'NodeRef is a reference to the corresponding workload
+                  cluster Node if it exists. Deprecated: Do not use. Will be removed
+                  in a future release.'
                 properties:
                   apiVersion:
                     description: API version of the referent.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
In #331, we deprecated the `NutanixMachine.status.nodeRef` field, but it looks like the changes were not reflected in the CRD kustomization base:

```console
> git checkout 167cf7cf939bb182277f44765f995824c775d6cf
> make prepare-local-clusterctl
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/controller-gen-v0.8.0 "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build templates/base > templates/cluster-template.yaml
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build templates/csi > templates/cluster-template-csi.yaml
git mkdir -p ~/.cluster-api/overrides/infrastructure-nutanix/v1.3.99
cd config/manager && /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 edit set image controller=ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build config/default > ~/.cluster-api/overrides/infrastructure-nutanix/v1.3.99/infrastructure-components.yaml
cp ./metadata.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v1.3.99/
cp ./templates/cluster-template*.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v1.3.99/
cp ./clusterctl.yaml ~/.cluster-api/clusterctl.yaml
> git diff --name-only
config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
```

**Update:** I've added a make target to verify that generated manifests are up to date, and updated the `Test Build` GitHub Actions workflow to run this target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

**Update**: The updated `Test Build` workflow will verify that generated manifests are up to date. I'll paste an excerpt of the output, once the workflow runs.

```console
> make deploy
/home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/controller-gen-v0.8.0 "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
GOOS=linux GOARCH=amd64 KO_DOCKER_REPO=ko.local /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/ko-v0.11.2 build -B -t latest -L .
2023/12/18 11:45:15 Using base gcr.io/distroless/static:nonroot@sha256:112a87f19e83c83711cc81ce8ed0b4d79acd65789682a6a272df57c4a0858534 for github.com/nutanix-cloud-native/cluster-api-provider-nutanix
2023/12/18 11:45:15 Building github.com/nutanix-cloud-native/cluster-api-provider-nutanix for linux/amd64
2023/12/18 11:45:18 Loading ko.local/cluster-api-provider-nutanix:d1d81bb3537e6a22921bead6b85ece34b0e622904e72cb040188984cf6422469
2023/12/18 11:45:20 Loaded ko.local/cluster-api-provider-nutanix:d1d81bb3537e6a22921bead6b85ece34b0e622904e72cb040188984cf6422469
2023/12/18 11:45:20 Adding tag latest
2023/12/18 11:45:20 Added tag latest
ko.local/cluster-api-provider-nutanix:d1d81bb3537e6a22921bead6b85ece34b0e622904e72cb040188984cf6422469
docker tag ko.local/cluster-api-provider-nutanix:latest ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
kind load docker-image --name capi-test ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
Image: "ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest" with ID "sha256:b73c301a3eb60d91c14c4194ce825f30ed73c9d964ccc993703986b15421f7e9" not yet present on node "capi-test-control-plane", loading...
clusterctl delete --infrastructure nutanix:v1.3.99 --include-crd || true
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
Deleting Provider="infrastructure-nutanix" Version="v1.3.99" Namespace="capx-system"
Deleting Endpoints="capx-controller-manager-metrics-service" Namespace="capx-system"
Deleting Secret="capx-nutanix-creds" Namespace="capx-system"
Deleting ConfigMap="capx-manager-config" Namespace="capx-system"
Deleting ConfigMap="capx-nutanix-endpoint" Namespace="capx-system"
Deleting ConfigMap="capx-user-ca-bundle" Namespace="capx-system"
Deleting Service="capx-controller-manager-metrics-service" Namespace="capx-system"
Deleting ServiceAccount="capx-controller-manager" Namespace="capx-system"
Deleting Deployment="capx-controller-manager" Namespace="capx-system"
Deleting Role="capx-leader-election-role" Namespace="capx-system"
Deleting ClusterRole="capx-system-capx-manager-role"
Deleting ClusterRole="capx-system-capx-metrics-reader"
Deleting ClusterRole="capx-system-capx-proxy-role"
Deleting ClusterRoleBinding="capx-system-capx-manager-rolebinding"
Deleting ClusterRoleBinding="capx-system-capx-proxy-rolebinding"
Deleting RoleBinding="capx-leader-election-rolebinding" Namespace="capx-system"
Deleting CustomResourceDefinition="nutanixclusters.infrastructure.cluster.x-k8s.io"
Deleting CustomResourceDefinition="nutanixmachines.infrastructure.cluster.x-k8s.io"
Deleting CustomResourceDefinition="nutanixmachinetemplates.infrastructure.cluster.x-k8s.io"
Deleting EndpointSlice="capx-controller-manager-metrics-service-jncnx" Namespace="capx-system"
Deleting Provider="infrastructure-nutanix" Namespace="capx-system"
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
clusterctl init --infrastructure nutanix:v1.3.99 -v 9
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
Fetching providers
Using Override="infrastructure-components.yaml" Provider="infrastructure-nutanix" Version="v1.3.99"
Fetching File="metadata.yaml" Provider="cluster-api" Type="CoreProvider" Version="v1.6.0"
Using Override="metadata.yaml" Provider="infrastructure-nutanix" Version="v1.3.99"
Creating Namespace="cert-manager-test"
Creating Issuer="test-selfsigned" Namespace="cert-manager-test"
Creating Certificate="selfsigned-cert" Namespace="cert-manager-test"
Deleting Namespace="cert-manager-test"
Deleting Issuer="test-selfsigned" Namespace="cert-manager-test"
Deleting Certificate="selfsigned-cert" Namespace="cert-manager-test"
Skipping installing cert-manager as it is already installed
Installing Provider="infrastructure-nutanix" Version="v1.3.99" TargetNamespace="capx-system"
Creating objects Provider="infrastructure-nutanix" Version="v1.3.99" TargetNamespace="capx-system"
Patching Namespace="capx-system"
Creating CustomResourceDefinition="nutanixclusters.infrastructure.cluster.x-k8s.io"
Creating CustomResourceDefinition="nutanixmachines.infrastructure.cluster.x-k8s.io"
Creating CustomResourceDefinition="nutanixmachinetemplates.infrastructure.cluster.x-k8s.io"
Creating ServiceAccount="capx-controller-manager" Namespace="capx-system"
Creating Role="capx-leader-election-role" Namespace="capx-system"
Creating ClusterRole="capx-system-capx-manager-role"
Creating ClusterRole="capx-system-capx-metrics-reader"
Creating ClusterRole="capx-system-capx-proxy-role"
Creating RoleBinding="capx-leader-election-rolebinding" Namespace="capx-system"
Creating ClusterRoleBinding="capx-system-capx-manager-rolebinding"
Creating ClusterRoleBinding="capx-system-capx-proxy-rolebinding"
Creating ConfigMap="capx-manager-config" Namespace="capx-system"
Creating ConfigMap="capx-nutanix-endpoint" Namespace="capx-system"
Creating ConfigMap="capx-user-ca-bundle" Namespace="capx-system"
Creating Secret="capx-nutanix-creds" Namespace="capx-system"
Creating Service="capx-controller-manager-metrics-service" Namespace="capx-system"
Creating Deployment="capx-controller-manager" Namespace="capx-system"
Creating inventory entry Provider="infrastructure-nutanix" Version="v1.3.99" TargetNamespace="capx-system"
Using configuration File="/home/dlipovetsky/.cluster-api/clusterctl.yaml"
# cd config/manager && /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 edit set image controller=ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
# /home/dlipovetsky/nutanix/cluster-api-provider-nutanix/hack/tools/bin/kustomize-v4.5.4 build config/default | kubectl apply -f -
```

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```