### PR TITLE
refactor: task status file

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -346,7 +346,7 @@ func GetImageUUID(ctx context.Context, client *nutanixClientV3.Client, imageName
 // HasTaskInProgress returns true if the given task is in progress
 func HasTaskInProgress(ctx context.Context, client *nutanixClientV3.Client, taskUUID string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	taskStatus, err := nutanixClientHelper.GetTaskState(ctx, client, taskUUID)
+	taskStatus, err := nutanixClientHelper.GetTaskStatus(ctx, client, taskUUID)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -666,7 +666,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*nu
 		return nil, errorMsg
 	}
 	log.Info(fmt.Sprintf("Waiting for task %s to get completed for VM %s", lastTaskUUID, rctx.NutanixMachine.Name))
-	err = nutanixClient.WaitForTaskCompletion(ctx, nc, lastTaskUUID)
+	err = nutanixClient.WaitForTaskToSucceed(ctx, nc, lastTaskUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while waiting for task %s to start: %v", lastTaskUUID, err)
 		rctx.SetFailureStatus(capierrors.CreateMachineError, errorMsg)

--- a/pkg/client/state_test.go
+++ b/pkg/client/state_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	nutanixTestClient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/helpers/prism-go-client/v3"
 )
@@ -126,7 +127,7 @@ func Test_WaitForTaskCompletion(t *testing.T) {
 				fmt.Fprint(w, `{"status": "PENDING"}`)
 			},
 			ctx:         ctx,
-			expectedErr: context.DeadlineExceeded,
+			expectedErr: wait.ErrWaitTimeout,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/client/state_test.go
+++ b/pkg/client/state_test.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	nutanixTestClient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/helpers/prism-go-client/v3"
+)
+
+func Test_GetTaskState(t *testing.T) {
+	client, err := nutanixTestClient.NewTestClient()
+	assert.NoError(t, err)
+	// use cleanup over defer as the connection gets closed before the tests run with t.Parallel()
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	t.Parallel()
+	tests := []struct {
+		name          string
+		taskUUID      string
+		handler       func(w http.ResponseWriter, r *http.Request)
+		ctx           context.Context
+		expectedState string
+		expectedErr   error
+	}{
+		{
+			name:     "succeeded",
+			taskUUID: "succeeded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "SUCCEEDED"}`)
+			},
+			ctx:           context.Background(),
+			expectedState: "SUCCEEDED",
+		},
+		{
+			name:     "unauthorized",
+			taskUUID: "unauthorized",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, `{"error_code": "401"}`, http.StatusUnauthorized)
+			},
+			ctx:         context.Background(),
+			expectedErr: fmt.Errorf("invalid Nutanix credentials"),
+		},
+		{
+			name:     "invalid",
+			taskUUID: "invalid",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "INVALID_UUID", "error_detail": "invalid UUID", "progress_message": "invalid UUID"}`)
+			},
+			ctx:           context.Background(),
+			expectedState: "INVALID_UUID",
+			expectedErr:   fmt.Errorf("error_detail: invalid UUID, progress_message: invalid UUID"),
+		},
+		{
+			name:     "failed",
+			taskUUID: "failed",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "FAILED", "error_detail": "task failed", "progress_message": "will never succeed"}`)
+			},
+			ctx:           context.Background(),
+			expectedState: "FAILED",
+			expectedErr:   fmt.Errorf("error_detail: task failed, progress_message: will never succeed"),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Capture range variable.
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client.AddHandler(nutanixTestClient.GetTaskURLPath(tt.taskUUID), tt.handler)
+
+			state, err := GetTaskState(tt.ctx, client.Client, tt.taskUUID)
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, tt.expectedState, state)
+		})
+	}
+}
+
+func Test_WaitForTaskCompletion(t *testing.T) {
+	client, err := nutanixTestClient.NewTestClient()
+	assert.NoError(t, err)
+	// use cleanup over defer as the connection gets closed before the tests run with t.Parallel()
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	t.Parallel()
+	tests := []struct {
+		name        string
+		taskUUID    string
+		handler     func(w http.ResponseWriter, r *http.Request)
+		ctx         context.Context
+		expectedErr error
+	}{
+		{
+			name:     "succeeded",
+			taskUUID: "succeeded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "SUCCEEDED"}`)
+			},
+			ctx: ctx,
+		},
+		{
+			name:     "invalid",
+			taskUUID: "invalid",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "INVALID_UUID", "error_detail": "invalid UUID", "progress_message": "invalid UUID"}`)
+			},
+			ctx:         ctx,
+			expectedErr: fmt.Errorf("error_detail: invalid UUID, progress_message: invalid UUID"),
+		},
+		{
+			name:     "timeout",
+			taskUUID: "timeout",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status": "PENDING"}`)
+			},
+			ctx:         ctx,
+			expectedErr: context.DeadlineExceeded,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Capture range variable.
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client.AddHandler(nutanixTestClient.GetTaskURLPath(tt.taskUUID), tt.handler)
+
+			err := WaitForTaskCompletion(tt.ctx, client.Client, tt.taskUUID)
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -29,24 +29,24 @@ import (
 
 const (
 	pollingInterval = time.Second * 2
-	stateSucceeded  = "SUCCEEDED"
+	statusSucceeded = "SUCCEEDED"
 )
 
-// WaitForTaskCompletion will poll indefinitely every 2 seconds for the task with uuid to have status of "SUCCEEDED".
-// Returns an error from GetTaskState or a timeout error if the context is cancelled.
-func WaitForTaskCompletion(ctx context.Context, conn *nutanixClientV3.Client, uuid string) error {
+// WaitForTaskToSucceed will poll indefinitely every 2 seconds for the task with uuid to have status of "SUCCEEDED".
+// Returns an error from GetTaskStatus or a timeout error if the context is cancelled.
+func WaitForTaskToSucceed(ctx context.Context, conn *nutanixClientV3.Client, uuid string) error {
 	return wait.PollImmediateInfiniteWithContext(ctx, pollingInterval, func(ctx context.Context) (done bool, err error) {
-		state, getErr := GetTaskState(ctx, conn, uuid)
-		return state == stateSucceeded, getErr
+		status, getErr := GetTaskStatus(ctx, conn, uuid)
+		return status == statusSucceeded, getErr
 	})
 }
 
-func GetTaskState(ctx context.Context, client *nutanixClientV3.Client, taskUUID string) (string, error) {
+func GetTaskStatus(ctx context.Context, client *nutanixClientV3.Client, uuid string) (string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info(fmt.Sprintf("Getting task with UUID %s", taskUUID))
-	v, err := client.V3.GetTask(ctx, taskUUID)
+	log.V(1).Info(fmt.Sprintf("Getting task with UUID %s", uuid))
+	v, err := client.V3.GetTask(ctx, uuid)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("error occurred while waiting for task with UUID %s", taskUUID))
+		log.Error(err, fmt.Sprintf("error occurred while waiting for task with UUID %s", uuid))
 		return "", err
 	}
 
@@ -55,6 +55,6 @@ func GetTaskState(ctx context.Context, client *nutanixClientV3.Client, taskUUID 
 			fmt.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(v.ErrorDetail), utils.StringValue(v.ProgressMessage))
 	}
 	taskStatus := *v.Status
-	log.V(1).Info(fmt.Sprintf("Status for task with UUID %s: %s", taskUUID, taskStatus))
+	log.V(1).Info(fmt.Sprintf("Status for task with UUID %s: %s", uuid, taskStatus))
 	return taskStatus, nil
 }

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -33,9 +33,10 @@ const (
 )
 
 // WaitForTaskToSucceed will poll indefinitely every 2 seconds for the task with uuid to have status of "SUCCEEDED".
-// Returns an error from GetTaskStatus or a timeout error if the context is cancelled.
+// The polling will not stop if the ctx is cancelled, it's only used for HTTP requests in the client.
+// WaitForTaskToSucceed will exit immediately on an error getting the task.
 func WaitForTaskToSucceed(ctx context.Context, conn *nutanixClientV3.Client, uuid string) error {
-	return wait.PollImmediateInfiniteWithContext(ctx, pollingInterval, func(ctx context.Context) (done bool, err error) {
+	return wait.PollImmediateInfinite(pollingInterval, func() (done bool, err error) {
 		status, getErr := GetTaskStatus(ctx, conn, uuid)
 		return status == statusSucceeded, getErr
 	})

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -88,7 +88,7 @@ func Test_GetTaskStatus(t *testing.T) {
 		tt := tt // Capture range variable.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client.AddHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
+			client.AddMockHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
 
 			status, err := GetTaskStatus(tt.ctx, client.Client, tt.taskUUID)
 			assert.Equal(t, tt.expectedErr, err)
@@ -153,7 +153,7 @@ func Test_WaitForTaskCompletion(t *testing.T) {
 		tt := tt // Capture range variable.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client.AddHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
+			client.AddMockHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
 
 			err := WaitForTaskToSucceed(tt.ctx, client.Client, tt.taskUUID)
 			if tt.expectedErr != nil {

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	nutanixTestClient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/helpers/prism-go-client/v3"
+	nutanixtestclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/helpers/prism-go-client/v3"
 )
 
 func Test_GetTaskStatus(t *testing.T) {
-	client, err := nutanixTestClient.NewTestClient()
+	client, err := nutanixtestclient.NewTestClient()
 	assert.NoError(t, err)
 	// use cleanup over defer as the connection gets closed before the tests run with t.Parallel()
 	t.Cleanup(func() {
@@ -73,7 +73,7 @@ func Test_GetTaskStatus(t *testing.T) {
 		tt := tt // Capture range variable.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client.AddHandler(nutanixTestClient.GetTaskURLPath(tt.taskUUID), tt.handler)
+			client.AddHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
 
 			status, err := GetTaskStatus(tt.ctx, client.Client, tt.taskUUID)
 			assert.Equal(t, tt.expectedErr, err)
@@ -83,7 +83,7 @@ func Test_GetTaskStatus(t *testing.T) {
 }
 
 func Test_WaitForTaskCompletion(t *testing.T) {
-	client, err := nutanixTestClient.NewTestClient()
+	client, err := nutanixtestclient.NewTestClient()
 	assert.NoError(t, err)
 	// use cleanup over defer as the connection gets closed before the tests run with t.Parallel()
 	t.Cleanup(func() {
@@ -134,7 +134,7 @@ func Test_WaitForTaskCompletion(t *testing.T) {
 		tt := tt // Capture range variable.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			client.AddHandler(nutanixTestClient.GetTaskURLPath(tt.taskUUID), tt.handler)
+			client.AddHandler(nutanixtestclient.GetTaskURLPath(tt.taskUUID), tt.handler)
 
 			err := WaitForTaskToSucceed(tt.ctx, client.Client, tt.taskUUID)
 			if tt.expectedErr != nil {

--- a/test/helpers/prism-go-client/v3/client.go
+++ b/test/helpers/prism-go-client/v3/client.go
@@ -60,7 +60,7 @@ func (c *TestClient) Close() {
 	c.server.Close()
 }
 
-func (c *TestClient) AddHandler(pattern string, handler func(w http.ResponseWriter, r *http.Request)) {
+func (c *TestClient) AddMockHandler(pattern string, handler func(w http.ResponseWriter, r *http.Request)) {
 	c.mux.HandleFunc(pattern, handler)
 }
 

--- a/test/helpers/prism-go-client/v3/client.go
+++ b/test/helpers/prism-go-client/v3/client.go
@@ -1,0 +1,53 @@
+package v3
+
+import (
+	"fmt"
+
+	"net/http"
+	"net/http/httptest"
+	"path"
+
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
+	nutanixClientV3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+)
+
+const (
+	baseURLPath = "/api/nutanix/v3/"
+)
+
+type TestClient struct {
+	*nutanixClientV3.Client
+
+	mux    *http.ServeMux
+	server *httptest.Server
+}
+
+func NewTestClient() (*TestClient, error) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	cred := prismgoclient.Credentials{
+		URL:      server.URL,
+		Username: "username",
+		Password: "password",
+		Endpoint: "0.0.0.0",
+	}
+
+	client, err := nutanixClientV3.NewV3Client(cred)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Nutanix test client: %w", err)
+	}
+	return &TestClient{client, mux, server}, nil
+}
+
+func (c *TestClient) Close() {
+	c.server.Close()
+}
+
+func (c *TestClient) AddHandler(pattern string, handler func(w http.ResponseWriter, r *http.Request)) {
+	c.mux.HandleFunc(pattern, handler)
+}
+
+func GetTaskURLPath(uuid string) string {
+	return path.Join(baseURLPath, "tasks", uuid)
+}

--- a/test/helpers/prism-go-client/v3/client.go
+++ b/test/helpers/prism-go-client/v3/client.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v3
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This started as an effort to start increasing the code coverage, but noticed that there was some code we can remove and instead rely on the apimachine `wait` helper functions.

1. Added unit tests to cover existing functions
2. Removed the custom wait code (~notice how only the error message with the timeout changed, all other tests cases stayed the same~, all tests stayed the same after the refactor)
3. While working on the PR I kept getting mixed up on "state" vs "status" as they were being used interchangeably. I made it all consistent with "status" as that is what the API returns. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

New unit tests

**Special notes for your reviewer**:
I broke up the PR into logical commits and would recommend reviewing it that way too.

I initially started by trying to mock the client but the is a bug that prevented me from doing that https://github.com/nutanix-cloud-native/prism-go-client/pull/150. I went with the http route based on the client's own test files https://github.com/nutanix-cloud-native/prism-go-client/blob/main/v3/v3_service_test.go, but can refactor back to using mocks if we find that to be easier to maintain, if/when the bug PR is merged and released.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```