### PR TITLE
Add `pkg_test.go` files for every package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ endif
 
 .PHONY: coverage
 coverage: setup-envtest ## Run the tests of the project and export the coverage
-	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION)  --arch=amd64 -p path)" $(GOTEST) -cover -covermode=count -coverprofile=profile.cov ./...
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 -p path)" $(GOTEST) -cover -covermode=count -coverprofile=profile.cov -coverpkg=./... ./...
 	$(GOTOOL) cover -func profile.cov
 ifeq ($(EXPORT_RESULT), true)
 	GO111MODULE=off $(GOGET) -u github.com/AlekSi/gocov-xml

--- a/api/v1alpha4/v1alpha4_test.go
+++ b/api/v1alpha4/v1alpha4_test.go
@@ -1,0 +1,60 @@
+package v1alpha4
+
+import (
+	"testing"
+
+	"github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
+
+	"github.com/nutanix-cloud-native/prism-go-client/utils"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+func TestNutanixCluster(t *testing.T) {
+	// Tests DeepCopyObject on NutanixCluster
+	clusterSpec := NutanixClusterSpec{
+		ControlPlaneEndpoint: v1alpha4.APIEndpoint{},
+		PrismCentral:         &credentials.NutanixPrismEndpoint{},
+		FailureDomains:       []NutanixFailureDomain{},
+	}
+
+	clusterStatus := NutanixClusterStatus{
+		FailureDomains: map[string]v1alpha4.FailureDomainSpec{},
+	}
+
+	cluster := NutanixCluster{
+		Spec:   clusterSpec,
+		Status: clusterStatus,
+	}
+
+	obj := cluster.DeepCopyObject()
+	assert.NotNil(t, obj)
+}
+
+func TestNutanixMachine(t *testing.T) {
+	// Tests DeepCopyObject on NutanixMachine
+	machineSpec := NutanixMachineSpec{
+		Image: NutanixResourceIdentifier{
+			Type: NutanixIdentifierName,
+			Name: utils.StringPtr("test-image"),
+		},
+		AdditionalCategories: []NutanixCategoryIdentifier{
+			{
+				Key:   "key",
+				Value: "value",
+			},
+		},
+	}
+
+	machineStatus := NutanixMachineStatus{
+		Addresses: []v1alpha4.MachineAddress{},
+	}
+
+	machine := NutanixMachine{
+		Spec:   machineSpec,
+		Status: machineStatus,
+	}
+
+	obj := machine.DeepCopyObject()
+	assert.NotNil(t, obj)
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClient(t *testing.T) {
+	clientHelper, err := NewNutanixClientHelper(nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, clientHelper)
+}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,0 +1,51 @@
+package context
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"testing"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+func TestIsControlPlaneMachine(t *testing.T) {
+	tests := []struct {
+		name     string
+		machine  *infrav1.NutanixMachine
+		expected bool
+	}{
+		{
+			name:     "control plane machine",
+			expected: true,
+			machine: &infrav1.NutanixMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						capiv1.MachineControlPlaneLabelName: "",
+					},
+				},
+			},
+		},
+		{
+			name:     "worker machine",
+			expected: false,
+			machine: &infrav1.NutanixMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+		},
+		{
+			name:     "nil machine",
+			expected: false,
+			machine:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsControlPlaneMachine(tt.machine); got != tt.expected {
+				t.Errorf("IsControlPlaneMachine() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Unless a `pkg_test.go` file is present in a `pkg` package, go toolchain will not consider that package for the purposes of coverage metrics. This is a regression and will be fixed in go1.22 but until then we need these files in each package to keep the coverage report honest.