### PR TITLE
Bump up default version of CCM to v0.3.2

### DIFF
--- a/scripts/ccm_nutanix_update.sh
+++ b/scripts/ccm_nutanix_update.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NUTANIX_CCM_VERSION=0.3.1
+NUTANIX_CCM_VERSION=0.3.2
 NUTANIX_CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller
 
 helm repo add nutanix https://nutanix.github.io/helm/ --force-update && helm repo update

--- a/templates/base/nutanix-ccm.yaml
+++ b/templates/base/nutanix-ccm.yaml
@@ -186,7 +186,7 @@ spec:
           key: node.kubernetes.io/not-ready
           operator: Exists
       containers:
-        - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.1}"
+        - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.2}"
           imagePullPolicy: IfNotPresent
           name: nutanix-cloud-controller-manager
           env:

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -197,7 +197,7 @@ data:
               key: node.kubernetes.io/not-ready
               operator: Exists
           containers:
-            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.1}"
+            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.2}"
               imagePullPolicy: IfNotPresent
               name: nutanix-cloud-controller-manager
               env:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -197,7 +197,7 @@ data:
               key: node.kubernetes.io/not-ready
               operator: Exists
           containers:
-            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.1}"
+            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.2}"
               imagePullPolicy: IfNotPresent
               name: nutanix-cloud-controller-manager
               env:

--- a/test/e2e/data/infrastructure-nutanix/ccm-update.yaml
+++ b/test/e2e/data/infrastructure-nutanix/ccm-update.yaml
@@ -189,7 +189,7 @@ data:
               key: node.kubernetes.io/not-ready
               operator: Exists
           containers:
-            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.1}"
+            - image: "${CCM_REPO=ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller}:${CCM_TAG=v0.3.2}"
               imagePullPolicy: IfNotPresent
               name: nutanix-cloud-controller-manager
               env:


### PR DESCRIPTION
v0.3.2 is the last version of CCM that will adhere to a static version strategy. Going forward we will have a CCM version per kubernetes version.