### PR TITLE
Update codecov.yml to omit generated code

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,10 @@
 codecov:
   require_ci_to_pass: yes
 
+ignore:
+  # ignore all generated controller-gen and conversion-gen code
+  - "**/zz_generated.*.go"
+
 coverage:
   precision: 2
   round: down
@@ -9,3 +13,4 @@ coverage:
     patch:
       default:
         target: 75%
+


### PR DESCRIPTION
Everytime we add or modify a CRD, we will fail to meet generated code coverage. The onus of ensuring the correctness of generated code lies on the generator itself. We can, in future, think about generating tests for this code (trust but verify) but, for the time being, it's best to exclude this from metrics.
