### PR TITLE
Use codecov token for uploading codecov report

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml  # Replace with the path to your coverage report
           fail_ci_if_error: true


### PR DESCRIPTION
This is to bypass the ratelimits that impact our coverage report upload sporadically.