### PR TITLE
Update Labels for E2E tests

### DIFF
--- a/test/e2e/basic_uuid_test.go
+++ b/test/e2e/basic_uuid_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
-var _ = Describe("Nutanix Basic Creation with UUID", Label("capx-feature-test", "uuid", "slow", "network"), func() {
+var _ = Describe("Nutanix Basic Creation with UUID", Label("capx-feature-test", "uuid"), func() {
 	const (
 		specName           = "cluster-uuid"
 		ccmInstanceTypeKey = "node.kubernetes.io/instance-type"

--- a/test/e2e/capx_quick_start_test.go
+++ b/test/e2e/capx_quick_start_test.go
@@ -20,11 +20,10 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	// "k8s.io/utils/pointer"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When following the Cluster API quick-start", Label("prblocker", "slow", "network"), func() {
+var _ = Describe("When following the Cluster API quick-start", Label("quickstart", "capx-feature-test"), func() {
 	capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
 		return capi_e2e.QuickStartSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/capx_regression_test.go
+++ b/test/e2e/capx_regression_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Nutanix regression tests", Label("capx-regression-test", "regression", "slow", "network"), func() {
+var _ = Describe("Nutanix regression tests", Label("capx-feature-test", "regression"), func() {
 	const specName = "capx-regression"
 
 	var (

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -35,7 +35,7 @@ const (
 	defaultNonExistingAdditionalCategoryValue = "nonExistingCategoryValueCAPX"
 )
 
-var _ = Describe("Nutanix categories", Label("capx-feature-test", "categories", "slow", "network"), func() {
+var _ = Describe("Nutanix categories", Label("capx-feature-test", "categories"), func() {
 	const (
 		specName = "cluster-categories"
 	)

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -26,7 +26,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When upgrading a workload cluster and testing K8S conformance", Label("cluster-upgrade-conformance", "slow", "network"), func() {
+var _ = Describe("When upgrading a workload cluster and testing K8S conformance", Label("cluster-upgrade-conformance"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -54,7 +54,7 @@ var _ = Describe("When upgrading a workload cluster and testing K8S conformance"
 // 	})
 // })
 
-var _ = Describe("When upgrading a workload cluster with a single control plane machine", Label("cluster-upgrade-conformance", "slow", "network"), func() {
+var _ = Describe("When upgrading a workload cluster with a single control plane machine", Label("cluster-upgrade-conformance"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -71,7 +71,7 @@ var _ = Describe("When upgrading a workload cluster with a single control plane 
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster with a HA control plane", Label("cluster-upgrade-conformance", "slow", "network"), func() {
+var _ = Describe("When upgrading a workload cluster with a HA control plane", Label("cluster-upgrade-conformance"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -88,7 +88,7 @@ var _ = Describe("When upgrading a workload cluster with a HA control plane", La
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster with a HA control plane using scale-in rollout", Label("cluster-upgrade-conformance", "slow", "network"), func() {
+var _ = Describe("When upgrading a workload cluster with a HA control plane using scale-in rollout", Label("cluster-upgrade-conformance"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -59,7 +59,7 @@ func getKubernetesVersion() string {
 	return "undefined"
 }
 
-var _ = Describe("[clusterctl-Upgrade] Upgrade CAPX (v1.2.4 => current) K8S "+kubernetesVersion, Label("clusterctl-upgrade", "slow", "network"), func() {
+var _ = Describe("[clusterctl-Upgrade] Upgrade CAPX (v1.2.4 => current) K8S "+kubernetesVersion, Label("clusterctl-upgrade"), func() {
 
 	preWaitForCluster := createPreWaitForClusterFunc(func() capi_e2e.ClusterctlUpgradeSpecInput {
 		return capi_e2e.ClusterctlUpgradeSpecInput{

--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi", "slow", "network"), func() {
+var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi"), func() {
 	const (
 		specName = "cluster-csi"
 

--- a/test/e2e/failure_domains_test.go
+++ b/test/e2e/failure_domains_test.go
@@ -42,7 +42,7 @@ const (
 //   - the control plane nodes are spread across the defined failure domains
 //   - the VMs are deployed on the correct Prism Element cluster and subnet
 //   - the correct failure domain conditions are applied to the nutanixCluster object
-var _ = Describe("Nutanix failure domains", Label("capx-feature-test", "failure-domains", "only-for-validation", "slow", "network"), func() {
+var _ = Describe("Nutanix failure domains", Label("capx-feature-test", "failure-domains", "only-for-validation"), func() {
 	const specName = "failure-domains"
 
 	var (

--- a/test/e2e/gpu_test.go
+++ b/test/e2e/gpu_test.go
@@ -35,7 +35,7 @@ const (
 	nutanixGPUVirtualNameEnv     = "NUTANIX_GPU_VIRTUAL_NAME"
 )
 
-var _ = Describe("Nutanix Passthrough GPU", Label("capx-feature-test", "only-for-validation", "passthrough", "gpu", "slow", "network"), func() {
+var _ = Describe("Nutanix Passthrough GPU", Label("capx-feature-test", "only-for-validation", "passthrough", "gpu"), func() {
 	const specName = "cluster-gpu-passthrough"
 
 	var (
@@ -187,7 +187,7 @@ var _ = Describe("Nutanix Passthrough GPU", Label("capx-feature-test", "only-for
 	})
 })
 
-var _ = Describe("Nutanix Virtual GPU", Label("capx-feature-test", "only-for-validation", "virtual", "gpu", "slow", "network"), func() {
+var _ = Describe("Nutanix Virtual GPU", Label("capx-feature-test", "only-for-validation", "virtual", "gpu"), func() {
 	const specName = "cluster-gpu-virtual"
 
 	var (

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -22,7 +22,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When testing K8S conformance", Label("conformance", "slow", "network"), func() {
+var _ = Describe("When testing K8S conformance", Label("conformance"), func() {
 	capi_e2e.K8SConformanceSpec(ctx, func() capi_e2e.K8SConformanceSpecInput {
 		return capi_e2e.K8SConformanceSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -24,7 +24,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When testing MachineDeployment rolling upgrades", Label("md-rolling-upgrades", "slow", "network"), func() {
+var _ = Describe("When testing MachineDeployment rolling upgrades", Label("scaling", "md-rolling-upgrades"), func() {
 	capi_e2e.MachineDeploymentRolloutSpec(ctx, func() capi_e2e.MachineDeploymentRolloutSpecInput {
 		return capi_e2e.MachineDeploymentRolloutSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-out-in", "slow", "network"), func() {
+var _ = Describe("When testing MachineDeployment scale out/in", Label("scaling", "md-scale-out-in"), func() {
 	capi_e2e.MachineDeploymentScaleSpec(ctx, func() capi_e2e.MachineDeploymentScaleSpecInput {
 		return capi_e2e.MachineDeploymentScaleSpecInput{
 			E2EConfig:             e2eConfig,
@@ -47,7 +47,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", Label("md-scale-
 })
 
 // Label `only-for-validation` is used to run this test only for validation and not as part of the regular test suite.
-var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again", Label("md-scale-up-down", "slow", "network", "only-for-validation"), func() {
+var _ = Describe("When testing MachineDeployment scale up/down from 10 replicas to 20 replicas to 10 again", Label("scaling", "md-scale-up-down", "only-for-validation"), func() {
 	// MachineDeploymentScaleSpec implements a test that verifies that MachineDeployment scale operations are successful.
 	inputGetter := func() capi_e2e.MachineDeploymentScaleSpecInput {
 		return capi_e2e.MachineDeploymentScaleSpecInput{

--- a/test/e2e/mhc_remediations_test.go
+++ b/test/e2e/mhc_remediations_test.go
@@ -24,7 +24,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When testing unhealthy machines remediation", Label("machine-health-remediation", "slow", "network"), func() {
+var _ = Describe("When testing unhealthy machines remediation", Label("scaling", "machine-health-remediation"), func() {
 	capi_e2e.MachineRemediationSpec(ctx, func() capi_e2e.MachineRemediationSpecInput {
 		return capi_e2e.MachineRemediationSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -35,7 +35,7 @@ const (
 	additionalSubnetVarKey = "NUTANIX_ADDITIONAL_SUBNET_NAME"
 )
 
-var _ = Describe("Nutanix Subnets", Label("capx-feature-test", "multi-nic", "slow", "network"), func() {
+var _ = Describe("Nutanix Subnets", Label("capx-feature-test", "multi-nic"), func() {
 	const specName = "cluster-multi-nic"
 
 	var (

--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -33,7 +33,7 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
-var _ = Describe("Nutanix client", Label("capx-feature-test", "nutanix-client", "slow", "network"), func() {
+var _ = Describe("Nutanix client", Label("capx-feature-test", "nutanix-client"), func() {
 	const (
 		specName = "cluster-ntnx-client"
 

--- a/test/e2e/projects_test.go
+++ b/test/e2e/projects_test.go
@@ -31,7 +31,7 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
-var _ = Describe("Nutanix projects", Label("capx-feature-test", "projects", "slow", "network"), func() {
+var _ = Describe("Nutanix projects", Label("capx-feature-test", "projects"), func() {
 	const (
 		specName               = "cluster-projects"
 		nonExistingProjectName = "nonExistingProjectNameCAPX"


### PR DESCRIPTION
- Replace 'prblocker' with 'quickstart' to clarify intent
- Remove 'slow' and 'network' as every test had it making it moot
- Expand scope of 'capx-feature-test' to target all nutanix interactions
- Add 'scaling' to target all tests involving node churn
