### PR TITLE
remove CPU/Memory resources settings

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -114,12 +114,6 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-          resources:
-            limits:
-              memory: 100Mi
-            requests:
-              cpu: 30m
-              memory: 50Mi
       volumes:
         - name: endpoint
           configMap:


### PR DESCRIPTION
This PR fully removes the CPU/Memory limits as it is generally recommended not to enforce them.

goal is to align with other provider like CAPV/CAPA/CAPG

