### PR TITLE
Change target Github branches for Github Actions

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -3,9 +3,10 @@ env:
   EXPORT_RESULT: true
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: ["main"]
 jobs:
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,10 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
   schedule:
     - cron: '30 1 * * 0'
 

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,9 +1,10 @@
 name: Black Duck Policy Check
 on:
   pull_request:
+  push:
     branches:
       - main
-  push:
+      - 'release-*'
 
 jobs:
   security:


### PR DESCRIPTION
The actions would previously run against PRs that were based against the main branch. They should run on any PR against any branch. The Push triggers should be limited to main and 'release-*' branches.
