### PR TITLE
removed namespace for clusterclass and cluster with topology

### DIFF
--- a/templates/base-root/kustomization.yaml
+++ b/templates/base-root/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: "${NAMESPACE}"
-
 configMapGenerator:
 - name: nutanix-ccm
   behavior: merge

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -4,7 +4,6 @@ binaryData:
 kind: ConfigMap
 metadata:
   name: ${CLUSTER_NAME}-pc-trusted-ca-bundle
-  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -223,13 +222,11 @@ data:
 kind: ConfigMap
 metadata:
   name: nutanix-ccm
-  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${NAMESPACE}
 stringData:
   credentials: |
     [
@@ -248,7 +245,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: nutanix-ccm-secret
-  namespace: ${NAMESPACE}
 stringData:
   nutanix-ccm-secret.yaml: |
     apiVersion: v1
@@ -276,7 +272,6 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: nutanix-ccm-crs
-  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -294,7 +289,6 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-kcfg-0
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -315,7 +309,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: ${CLUSTER_CLASS_NAME}
-  namespace: ${NAMESPACE}
 spec:
   controlPlane:
     machineHealthCheck:
@@ -621,7 +614,6 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-kcpt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -753,7 +745,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixClusterTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-nct
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -763,7 +754,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-cp-nmt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -787,7 +777,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-md-nmt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -5,7 +5,6 @@ metadata:
     ccm: nutanix
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
   name: ${CLUSTER_NAME}
-  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     pods:

--- a/templates/clusterclass/kustomization.yaml
+++ b/templates/clusterclass/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: "${NAMESPACE}"
-
 bases:
   - ../base-root
   - ./nct.yaml

--- a/templates/topology/kustomization.yaml
+++ b/templates/topology/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: "${NAMESPACE}"
-
 bases:
   - ./cluster-with-topology.yaml
 

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/clusterclass-e2e.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/clusterclass-e2e.yaml
@@ -4,7 +4,6 @@ binaryData:
 kind: ConfigMap
 metadata:
   name: ${CLUSTER_NAME}-pc-trusted-ca-bundle
-  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 data:
@@ -223,13 +222,11 @@ data:
 kind: ConfigMap
 metadata:
   name: nutanix-ccm
-  namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: ${NAMESPACE}
 stringData:
   credentials: |
     [
@@ -248,7 +245,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: nutanix-ccm-secret
-  namespace: ${NAMESPACE}
 stringData:
   nutanix-ccm-secret.yaml: |
     apiVersion: v1
@@ -276,7 +272,6 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: nutanix-ccm-crs
-  namespace: ${NAMESPACE}
 spec:
   clusterSelector:
     matchLabels:
@@ -294,7 +289,6 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-kcfg-0
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -315,7 +309,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: ${CLUSTER_CLASS_NAME}
-  namespace: ${NAMESPACE}
 spec:
   controlPlane:
     machineHealthCheck:
@@ -621,7 +614,6 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-kcpt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -753,7 +745,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixClusterTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-nct
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -763,7 +754,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-cp-nmt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -787,7 +777,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-md-nmt
-  namespace: ${NAMESPACE}
 spec:
   template:
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the default addition of namespace in all the objects related to clusterclass and cluster with topology so that user does not have to define an extra env variable NAMESPACE and can provide teh same at the time of kubectl create/apply itself giving them flexibility and its also a standard practice in the industry

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:
<pre>
make cluster-templates
make cluster-e2e-templates
</pre>

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```