### PR TITLE
Update kustomization.yaml files to new format

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 - bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_nutanixclusters.yaml
@@ -25,34 +24,38 @@ patchesStrategicMerge:
 #- patches/cainjection_in_nutanixclustertemplates.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-patchesJson6902:
   # controller-gen doesn't allow for complex anyOf declarations in CRD generation code markers so we have to add these
   # via a JSON patch instead.
   #
   # This enforces the Prism Central address to be either a hostname or an IP address without resorting to complex
   # regular expressions.
-  - target:
-      group: apiextensions.k8s.io
-      version: v1
-      kind: CustomResourceDefinition
-      name: nutanixclusters.infrastructure.cluster.x-k8s.io
-    patch: |-
-      - op: add
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/prismCentral/properties/address/anyOf
-        value:
-          - format: hostname
-          - format: ipv4
-          - format: ipv6
-      - op: add
-        path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/prismCentral/properties/address/anyOf
-        value:
-          - format: hostname
-          - format: ipv4
-          - format: ipv6
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
 
-commonLabels:
-  cluster.x-k8s.io/v1beta1: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/v1beta1: v1beta1
+patches:
+- patch: |-
+    - op: add
+      path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/prismCentral/properties/address/anyOf
+      value:
+        - format: hostname
+        - format: ipv4
+        - format: ipv6
+    - op: add
+      path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/prismCentral/properties/address/anyOf
+      value:
+        - format: hostname
+        - format: ipv4
+        - format: ipv6
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    name: nutanixclusters.infrastructure.cluster.x-k8s.io
+    version: v1

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,13 +9,7 @@ namespace: capx-system
 namePrefix: capx-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  cluster.x-k8s.io/provider: "infrastructure-nutanix"
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
@@ -24,11 +18,9 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
@@ -44,31 +36,15 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: infrastructure-nutanix
+patches:
+- path: manager_auth_proxy_patch.yaml

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - monitor.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,18 +1,20 @@
-resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
-# Comment the following 4 lines if you want to disable
-# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-# which protects your /metrics endpoint.
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/templates/base/kustomization.yaml
+++ b/templates/base/kustomization.yaml
@@ -1,19 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: "${NAMESPACE}"
+namespace: ${NAMESPACE}
 
-bases:
-  - ../ccm
-  - ./cm.yaml
-  - ./secret.yaml
-  - ./nutanix-cluster.yaml
-  - ./cluster-without-topology.yaml
-  - ./kcp.yaml
-  - ./kct.yaml
-  - ./nmt.yaml
-  - ./md.yaml
-  - ./mhc.yaml
 
-patchesStrategicMerge:
-- ./ccm-patch.yaml
+resources:
+- ../ccm
+- ./cm.yaml
+- ./secret.yaml
+- ./nutanix-cluster.yaml
+- ./cluster-without-topology.yaml
+- ./kcp.yaml
+- ./kct.yaml
+- ./nmt.yaml
+- ./md.yaml
+- ./mhc.yaml
+patches:
+- path: ./ccm-patch.yaml

--- a/templates/ccm/kustomization.yaml
+++ b/templates/ccm/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 configMapGenerator:
-- name: nutanix-ccm
-  behavior: merge
+- behavior: merge
   files:
   - nutanix-ccm.yaml
+  name: nutanix-ccm
 
-bases:
-  - ./nutanix-ccm-crs.yaml
-  - ./nutanix-ccm-secret.yaml
+resources:
+- ./nutanix-ccm-crs.yaml
+- ./nutanix-ccm-secret.yaml

--- a/templates/clusterclass/kustomization.yaml
+++ b/templates/clusterclass/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ./nct.yaml
-  - ./clusterclass.yaml
-  - ./nmt-cp.yaml
-  - ./nmt-md.yaml
-  - ./kcpt.yaml
-  - ./kct.yaml
+resources:
+- ./nct.yaml
+- ./clusterclass.yaml
+- ./nmt-cp.yaml
+- ./nmt-md.yaml
+- ./kcpt.yaml
+- ./kct.yaml

--- a/templates/csi/kustomization.yaml
+++ b/templates/csi/kustomization.yaml
@@ -2,17 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 configMapGenerator:
-- name: nutanix-csi
-  behavior: merge
+- behavior: merge
   files:
   - nutanix-csi-storage.yaml
   - nutanix-csi-snapshot.yaml
   - nutanix-csi-webhook.yaml
+  name: nutanix-csi
 
 resources:
 - ../base/
 - nutanix-csi.yaml
 - nutanix-csi-crs.yaml
 
-patchesStrategicMerge:
-- csi-patch.yaml
+patches:
+- path: csi-patch.yaml

--- a/templates/topology/kustomization.yaml
+++ b/templates/topology/kustomization.yaml
@@ -2,17 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 configMapGenerator:
-- name: nutanix-ccm
-  behavior: merge
+- behavior: merge
   files:
   - nutanix-ccm.yaml
+  name: nutanix-ccm
 
-bases:
-  - ./cm.yaml
-  - ./cluster-with-topology.yaml
-  - ./secret.yaml
-  - ./nutanix-ccm-secret.yaml
-  - ./nutanix-ccm-crs.yaml
 
-patchesStrategicMerge:
-- ./ccm-patch.yaml
+resources:
+- ./cm.yaml
+- ./cluster-with-topology.yaml
+- ./secret.yaml
+- ./nutanix-ccm-secret.yaml
+- ./nutanix-ccm-crs.yaml
+patches:
+- path: ./ccm-patch.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1.2.4/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1.2.4/cluster-template/kustomization.yaml
@@ -1,14 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-bases:
-  - ../base/cluster-with-kcp.yaml
-  - ../base/secret.yaml
-  - ../base/cm.yaml
-  - ../base/nmt.yaml
-  - ../base/md.yaml
-  - ../base/mhc.yaml
-  - ../base/crs.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
+resources:
+- ../base/cluster-with-kcp.yaml
+- ../base/secret.yaml
+- ../base/cm.yaml
+- ../base/nmt.yaml
+- ../base/md.yaml
+- ../base/mhc.yaml
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1.3.0/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1.3.0/cluster-template/kustomization.yaml
@@ -1,23 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 configMapGenerator:
-- name: nutanix-ccm
-  behavior: merge
+- behavior: merge
   files:
   - ../base/nutanix-ccm.yaml
-
-bases:
-  - ../base/cluster-with-kcp.yaml
-  - ../base/secret.yaml
-  - ../base/cm.yaml
-  - ../base/nmt.yaml
-  - ../base/crs.yaml
-  - ../base/md.yaml
-  - ../base/mhc.yaml
-  - ../base/nutanix-ccm-crs.yaml
-  - ../base/nutanix-ccm-secret.yaml
-
-patchesStrategicMerge:
-  - ../base/ccm-patch.yaml
-  - ../base/cni-patch.yaml
+  name: nutanix-ccm
+resources:
+- ../base/cluster-with-kcp.yaml
+- ../base/secret.yaml
+- ../base/cm.yaml
+- ../base/nmt.yaml
+- ../base/crs.yaml
+- ../base/md.yaml
+- ../base/mhc.yaml
+- ../base/nutanix-ccm-crs.yaml
+- ../base/nutanix-ccm-secret.yaml
+patches:
+- path: ../base/ccm-patch.yaml
+- path: ../base/cni-patch.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1alpha4/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1alpha4/cluster-template/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-  - ../bases/cluster-with-kcp.yaml
-  - ../bases/md.yaml
-  - ../bases/mhc.yaml
-  - ../bases/cm.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../bases/cluster-with-kcp.yaml
+- ../bases/md.yaml
+- ../bases/mhc.yaml
+- ../bases/cm.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1alpha4/no-kubeproxy/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1alpha4/no-kubeproxy/cluster-template/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../cluster-template
-
-patchesStrategicMerge:
-  - ./nmt.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../cluster-template
+patches:
+- path: ./nmt.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-clusterclass/kustomization.yaml
@@ -1,2 +1,4 @@
-bases:
-  - ../../../../../../templates/clusterclass/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/clusterclass/

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kustomization.yaml
@@ -1,8 +1,9 @@
-bases:
-  - ../../../../../../templates/csi/
-  - ../base/crs.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ./kcp.yaml
-  - ./kct.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/csi/
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ./kcp.yaml
+- path: ./kct.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-failure-domains/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-failure-domains/kustomization.yaml
@@ -1,24 +1,24 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-  - failure-domain-nmt.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+- failure-domain-nmt.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: failure-domain-patch.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - failure-domain-patch.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,23 +1,23 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/nmt.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-  - ./mhc.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/nmt.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+- ./mhc.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -1,6 +1,7 @@
-bases:
-  - ../cluster-template-upgrades
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ./cluster-with-kcp.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../cluster-template-upgrades
+patches:
+- path: ../base/cni-patch.yaml
+- path: ./cluster-with-kcp.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -1,24 +1,24 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/nmt.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-  - ./mhc.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/nmt.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+- ./mhc.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ./md.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ./md.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt/kustomization.yaml
@@ -1,22 +1,22 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nutanix-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nutanix-cluster/kustomization.yaml
@@ -1,23 +1,23 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/nmt.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/nmt.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ./nc.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ./nc.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret/kustomization.yaml
@@ -1,22 +1,22 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/nmt.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../base/crs.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/nmt.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project/kustomization.yaml
@@ -1,24 +1,24 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/nmt.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/nmt.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ./nmt.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ./nmt.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-topology/kustomization.yaml
@@ -1,6 +1,7 @@
-bases:
-  - ../../../../../../templates/topology/
-  - ../base/crs.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/topology/
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/kustomization.yaml
@@ -1,23 +1,23 @@
-bases:
-  - ../../../../../../templates/base/nutanix-cluster.yaml
-  - ../../../../../../templates/base/cluster-without-topology.yaml
-  - ../../../../../../templates/base/kcp.yaml
-  - ../../../../../../templates/base/kct.yaml
-  - ../../../../../../templates/base/secret.yaml
-  - ../../../../../../templates/base/cm.yaml
-  - ../../../../../../templates/base/md.yaml
-  - ../../../../../../templates/base/mhc.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
-  - ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
-  - ../base/crs.yaml
-  - ./nmt.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/nutanix-cluster.yaml
+- ../../../../../../templates/base/cluster-without-topology.yaml
+- ../../../../../../templates/base/kcp.yaml
+- ../../../../../../templates/base/kct.yaml
+- ../../../../../../templates/base/secret.yaml
+- ../../../../../../templates/base/cm.yaml
+- ../../../../../../templates/base/md.yaml
+- ../../../../../../templates/base/mhc.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-crs.yaml
+- ../../../../../../templates/ccm/nutanix-ccm-secret.yaml
+- ../base/crs.yaml
+- ./nmt.yaml
+patches:
+- path: ../base/cni-patch.yaml
+- path: ../../../../../../templates/base/ccm-patch.yaml
 configMapGenerator:
-  - name: nutanix-ccm
-    behavior: merge
+  - behavior: merge
     files:
       - ../../../../../../templates/ccm/nutanix-ccm.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
-  - ../../../../../../templates/base/ccm-patch.yaml
+    name: nutanix-ccm

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template/kustomization.yaml
@@ -1,6 +1,7 @@
-bases:
-  - ../../../../../../templates/base/
-  - ../base/crs.yaml
-
-patchesStrategicMerge:
-  - ../base/cni-patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../templates/base/
+- ../base/crs.yaml
+patches:
+- path: ../base/cni-patch.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-additional-categories/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-additional-categories/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-additional-categories/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-additional-categories/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-clusterclass/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-clusterclass/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-clusterclass/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy-clusterclass.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-clusterclass/
+patches:
+- path: ../no-kubeproxy-clusterclass.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-csi/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-csi/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-csi/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-csi/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-failure-domains/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-failure-domains/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-failure-domains/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-failure-domains/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-kcp-remediation/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-kcp-remediation/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-kcp-scale-in/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-kcp-scale-in/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-kcp-scale-in/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-md-remediation/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-md-remediation/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-md-remediation/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-nmt/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-nmt/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-no-nmt/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-no-nmt/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-nutanix-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-nutanix-cluster/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-no-nutanix-cluster/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-no-nutanix-cluster/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-secret/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-no-secret/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-no-secret/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-no-secret/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-project/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-project/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-project/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-project/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-topology/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-topology/kustomization.yaml
@@ -1,2 +1,4 @@
-bases:
-  - ../../cluster-template-topology/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-topology/

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template-upgrades/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template-upgrades/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template-upgrades/
+patches:
+- path: ../no-kubeproxy.yaml

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/no-kubeproxy/cluster-template/kustomization.yaml
@@ -1,5 +1,6 @@
-bases:
-  - ../../cluster-template/
-
-patchesStrategicMerge:
-  - ../no-kubeproxy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../cluster-template/
+patches:
+- path: ../no-kubeproxy.yaml


### PR DESCRIPTION
kustomize has deprecated the older format which our older kustomization files were based on. These older format files were leading to a lot of deprecation warnings from kustomize during our build processes.

We used `kustomize edit fix` command to update our old kustomize files to our new kustomize files. This PR was largely auto-generated using the following command.

```
$ find . -type d -exec bash -c 'cd {} && kustomize edit fix' \;
```