### PR TITLE
Mark v1alpha4 CRDs as Deprecated and Unserved

### DIFF
--- a/api/v1alpha4/doc.go
+++ b/api/v1alpha4/doc.go
@@ -19,4 +19,6 @@ limitations under the License.
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 // +k8s:conversion-gen=github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/api/v1alpha4/nutanixcluster_types.go
+++ b/api/v1alpha4/nutanixcluster_types.go
@@ -91,6 +91,8 @@ type NutanixClusterStatus struct {
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="in ready status"
 
 // NutanixCluster is the Schema for the nutanixclusters API
+// +kubebuilder:deprecatedversion:warning=v1alpha4 NutanixCluster is deprecated and marked as unserved. It will be removed in a future release. Use v1beta1 NutanixCluster instead.
+// +kubebuilder:unservedversion
 type NutanixCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/nutanixmachine_types.go
+++ b/api/v1alpha4/nutanixmachine_types.go
@@ -134,6 +134,8 @@ type NutanixMachineStatus struct {
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="NutanixMachine instance ID"
 
 // NutanixMachine is the Schema for the nutanixmachines API
+// +kubebuilder:deprecatedversion:warning=v1alpha4 NutanixMachine is deprecated and marked as unserved. It will be removed in a future release. Use v1beta1 NutanixMachine instead.
+// +kubebuilder:unservedversion
 type NutanixMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -27,6 +27,9 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: string
+    deprecated: true
+    deprecationWarning: v1alpha4 NutanixCluster is deprecated and marked as unserved.
+      It will be removed in a future release. Use v1beta1 NutanixCluster instead.
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -300,7 +303,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -31,6 +31,9 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
+    deprecated: true
+    deprecationWarning: v1alpha4 NutanixMachine is deprecated and marked as unserved.
+      It will be removed in a future release. Use v1beta1 NutanixMachine instead.
     name: v1alpha4
     schema:
       openAPIV3Schema:
@@ -351,7 +354,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	infrav1alpha4 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1alpha4"
+	infrav1alpha4 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1alpha4" //nolint:staticcheck // deprecated package; will be removed in one of the next releases
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-provider-nutanix/controllers"
 	//+kubebuilder:scaffold:imports


### PR DESCRIPTION
CAPI v1.6 has v1alpha4 types marked as deprecated and unserved. To stay in sync, we are doing the same. With v1.7 these will be removed entirely and we will follow suit when we update to v1.7.