### PR TITLE
Reduce the memory of upgrade e2e nutanixmachinetemplate

### DIFF
--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades/nmt.yaml
@@ -11,7 +11,7 @@ spec:
       bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
       vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
       vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
-      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=8Gi}"
+      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"
       systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
       image:
         type: name
@@ -36,7 +36,7 @@ spec:
       bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
       vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
       vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
-      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=8Gi}"
+      memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"
       systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
       image:
         type: name


### PR DESCRIPTION
All other e2e machine templates are 4Gi of memory. This change reduces the upgrade e2e machine template from 8Gi to 4Gi to reduce unnecessary resource consumption in our CI environment.