### PR TITLE
Cherry-pick PR #382 to release-v1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ coverage.xml
 clusterctl.yaml
 cluster.yaml
 *.workload.kubeconfig
+
+junit-report.xml
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 GOCMD=go
 GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
+GOINSTALL=$(GOCMD) install
 GOTOOL=$(GOCMD) tool
 EXPORT_RESULT?=false # for CI please set EXPORT_RESULT to true
 # Image URL to use all building/pushing image targets
@@ -81,7 +81,7 @@ SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
 
-CONTROLLER_GEN_VER := v0.8.0
+CONTROLLER_GEN_VER := v0.14.0
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER))
 CONTROLLER_GEN_PKG := sigs.k8s.io/controller-tools/cmd/controller-gen
@@ -372,7 +372,7 @@ prepare-local-clusterctl: manifests kustomize cluster-templates envsubst ## Prep
 .PHONY: unit-test
 unit-test: setup-envtest ## Run unit tests.
 ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off $(GOGET) -u github.com/jstemmer/go-junit-report
+	$(GOINSTALL) github.com/jstemmer/go-junit-report/v2@latest
 	$(eval OUTPUT_OPTIONS = | go-junit-report -set-exit-code > junit-report.xml)
 endif
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION)  --arch=amd64 -p path)" $(GOTEST) ./... $(OUTPUT_OPTIONS)
@@ -382,8 +382,8 @@ coverage: setup-envtest ## Run the tests of the project and export the coverage
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=amd64 -p path)" $(GOTEST) -cover -covermode=count -coverprofile=profile.cov -coverpkg=./... ./...
 	$(GOTOOL) cover -func profile.cov
 ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off $(GOGET) -u github.com/AlekSi/gocov-xml
-	GO111MODULE=off $(GOGET) -u github.com/axw/gocov/gocov
+	$(GOINSTALL) github.com/AlekSi/gocov-xml@latest
+	$(GOINSTALL) github.com/axw/gocov/gocov@latest
 	gocov convert profile.cov | gocov-xml > coverage.xml
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: $(CONTROLLER_GEN_BIN) ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: release-manifests
@@ -228,7 +228,7 @@ release-manifests: manifests cluster-templates
 	cp $(REPO_ROOT)/metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: generate
-generate: controller-gen conversion-gen ## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject method implementations and API conversion implementations.
+generate: $(CONTROLLER_GEN_BIN) $(CONVERSION_GEN_BIN) ## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject method implementations and API conversion implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 	$(CONVERSION_GEN) \

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: nutanixclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -34,14 +33,19 @@ spec:
         description: NutanixCluster is the Schema for the nutanixclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,9 +53,9 @@ spec:
             description: NutanixClusterSpec defines the desired state of NutanixCluster
             properties:
               controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane. host can be either DNS name
-                  or ip address
+                description: |-
+                  ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                  host can be either DNS name or ip address
                 properties:
                   host:
                     description: The hostname on which the API server is serving.
@@ -65,20 +69,19 @@ spec:
                 - port
                 type: object
               failureDomains:
-                description: failureDomains configures failure domains information
-                  for the Nutanix platform. When set, the failure domains defined
-                  here may be used to spread Machines across prism element clusters
-                  to improve fault tolerance of the cluster.
+                description: |-
+                  failureDomains configures failure domains information for the Nutanix platform.
+                  When set, the failure domains defined here may be used to spread Machines across
+                  prism element clusters to improve fault tolerance of the cluster.
                 items:
                   description: NutanixFailureDomain configures failure domain information
                     for Nutanix.
                   properties:
                     cluster:
-                      description: cluster is to identify the cluster (the Prism Element
-                        under management of the Prism Central), in which the Machine's
-                        VM will be created. The cluster identifier (uuid or name)
-                        can be obtained from the Prism Central console or using the
-                        prism_central API.
+                      description: |-
+                        cluster is to identify the cluster (the Prism Element under management of the Prism Central),
+                        in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained
+                        from the Prism Central console or using the prism_central API.
                       properties:
                         name:
                           description: name is the resource name in the PC
@@ -101,22 +104,21 @@ spec:
                         plane nodes
                       type: boolean
                     name:
-                      description: name defines the unique name of a failure domain.
+                      description: |-
+                        name defines the unique name of a failure domain.
                         Name is required and must be at most 64 characters in length.
-                        It must consist of only lower case alphanumeric characters
-                        and hyphens (-). It must start and end with an alphanumeric
-                        character. This value is arbitrary and is used to identify
-                        the failure domain within the platform.
+                        It must consist of only lower case alphanumeric characters and hyphens (-).
+                        It must start and end with an alphanumeric character.
+                        This value is arbitrary and is used to identify the failure domain within the platform.
                       maxLength: 64
                       minLength: 1
                       pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                       type: string
                     subnets:
-                      description: subnets holds a list of identifiers (one or more)
-                        of the cluster's network subnets for the Machine's VM to connect
-                        to. The subnet identifiers (uuid or name) can be obtained
-                        from the Prism Central console or using the prism_central
-                        API.
+                      description: |-
+                        subnets holds a list of identifiers (one or more) of the cluster's network subnets
+                        for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be
+                        obtained from the Prism Central console or using the prism_central API.
                       items:
                         description: NutanixResourceIdentifier holds the identity
                           of a Nutanix PC resource (cluster, image, subnet, etc.)
@@ -152,18 +154,17 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               prismCentral:
-                description: prismCentral holds the endpoint address and port to access
-                  the Nutanix Prism Central. When a cluster-wide proxy is installed,
-                  by default, this endpoint will be accessed via the proxy. Should
-                  you wish for communication with this endpoint not to be proxied,
-                  please add the endpoint to the proxy spec.noProxy list.
+                description: |-
+                  prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
+                  When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
+                  Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
+                  proxy spec.noProxy list.
                 properties:
                   additionalTrustBundle:
-                    description: AdditionalTrustBundle is a PEM encoded x509 cert
-                      for the RootCA that was used to create the certificate for a
-                      Prism Central that uses certificates that were issued by a non-publicly
-                      trusted RootCA. The trust bundle is added to the cert pool used
-                      to authenticate the TLS connection to the Prism Central.
+                    description: |-
+                      AdditionalTrustBundle is a PEM encoded x509 cert for the RootCA that was used to create the certificate
+                      for a Prism Central that uses certificates that were issued by a non-publicly trusted RootCA. The trust
+                      bundle is added to the cert pool used to authenticate the TLS connection to the Prism Central.
                     properties:
                       data:
                         description: Data of the trust bundle if Kind is String.
@@ -235,37 +236,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - status
@@ -274,9 +275,9 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
@@ -320,14 +321,19 @@ spec:
         description: NutanixCluster is the Schema for the nutanixclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -335,9 +341,9 @@ spec:
             description: NutanixClusterSpec defines the desired state of NutanixCluster
             properties:
               controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane. host can be either DNS name
-                  or ip address
+                description: |-
+                  ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                  host can be either DNS name or ip address
                 properties:
                   host:
                     description: The hostname on which the API server is serving.
@@ -351,20 +357,19 @@ spec:
                 - port
                 type: object
               failureDomains:
-                description: failureDomains configures failure domains information
-                  for the Nutanix platform. When set, the failure domains defined
-                  here may be used to spread Machines across prism element clusters
-                  to improve fault tolerance of the cluster.
+                description: |-
+                  failureDomains configures failure domains information for the Nutanix platform.
+                  When set, the failure domains defined here may be used to spread Machines across
+                  prism element clusters to improve fault tolerance of the cluster.
                 items:
                   description: NutanixFailureDomain configures failure domain information
                     for Nutanix.
                   properties:
                     cluster:
-                      description: cluster is to identify the cluster (the Prism Element
-                        under management of the Prism Central), in which the Machine's
-                        VM will be created. The cluster identifier (uuid or name)
-                        can be obtained from the Prism Central console or using the
-                        prism_central API.
+                      description: |-
+                        cluster is to identify the cluster (the Prism Element under management of the Prism Central),
+                        in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained
+                        from the Prism Central console or using the prism_central API.
                       properties:
                         name:
                           description: name is the resource name in the PC
@@ -387,22 +392,21 @@ spec:
                         plane nodes
                       type: boolean
                     name:
-                      description: name defines the unique name of a failure domain.
+                      description: |-
+                        name defines the unique name of a failure domain.
                         Name is required and must be at most 64 characters in length.
-                        It must consist of only lower case alphanumeric characters
-                        and hyphens (-). It must start and end with an alphanumeric
-                        character. This value is arbitrary and is used to identify
-                        the failure domain within the platform.
+                        It must consist of only lower case alphanumeric characters and hyphens (-).
+                        It must start and end with an alphanumeric character.
+                        This value is arbitrary and is used to identify the failure domain within the platform.
                       maxLength: 64
                       minLength: 1
                       pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                       type: string
                     subnets:
-                      description: subnets holds a list of identifiers (one or more)
-                        of the cluster's network subnets for the Machine's VM to connect
-                        to. The subnet identifiers (uuid or name) can be obtained
-                        from the Prism Central console or using the prism_central
-                        API.
+                      description: |-
+                        subnets holds a list of identifiers (one or more) of the cluster's network subnets
+                        for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be
+                        obtained from the Prism Central console or using the prism_central API.
                       items:
                         description: NutanixResourceIdentifier holds the identity
                           of a Nutanix PC resource (cluster, image, subnet, etc.)
@@ -438,18 +442,17 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               prismCentral:
-                description: prismCentral holds the endpoint address and port to access
-                  the Nutanix Prism Central. When a cluster-wide proxy is installed,
-                  by default, this endpoint will be accessed via the proxy. Should
-                  you wish for communication with this endpoint not to be proxied,
-                  please add the endpoint to the proxy spec.noProxy list.
+                description: |-
+                  prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
+                  When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
+                  Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
+                  proxy spec.noProxy list.
                 properties:
                   additionalTrustBundle:
-                    description: AdditionalTrustBundle is a PEM encoded x509 cert
-                      for the RootCA that was used to create the certificate for a
-                      Prism Central that uses certificates that were issued by a non-publicly
-                      trusted RootCA. The trust bundle is added to the cert pool used
-                      to authenticate the TLS connection to the Prism Central.
+                    description: |-
+                      AdditionalTrustBundle is a PEM encoded x509 cert for the RootCA that was used to create the certificate
+                      for a Prism Central that uses certificates that were issued by a non-publicly trusted RootCA. The trust
+                      bundle is added to the cert pool used to authenticate the TLS connection to the Prism Central.
                     properties:
                       data:
                         description: Data of the trust bundle if Kind is String.
@@ -521,37 +524,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -561,9 +564,9 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: FailureDomainSpec is the Schema for Cluster API failure
-                    domains. It allows controllers to understand how many failure
-                    domains a cluster can optionally span across.
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
@@ -592,9 +595,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: nutanixmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -38,14 +37,19 @@ spec:
         description: NutanixMachine is the Schema for the nutanixmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -74,47 +78,57 @@ spec:
                 - uefi
                 type: string
               bootstrapRef:
-                description: BootstrapRef is a reference to a bootstrap provider-specific
-                  resource that holds configuration details.
+                description: |-
+                  BootstrapRef is a reference to a bootstrap provider-specific resource
+                  that holds configuration details.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cluster:
-                description: cluster is to identify the cluster (the Prism Element
-                  under management of the Prism Central), in which the Machine's VM
-                  will be created. The cluster identifier (uuid or name) can be obtained
-                  from the Prism Central console or using the prism_central API.
+                description: |-
+                  cluster is to identify the cluster (the Prism Element under management
+                  of the Prism Central), in which the Machine's VM will be created.
+                  The cluster identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 properties:
                   name:
                     description: name is the resource name in the PC
@@ -132,9 +146,10 @@ spec:
                 - type
                 type: object
               image:
-                description: image is to identify the rhcos image uploaded to the
-                  Prism Central (PC) The image identifier (uuid or name) can be obtained
-                  from the Prism Central console or using the prism_central API.
+                description: |-
+                  image is to identify the rhcos image uploaded to the Prism Central (PC)
+                  The image identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 properties:
                   name:
                     description: name is the resource name in the PC
@@ -155,8 +170,9 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: memorySize is the memory size (in Quantity format) of
-                  the VM The minimum memorySize is 2Gi bytes
+                description: |-
+                  memorySize is the memory size (in Quantity format) of the VM
+                  The minimum memorySize is 2Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               project:
@@ -180,10 +196,10 @@ spec:
               providerID:
                 type: string
               subnet:
-                description: subnet is to identify the cluster's network subnet to
-                  use for the Machine's VM The cluster identifier (uuid or name) can
-                  be obtained from the Prism Central console or using the prism_central
-                  API.
+                description: |-
+                  subnet is to identify the cluster's network subnet to use for the Machine's VM
+                  The cluster identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 items:
                   description: NutanixResourceIdentifier holds the identity of a Nutanix
                     PC resource (cluster, image, subnet, etc.)
@@ -208,8 +224,9 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: systemDiskSize is size (in Quantity format) of the system
-                  disk of the VM The minimum systemDiskSize is 20Gi bytes
+                description: |-
+                  systemDiskSize is size (in Quantity format) of the system disk of the VM
+                  The minimum systemDiskSize is 20Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               vcpuSockets:
@@ -235,9 +252,9 @@ spec:
             description: NutanixMachineStatus defines the observed state of NutanixMachine
             properties:
               addresses:
-                description: Addresses contains the Nutanix VM associated addresses.
-                  Address type is one of Hostname, ExternalIP, InternalIP, ExternalDNS,
-                  InternalDNS
+                description: |-
+                  Addresses contains the Nutanix VM associated addresses.
+                  Address type is one of Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS
                 items:
                   description: MachineAddress contains information for the node's
                     address.
@@ -261,37 +278,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - status
@@ -305,43 +322,51 @@ spec:
                 description: Will be set in case of failure of Machine instance
                 type: string
               nodeRef:
-                description: 'NodeRef is a reference to the corresponding workload
-                  cluster Node if it exists. Deprecated: Do not use. Will be removed
-                  in a future release.'
+                description: |-
+                  NodeRef is a reference to the corresponding workload cluster Node if it exists.
+                  Deprecated: Do not use. Will be removed in a future release.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
@@ -373,14 +398,19 @@ spec:
         description: NutanixMachine is the Schema for the nutanixmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -409,47 +439,57 @@ spec:
                 - uefi
                 type: string
               bootstrapRef:
-                description: BootstrapRef is a reference to a bootstrap provider-specific
-                  resource that holds configuration details.
+                description: |-
+                  BootstrapRef is a reference to a bootstrap provider-specific resource
+                  that holds configuration details.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cluster:
-                description: cluster is to identify the cluster (the Prism Element
-                  under management of the Prism Central), in which the Machine's VM
-                  will be created. The cluster identifier (uuid or name) can be obtained
-                  from the Prism Central console or using the prism_central API.
+                description: |-
+                  cluster is to identify the cluster (the Prism Element under management
+                  of the Prism Central), in which the Machine's VM will be created.
+                  The cluster identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 properties:
                   name:
                     description: name is the resource name in the PC
@@ -488,9 +528,10 @@ spec:
                   type: object
                 type: array
               image:
-                description: image is to identify the rhcos image uploaded to the
-                  Prism Central (PC) The image identifier (uuid or name) can be obtained
-                  from the Prism Central console or using the prism_central API.
+                description: |-
+                  image is to identify the rhcos image uploaded to the Prism Central (PC)
+                  The image identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 properties:
                   name:
                     description: name is the resource name in the PC
@@ -511,8 +552,9 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: memorySize is the memory size (in Quantity format) of
-                  the VM The minimum memorySize is 2Gi bytes
+                description: |-
+                  memorySize is the memory size (in Quantity format) of the VM
+                  The minimum memorySize is 2Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               project:
@@ -536,10 +578,10 @@ spec:
               providerID:
                 type: string
               subnet:
-                description: subnet is to identify the cluster's network subnet to
-                  use for the Machine's VM The cluster identifier (uuid or name) can
-                  be obtained from the Prism Central console or using the prism_central
-                  API.
+                description: |-
+                  subnet is to identify the cluster's network subnet to use for the Machine's VM
+                  The cluster identifier (uuid or name) can be obtained from the Prism Central console
+                  or using the prism_central API.
                 items:
                   description: NutanixResourceIdentifier holds the identity of a Nutanix
                     PC resource (cluster, image, subnet, etc.)
@@ -564,8 +606,9 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: systemDiskSize is size (in Quantity format) of the system
-                  disk of the VM The minimum systemDiskSize is 20Gi bytes
+                description: |-
+                  systemDiskSize is size (in Quantity format) of the system disk of the VM
+                  The minimum systemDiskSize is 20Gi bytes
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               vcpuSockets:
@@ -591,9 +634,9 @@ spec:
             description: NutanixMachineStatus defines the observed state of NutanixMachine
             properties:
               addresses:
-                description: Addresses contains the Nutanix VM associated addresses.
-                  Address type is one of Hostname, ExternalIP, InternalIP, ExternalDNS,
-                  InternalDNS
+                description: |-
+                  Addresses contains the Nutanix VM associated addresses.
+                  Address type is one of Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS
                 items:
                   description: MachineAddress contains information for the node's
                     address.
@@ -617,37 +660,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -662,43 +705,51 @@ spec:
                 description: Will be set in case of failure of Machine instance
                 type: string
               nodeRef:
-                description: 'NodeRef is a reference to the corresponding workload
-                  cluster Node if it exists. Deprecated: Do not use. Will be removed
-                  in a future release.'
+                description: |-
+                  NodeRef is a reference to the corresponding workload cluster Node if it exists.
+                  Deprecated: Do not use. Will be removed in a future release.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               ready:
                 description: Ready is true when the provider resource is ready.
                 type: boolean
@@ -711,9 +762,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: nutanixmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -26,14 +25,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -45,24 +49,27 @@ spec:
                   to create a NutanixMachine from a template
                 properties:
                   metadata:
-                    description: 'Standard object metadata. Ref: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    description: |-
+                      Standard object metadata.
+                      Ref: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                     type: object
                   spec:
@@ -91,48 +98,56 @@ spec:
                         - uefi
                         type: string
                       bootstrapRef:
-                        description: BootstrapRef is a reference to a bootstrap provider-specific
-                          resource that holds configuration details.
+                        description: |-
+                          BootstrapRef is a reference to a bootstrap provider-specific resource
+                          that holds configuration details.
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       cluster:
-                        description: cluster is to identify the cluster (the Prism
-                          Element under management of the Prism Central), in which
-                          the Machine's VM will be created. The cluster identifier
-                          (uuid or name) can be obtained from the Prism Central console
+                        description: |-
+                          cluster is to identify the cluster (the Prism Element under management
+                          of the Prism Central), in which the Machine's VM will be created.
+                          The cluster identifier (uuid or name) can be obtained from the Prism Central console
                           or using the prism_central API.
                         properties:
                           name:
@@ -152,10 +167,10 @@ spec:
                         - type
                         type: object
                       image:
-                        description: image is to identify the rhcos image uploaded
-                          to the Prism Central (PC) The image identifier (uuid or
-                          name) can be obtained from the Prism Central console or
-                          using the prism_central API.
+                        description: |-
+                          image is to identify the rhcos image uploaded to the Prism Central (PC)
+                          The image identifier (uuid or name) can be obtained from the Prism Central console
+                          or using the prism_central API.
                         properties:
                           name:
                             description: name is the resource name in the PC
@@ -177,8 +192,9 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: memorySize is the memory size (in Quantity format)
-                          of the VM The minimum memorySize is 2Gi bytes
+                        description: |-
+                          memorySize is the memory size (in Quantity format) of the VM
+                          The minimum memorySize is 2Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       project:
@@ -204,9 +220,9 @@ spec:
                       providerID:
                         type: string
                       subnet:
-                        description: subnet is to identify the cluster's network subnet
-                          to use for the Machine's VM The cluster identifier (uuid
-                          or name) can be obtained from the Prism Central console
+                        description: |-
+                          subnet is to identify the cluster's network subnet to use for the Machine's VM
+                          The cluster identifier (uuid or name) can be obtained from the Prism Central console
                           or using the prism_central API.
                         items:
                           description: NutanixResourceIdentifier holds the identity
@@ -234,9 +250,9 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: systemDiskSize is size (in Quantity format) of
-                          the system disk of the VM The minimum systemDiskSize is
-                          20Gi bytes
+                        description: |-
+                          systemDiskSize is size (in Quantity format) of the system disk of the VM
+                          The minimum systemDiskSize is 20Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       vcpuSockets:
@@ -275,14 +291,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -294,24 +315,27 @@ spec:
                   to create a NutanixMachine from a template
                 properties:
                   metadata:
-                    description: 'Standard object metadata. Ref: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    description: |-
+                      Standard object metadata.
+                      Ref: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                     type: object
                   spec:
@@ -340,48 +364,56 @@ spec:
                         - uefi
                         type: string
                       bootstrapRef:
-                        description: BootstrapRef is a reference to a bootstrap provider-specific
-                          resource that holds configuration details.
+                        description: |-
+                          BootstrapRef is a reference to a bootstrap provider-specific resource
+                          that holds configuration details.
                         properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                             type: string
                           resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                             type: string
                           uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       cluster:
-                        description: cluster is to identify the cluster (the Prism
-                          Element under management of the Prism Central), in which
-                          the Machine's VM will be created. The cluster identifier
-                          (uuid or name) can be obtained from the Prism Central console
+                        description: |-
+                          cluster is to identify the cluster (the Prism Element under management
+                          of the Prism Central), in which the Machine's VM will be created.
+                          The cluster identifier (uuid or name) can be obtained from the Prism Central console
                           or using the prism_central API.
                         properties:
                           name:
@@ -424,10 +456,10 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: image is to identify the rhcos image uploaded
-                          to the Prism Central (PC) The image identifier (uuid or
-                          name) can be obtained from the Prism Central console or
-                          using the prism_central API.
+                        description: |-
+                          image is to identify the rhcos image uploaded to the Prism Central (PC)
+                          The image identifier (uuid or name) can be obtained from the Prism Central console
+                          or using the prism_central API.
                         properties:
                           name:
                             description: name is the resource name in the PC
@@ -449,8 +481,9 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: memorySize is the memory size (in Quantity format)
-                          of the VM The minimum memorySize is 2Gi bytes
+                        description: |-
+                          memorySize is the memory size (in Quantity format) of the VM
+                          The minimum memorySize is 2Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       project:
@@ -476,9 +509,9 @@ spec:
                       providerID:
                         type: string
                       subnet:
-                        description: subnet is to identify the cluster's network subnet
-                          to use for the Machine's VM The cluster identifier (uuid
-                          or name) can be obtained from the Prism Central console
+                        description: |-
+                          subnet is to identify the cluster's network subnet to use for the Machine's VM
+                          The cluster identifier (uuid or name) can be obtained from the Prism Central console
                           or using the prism_central API.
                         items:
                           description: NutanixResourceIdentifier holds the identity
@@ -506,9 +539,9 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: systemDiskSize is size (in Quantity format) of
-                          the system disk of the VM The minimum systemDiskSize is
-                          20Gi bytes
+                        description: |-
+                          systemDiskSize is size (in Quantity format) of the system disk of the VM
+                          The minimum systemDiskSize is 20Gi bytes
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       vcpuSockets:
@@ -540,9 +573,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/templates/base/cluster-with-kcp.yaml
+++ b/templates/base/cluster-with-kcp.yaml
@@ -40,7 +40,6 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
     name: "${CLUSTER_NAME}"
-
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -125,10 +124,6 @@ spec:
                     name: kubeconfig
                 resources: {}
             hostNetwork: true
-            hostAliases:
-              - hostnames:
-                  - kubernetes
-                ip: 127.0.0.1
             volumes:
               - name: kubeconfig
                 hostPath:
@@ -162,12 +157,31 @@ spec:
     preKubeadmCommands:
       - echo "before kubeadm call" > /var/log/prekubeadm.log
       - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   kubernetes" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+      - |
+        KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+        VERSION_TO_COMPARE=1.29.0
+        if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+          if [ -f /run/kubeadm/kubeadm.yaml ]; then
+            sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+          fi
+        fi
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+      - |
+        KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+        VERSION_TO_COMPARE=1.29.0
+        if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+          if [ -f /run/kubeadm/kubeadm.yaml ]; then
+            sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+          fi
+        fi
       - echo "after kubeadm call" > /var/log/postkubeadm.log
     useExperimentalRetryJoin: true
     verbosity: 10
-
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1788,10 +1788,6 @@ spec:
                   name: kubeconfig
               resources: {}
           hostNetwork: true
-          hostAliases:
-            - hostnames:
-                - kubernetes
-              ip: 127.0.0.1
           volumes:
             - name: kubeconfig
               hostPath:
@@ -1814,10 +1810,30 @@ spec:
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
     postKubeadmCommands:
     - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.29.0
+      if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
     - echo "after kubeadm call" > /var/log/postkubeadm.log
     preKubeadmCommands:
     - echo "before kubeadm call" > /var/log/prekubeadm.log
     - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+    - echo "127.0.0.1   localhost" >>/etc/hosts
+    - echo "127.0.0.1   kubernetes" >>/etc/hosts
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.29.0
+      if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
     useExperimentalRetryJoin: true
     users:
     - lockPassword: false

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -455,10 +455,6 @@ spec:
                   name: kubeconfig
               resources: {}
           hostNetwork: true
-          hostAliases:
-            - hostnames:
-                - kubernetes
-              ip: 127.0.0.1
           volumes:
             - name: kubeconfig
               hostPath:
@@ -481,10 +477,30 @@ spec:
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
     postKubeadmCommands:
     - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.29.0
+      if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
     - echo "after kubeadm call" > /var/log/postkubeadm.log
     preKubeadmCommands:
     - echo "before kubeadm call" > /var/log/prekubeadm.log
     - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+    - echo "127.0.0.1   localhost" >>/etc/hosts
+    - echo "127.0.0.1   kubernetes" >>/etc/hosts
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.29.0
+      if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
     useExperimentalRetryJoin: true
     users:
     - lockPassword: false

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi/kcp.yaml
@@ -12,3 +12,15 @@ spec:
       - apt update
       - apt install -y nfs-common open-iscsi lvm2 xfsprogs
       - systemctl enable --now iscsid
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   kubernetes" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+      - |
+        KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+        VERSION_TO_COMPARE=1.29.0
+        if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
+          if [ -f /run/kubeadm/kubeadm.yaml ]; then
+            sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+          fi
+        fi


### PR DESCRIPTION
### Cherry-Pick Details
- **Original PR Title:** Add support for Kubernetes v1.29 clusters
- **Original PR URL:** https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/382
- **Commit SHA:** d5ff104206b3089568e218e0a3d9f18038e122ab
- **Cherry-Pick Reason:** Ensuring Kubernetes v1.29 is supported on release-v1.3 branch

This PR also merges commits from https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/391 as E2Es won't pass without Kubernetes 1.29 support on that PR and unit tests on this PR won't pass without changes in that PR. 