### PR TITLE
Add variable for setting the additional categories on cluster

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -272,6 +272,31 @@ spec:
             - nutanix-quick-start-worker
     enabledIf: '{{if .project}}true{{end}}'
     name: add-project
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/additionalCategories
+        valueFrom:
+          variable: additionalCategories
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/additionalCategories
+        valueFrom:
+          variable: additionalCategories
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - nutanix-quick-start-worker
+    enabledIf: '{{if .additionalCategories}}true{{end}}'
+    name: add-additional-categories
   variables:
   - name: sshKey
     required: true
@@ -403,6 +428,18 @@ spec:
           uuid:
             type: string
         type: object
+  - name: additionalCategories
+    required: false
+    schema:
+      openAPIV3Schema:
+        items:
+          properties:
+            key:
+              type: string
+            value:
+              type: string
+          type: object
+        type: array
   workers:
     machineDeployments:
     - class: nutanix-quick-start-worker

--- a/templates/clusterclass/clusterclass.yaml
+++ b/templates/clusterclass/clusterclass.yaml
@@ -288,6 +288,31 @@ spec:
             path: /spec/template/spec/project
             valueFrom:
               variable: project
+  - name: add-additional-categories
+    enabledIf: "{{if .additionalCategories}}true{{end}}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: NutanixMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/additionalCategories
+            valueFrom:
+              variable: additionalCategories
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: NutanixMachineTemplate
+          matchResources:
+            machineDeploymentClass:
+              names:
+              - nutanix-quick-start-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/additionalCategories
+            valueFrom:
+              variable: additionalCategories
   variables:
   - name: sshKey
     required: true
@@ -419,3 +444,15 @@ spec:
             enum:
               - name
               - uuid
+  - name: additionalCategories
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            value:
+              type: string

--- a/templates/testdata/cluster-with-additional-categories.yaml
+++ b/templates/testdata/cluster-with-additional-categories.yaml
@@ -1,0 +1,56 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    ccm: nutanix
+    cluster.x-k8s.io/cluster-name: cluster-with-additional-categories
+  name: cluster-with-additional-categories
+spec:
+  topology:
+    class: nutanix-quick-start
+    controlPlane:
+      metadata: {}
+      replicas: 1
+    variables:
+      - name: sshKey
+        value: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMe61GqA9gqeX3zDCiwuU8zEDt3ckLnfVm8ZxN7UuFyL user@host
+      - name: controlPlaneEndpoint
+        value:
+          IP: 1.2.3.4
+          port: 6443
+      - name: prismCentralEndpoint
+        value:
+          address: prismcentral.fake
+          credentialSecret: nutanix-quick-start-pc-creds
+          insecure: false
+          port: 9440
+      - name: controlPlaneMachineDetails
+        value:
+          bootType: legacy
+          clusterName: fake-cluster
+          imageName: ubuntu-2204-kube-v1.29.2.qcow2
+          memorySize: 4Gi
+          subnetName: fake-subnet
+          systemDiskSize: 40Gi
+          vcpuSockets: 2
+          vcpusPerSocket: 1
+      - name: workerMachineDetails
+        value:
+          bootType: legacy
+          clusterName: fake-cluster
+          imageName: ubuntu-2204-kube-v1.29.2.qcow2
+          memorySize: 4Gi
+          subnetName: fake-subnet
+          systemDiskSize: 40Gi
+          vcpuSockets: 2
+          vcpusPerSocket: 1
+      - name: additionalCategories
+        value:
+          - key: fake-category-key
+            value: fake-category-value
+    version: v1.29.2
+    workers:
+      machineDeployments:
+        - class: nutanix-quick-start-worker
+          name: md-0
+          replicas: 2


### PR DESCRIPTION
The diff also includes a patch to set the additional categories on nutanixmachinetemplate resources for control plane and worker machine deployments.
