### PR TITLE
Add a cache for storing NutanixClients

### DIFF
--- a/pkg/client/prismclientcache/cache.go
+++ b/pkg/client/prismclientcache/cache.go
@@ -1,0 +1,61 @@
+package prismclientcache
+
+import (
+	"errors"
+	"sync"
+
+	prismGoClientV3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+)
+
+type clientCacheMap map[string]*prismGoClientV3.Client
+
+var (
+	// ErrorClientNotFound is returned when the client is not found in the cache
+	ErrorClientNotFound = errors.New("client not found in client cache")
+
+	// DefaultCache is the default cache of prism clients to be shared across the different controllers
+	DefaultCache = newCache()
+)
+
+// ClientCache is a cache for prism clients
+type ClientCache struct {
+	cache clientCacheMap
+	mtx   sync.RWMutex
+}
+
+// newCache returns a new ClientCache
+func newCache() *ClientCache {
+	return &ClientCache{
+		cache: make(clientCacheMap),
+		mtx:   sync.RWMutex{},
+	}
+}
+
+// Get returns the client for the given cluster name
+func (c *ClientCache) Get(clusterName string) (*prismGoClientV3.Client, error) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	clnt, ok := c.cache[clusterName]
+	if !ok {
+		return nil, ErrorClientNotFound
+	}
+
+	return clnt, nil
+}
+
+// Set adds the client to the cache
+func (c *ClientCache) Set(clusterName string, client *prismGoClientV3.Client) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.cache[clusterName] = client
+}
+
+// Delete removes the client from the cache
+func (c *ClientCache) Delete(clusterName string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	delete(c.cache, clusterName)
+}

--- a/pkg/client/prismclientcache/cache_test.go
+++ b/pkg/client/prismclientcache/cache_test.go
@@ -1,0 +1,71 @@
+package prismclientcache
+
+import (
+	"testing"
+
+	prismGoClientV3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetReturnsClientIfPresentInCache(t *testing.T) {
+	cache := newCache()
+	client := &prismGoClientV3.Client{}
+	cache.Set("cluster1", client)
+
+	returnedClient, err := cache.Get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, client, returnedClient)
+}
+
+func TestGetReturnsErrorIfClientNotPresentInCache(t *testing.T) {
+	cache := newCache()
+
+	_, err := cache.Get("cluster1")
+
+	assert.ErrorIs(t, err, ErrorClientNotFound)
+}
+
+func TestAddAddsClientToCache(t *testing.T) {
+	cache := newCache()
+	client := &prismGoClientV3.Client{}
+
+	cache.Set("cluster1", client)
+
+	returnedClient, err := cache.Get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, client, returnedClient)
+}
+
+func TestAddOverwritesExistingClientInCache(t *testing.T) {
+	cache := newCache()
+	client1 := &prismGoClientV3.Client{}
+	client2 := &prismGoClientV3.Client{}
+
+	cache.Set("cluster1", client1)
+	cache.Set("cluster1", client2)
+
+	returnedClient, err := cache.Get("cluster1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, client2, returnedClient)
+}
+
+func TestDeleteRemovesClientFromCache(t *testing.T) {
+	cache := newCache()
+	client := &prismGoClientV3.Client{}
+	cache.Set("cluster1", client)
+
+	cache.Delete("cluster1")
+
+	_, err := cache.Get("cluster1")
+
+	assert.ErrorIs(t, err, ErrorClientNotFound)
+}
+
+func TestDeleteDoesNotErrorIfClientNotPresentInCache(t *testing.T) {
+	cache := newCache()
+
+	cache.Delete("cluster1") // No error expected
+}


### PR DESCRIPTION
The cache stores a prismgoclient.V3 client instance for each NutanixCluster instance. The cache is shared between nutanixcluster and nutanixmachine controllers.