### PR TITLE
fix: set the kube-vip var to default value instead of env for clusterclass

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -539,11 +539,11 @@ spec:
                     - name: vip_retryperiod
                       value: "2"
                     - name: svc_enable
-                      value: "${KUBEVIP_SVC_ENABLE=false}"
+                      value: "false"
                     - name: lb_enable
-                      value: "${KUBEVIP_LB_ENABLE=false}"
+                      value: "false"
                     - name: enableServicesElection
-                      value: "${KUBEVIP_SVC_ELECTION=false}"
+                      value: "false"
                   securityContext:
                     capabilities:
                       add:

--- a/templates/clusterclass/kcpt.yaml
+++ b/templates/clusterclass/kcpt.yaml
@@ -60,11 +60,11 @@ spec:
                       - name: vip_retryperiod
                         value: "2"
                       - name: svc_enable
-                        value: "${KUBEVIP_SVC_ENABLE=false}"
+                        value: "false"
                       - name: lb_enable
-                        value: "${KUBEVIP_LB_ENABLE=false}"
+                        value: "false"
                       - name: enableServicesElection
-                        value: "${KUBEVIP_SVC_ELECTION=false}"
+                        value: "false"
                     securityContext:
                       capabilities:
                         add:


### PR DESCRIPTION
for timebeing am going to reset these variables to false as default so that kube-vip with CAREN can be up . 

Future
once we add above things, we can make them configurable

- either make entire yaml as variable or
- allow configuring specific variables