### PR TITLE
Ensure fallback config is read only when prismCentral is absent

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -108,15 +108,15 @@ func (n *NutanixClientHelper) buildManagementEndpoint(ctx context.Context, nutan
 		providers = append(providers, providerForNutanixCluster)
 	} else {
 		log.Info(fmt.Sprintf("[WARNING] prismCentral attribute was not set on NutanixCluster %s in namespace %s. Defaulting to CAPX manager credentials", nutanixCluster.Name, nutanixCluster.Namespace))
-	}
-
-	// Fallback to building a provider using the global CAPX manager credentials
-	providerForLocalFile, err := n.buildProviderFromFile()
-	if err != nil {
-		return nil, fmt.Errorf("error building an environment provider from file: %w", err)
-	}
-	if providerForLocalFile != nil {
-		providers = append(providers, providerForLocalFile)
+		// Fallback to building a provider using prism central information from the CAPX management cluster
+		// using information from /etc/nutanix/config/prismCentral
+		providerForLocalFile, err := n.buildProviderFromFile()
+		if err != nil {
+			return nil, fmt.Errorf("error building an environment provider from file: %w", err)
+		}
+		if providerForLocalFile != nil {
+			providers = append(providers, providerForLocalFile)
+		}
 	}
 
 	// Initialize environment with providers

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -116,23 +116,11 @@ func Test_buildManagementEndpoint(t *testing.T) {
 		expectedErr                error
 	}{
 		{
-			name: "all information set in NutanixCluster",
+			name: "all information set in NutanixCluster, should not fallback to management",
+			// asserting that not being able to read the file will not result in an error
 			helper: testHelperWithFakedInformers(testSecrets, testConfigMaps).withCustomNutanixPrismEndpointReader(
 				func() (*credentials.NutanixPrismEndpoint, error) {
-					return &credentials.NutanixPrismEndpoint{
-						Address: "manager-endpoint",
-						Port:    9440,
-						CredentialRef: &credentials.NutanixCredentialReference{
-							Kind:      credentials.SecretKind,
-							Name:      "capx-nutanix-creds",
-							Namespace: "capx-system",
-						},
-						AdditionalTrustBundle: &credentials.NutanixTrustBundleReference{
-							Kind:      credentials.NutanixTrustBundleKindConfigMap,
-							Name:      "cm",
-							Namespace: "capx-system",
-						},
-					}, nil
+					return nil, fmt.Errorf("could not read config")
 				},
 			),
 			nutanixCluster: &infrav1.NutanixCluster{


### PR DESCRIPTION
Skip reading fallback config file from `/etc/nutanix/config/prismCentral`
if NutanixCluster has prismCentral set.