### PR TITLE
Update additionalCategories clusterclass patch to target controlplane and workers separately

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -200,6 +200,19 @@ spec:
   - definitions:
     - jsonPatches:
       - op: add
+        path: /spec/template/spec/additionalCategories
+        valueFrom:
+          variable: controlPlaneMachineDetails.additionalCategories
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        matchResources:
+          controlPlane: true
+    enabledIf: '{{if .controlPlaneMachineDetails.additionalCategories}}true{{end}}'
+    name: update-control-plane-machine-template-additional-categories
+  - definitions:
+    - jsonPatches:
+      - op: add
         path: /spec/template/spec/bootType
         valueFrom:
           variable: workerMachineDetails.bootType
@@ -254,6 +267,21 @@ spec:
     name: update-worker-machine-template-gpus
   - definitions:
     - jsonPatches:
+      - op: add
+        path: /spec/template/spec/additionalCategories
+        valueFrom:
+          variable: workerMachineDetails.additionalCategories
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - nutanix-quick-start-worker
+    enabledIf: '{{if .workerMachineDetails.additionalCategories}}true{{end}}'
+    name: update-worker-machine-template-additional-categories
+  - definitions:
+    - jsonPatches:
       - op: replace
         path: /spec/template/spec/failureDomains
         valueFrom:
@@ -300,31 +328,6 @@ spec:
             - nutanix-quick-start-worker
     enabledIf: '{{if .project}}true{{end}}'
     name: add-project
-  - definitions:
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/additionalCategories
-        valueFrom:
-          variable: additionalCategories
-      selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: NutanixMachineTemplate
-        matchResources:
-          controlPlane: true
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/additionalCategories
-        valueFrom:
-          variable: additionalCategories
-      selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: NutanixMachineTemplate
-        matchResources:
-          machineDeploymentClass:
-            names:
-            - nutanix-quick-start-worker
-    enabledIf: '{{if .additionalCategories}}true{{end}}'
-    name: add-additional-categories
   variables:
   - name: sshKey
     required: true
@@ -366,6 +369,15 @@ spec:
       openAPIV3Schema:
         description: Details of the control plane machine deployment.
         properties:
+          additionalCategories:
+            items:
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+              type: object
+            type: array
           bootType:
             type: string
           clusterName:
@@ -400,6 +412,15 @@ spec:
       openAPIV3Schema:
         description: Details of the worker machine deployment.
         properties:
+          additionalCategories:
+            items:
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+              type: object
+            type: array
           bootType:
             type: string
           clusterName:
@@ -483,20 +504,6 @@ spec:
           uuid:
             type: string
         type: object
-  - name: additionalCategories
-    required: false
-    schema:
-      openAPIV3Schema:
-        description: Additional categories to be added to the machine deployment in
-          cluster.
-        items:
-          properties:
-            key:
-              type: string
-            value:
-              type: string
-          type: object
-        type: array
   workers:
     machineDeployments:
     - class: nutanix-quick-start-worker

--- a/templates/clusterclass/clusterclass.yaml
+++ b/templates/clusterclass/clusterclass.yaml
@@ -213,6 +213,19 @@ spec:
             path: /spec/template/spec/gpus
             valueFrom:
               variable: controlPlaneMachineDetails.gpus
+  - name: update-control-plane-machine-template-additional-categories
+    enabledIf: "{{if .controlPlaneMachineDetails.additionalCategories}}true{{end}}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: NutanixMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/additionalCategories
+            valueFrom:
+              variable: controlPlaneMachineDetails.additionalCategories
   - name: update-worker-machine-template
     definitions:
     - selector:
@@ -268,6 +281,21 @@ spec:
             path: /spec/template/spec/gpus
             valueFrom:
               variable: workerMachineDetails.gpus
+  - name: update-worker-machine-template-additional-categories
+    enabledIf: "{{if .workerMachineDetails.additionalCategories}}true{{end}}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: NutanixMachineTemplate
+          matchResources:
+            machineDeploymentClass:
+              names:
+                - nutanix-quick-start-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/additionalCategories
+            valueFrom:
+              variable: workerMachineDetails.additionalCategories
   - name: add-failure-domains
     enabledIf: "{{if .failureDomains}}true{{end}}"
     definitions:
@@ -316,31 +344,6 @@ spec:
             path: /spec/template/spec/project
             valueFrom:
               variable: project
-  - name: add-additional-categories
-    enabledIf: "{{if .additionalCategories}}true{{end}}"
-    definitions:
-      - selector:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-          kind: NutanixMachineTemplate
-          matchResources:
-            controlPlane: true
-        jsonPatches:
-          - op: add
-            path: /spec/template/spec/additionalCategories
-            valueFrom:
-              variable: additionalCategories
-      - selector:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-          kind: NutanixMachineTemplate
-          matchResources:
-            machineDeploymentClass:
-              names:
-              - nutanix-quick-start-worker
-        jsonPatches:
-          - op: add
-            path: /spec/template/spec/additionalCategories
-            valueFrom:
-              variable: additionalCategories
   variables:
   - name: sshKey
     required: true
@@ -409,6 +412,15 @@ spec:
                   type: integer
                 type:
                   type: string
+          additionalCategories:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
         type: object
   - name: workerMachineDetails
     required: true
@@ -442,6 +454,15 @@ spec:
                 deviceID:
                   type: integer
                 type:
+                  type: string
+          additionalCategories:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
                   type: string
         type: object
   - name: failureDomains
@@ -499,16 +520,3 @@ spec:
             enum:
               - name
               - uuid
-  - name: additionalCategories
-    required: false
-    schema:
-      openAPIV3Schema:
-        description: Additional categories to be added to the machine deployment in cluster.
-        type: array
-        items:
-          type: object
-          properties:
-            key:
-              type: string
-            value:
-              type: string

--- a/templates/testdata/cluster-with-additional-categories.yaml
+++ b/templates/testdata/cluster-with-additional-categories.yaml
@@ -34,6 +34,9 @@ spec:
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
+          additionalCategories:
+            - key: fake-category-key
+              value: fake-category-value
       - name: workerMachineDetails
         value:
           bootType: legacy
@@ -44,10 +47,9 @@ spec:
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
-      - name: additionalCategories
-        value:
-          - key: fake-category-key
-            value: fake-category-value
+          additionalCategories:
+            - key: fake-category-key
+              value: fake-category-value
     version: v1.29.2
     workers:
       machineDeployments:


### PR DESCRIPTION
This allows setting additionalCategories independently for controlplane and worker machine deployments.
