### PR TITLE
Modify clusterclass patch for subnets to fix subnet cardinality and source for worker subnets

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -175,9 +175,7 @@ spec:
       - op: add
         path: /spec/template/spec/subnet
         valueFrom:
-          template: |
-            - type: name
-              name: {{ .controlPlaneMachineDetails.subnetName }}
+          variable: controlPlaneMachineDetails.subnets
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: NutanixMachineTemplate
@@ -239,9 +237,7 @@ spec:
       - op: add
         path: /spec/template/spec/subnet
         valueFrom:
-          template: |
-            - type: name
-              name: {{ .controlPlaneMachineDetails.subnetName }}
+          variable: workerMachineDetails.subnets
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: NutanixMachineTemplate
@@ -397,8 +393,20 @@ spec:
             type: string
           memorySize:
             type: string
-          subnetName:
-            type: string
+          subnets:
+            items:
+              properties:
+                name:
+                  type: string
+                type:
+                  enum:
+                  - name
+                  - uuid
+                  type: string
+                uuid:
+                  type: string
+              type: object
+            type: array
           systemDiskSize:
             type: string
           vcpuSockets:
@@ -440,8 +448,20 @@ spec:
             type: string
           memorySize:
             type: string
-          subnetName:
-            type: string
+          subnets:
+            items:
+              properties:
+                name:
+                  type: string
+                type:
+                  enum:
+                  - name
+                  - uuid
+                  type: string
+                uuid:
+                  type: string
+              type: object
+            type: array
           systemDiskSize:
             type: string
           vcpuSockets:

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -326,7 +326,9 @@ spec:
         clusterName: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         imageName: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
         memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
-        subnetName: ${NUTANIX_SUBNET_NAME}
+        subnets:
+        - name: ${NUTANIX_SUBNET_NAME}
+          type: name
         systemDiskSize: ${NUTANIX_SYSTEMDISK_SIZE=40Gi}
         vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
         vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
@@ -336,7 +338,9 @@ spec:
         clusterName: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         imageName: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
         memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
-        subnetName: ${NUTANIX_SUBNET_NAME}
+        subnets:
+        - name: ${NUTANIX_SUBNET_NAME}
+          type: name
         systemDiskSize: ${NUTANIX_SYSTEMDISK_SIZE=40Gi}
         vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
         vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}

--- a/templates/clusterclass/clusterclass.yaml
+++ b/templates/clusterclass/clusterclass.yaml
@@ -197,9 +197,7 @@ spec:
           - op: add
             path: /spec/template/spec/subnet
             valueFrom:
-              template: |
-                - type: name
-                  name: {{ .controlPlaneMachineDetails.subnetName }}
+              variable: controlPlaneMachineDetails.subnets
   - name: update-control-plane-machine-template-gpus
     enabledIf: "{{if .controlPlaneMachineDetails.gpus}}true{{end}}"
     definitions:
@@ -263,9 +261,7 @@ spec:
           - op: add
             path: /spec/template/spec/subnet
             valueFrom:
-              template: |
-                - type: name
-                  name: {{ .controlPlaneMachineDetails.subnetName }}
+              variable: workerMachineDetails.subnets
   - name: update-worker-machine-template-gpus
     enabledIf: "{{if .workerMachineDetails.gpus}}true{{end}}"
     definitions:
@@ -399,8 +395,20 @@ spec:
             type: string
           clusterName:
             type: string
-          subnetName:
-            type: string
+          subnets:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                uuid:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - name
+                    - uuid
           gpus:
             type: array
             items:
@@ -442,8 +450,20 @@ spec:
             type: string
           clusterName:
             type: string
-          subnetName:
-            type: string
+          subnets:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                uuid:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - name
+                    - uuid
           gpus:
             type: array
             items:

--- a/templates/testdata/cluster-with-control-plane-endpoint.yaml
+++ b/templates/testdata/cluster-with-control-plane-endpoint.yaml
@@ -30,7 +30,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
@@ -40,7 +42,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1

--- a/templates/testdata/cluster-with-failure-domain.yaml
+++ b/templates/testdata/cluster-with-failure-domain.yaml
@@ -31,7 +31,9 @@ spec:
           clusterName: fake
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
@@ -41,7 +43,9 @@ spec:
           clusterName: fake
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1

--- a/templates/testdata/cluster-with-gpu.yaml
+++ b/templates/testdata/cluster-with-gpu.yaml
@@ -30,7 +30,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
@@ -43,7 +45,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1

--- a/templates/testdata/cluster-with-project-name.yaml
+++ b/templates/testdata/cluster-with-project-name.yaml
@@ -30,7 +30,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
@@ -40,7 +42,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1

--- a/templates/testdata/cluster-with-project-uuid.yaml
+++ b/templates/testdata/cluster-with-project-uuid.yaml
@@ -30,7 +30,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
@@ -40,7 +42,9 @@ spec:
           clusterName: fake-cluster
           imageName: ubuntu-2204-kube-v1.29.2.qcow2
           memorySize: 4Gi
-          subnetName: fake-subnet
+          subnets:
+            - type: name
+              name: fake-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1

--- a/templates/testdata/cluster-with-subnets.yaml
+++ b/templates/testdata/cluster-with-subnets.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   labels:
     ccm: nutanix
-    cluster.x-k8s.io/cluster-name: cluster-with-additional-categories
-  name: cluster-with-additional-categories
+    cluster.x-k8s.io/cluster-name: cluster-with-subnets
+  name: cluster-with-subnets
 spec:
   topology:
     class: nutanix-quick-start
@@ -32,13 +32,12 @@ spec:
           memorySize: 4Gi
           subnets:
             - type: name
-              name: fake-subnet
+              name: shared-subnet
+            - type: name
+              name: controlplane-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
-          additionalCategories:
-            - key: fake-category-key
-              value: fake-category-value
       - name: workerMachineDetails
         value:
           bootType: legacy
@@ -47,13 +46,12 @@ spec:
           memorySize: 4Gi
           subnets:
             - type: name
-              name: fake-subnet
+              name: shared-subnet
+            - type: name
+              name: worker-subnet
           systemDiskSize: 40Gi
           vcpuSockets: 2
           vcpusPerSocket: 1
-          additionalCategories:
-            - key: fake-category-key
-              value: fake-category-value
     version: v1.29.2
     workers:
       machineDeployments:

--- a/templates/topology/cluster-with-topology.yaml
+++ b/templates/topology/cluster-with-topology.yaml
@@ -46,7 +46,9 @@ spec:
         systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
         imageName: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}"
         clusterName: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
-        subnetName: "${NUTANIX_SUBNET_NAME}"
+        subnets:
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"
     - name: workerMachineDetails
       value:
         bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
@@ -56,4 +58,6 @@ spec:
         systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
         imageName: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}"
         clusterName: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"
-        subnetName: "${NUTANIX_SUBNET_NAME}"
+        subnets:
+        - type: name
+          name: "${NUTANIX_SUBNET_NAME}"


### PR DESCRIPTION
The cardinality of subnets in the clusterclass was incorrect and the source of subnet for worker machine deployment was incorrect. This changes the subnet cardinality from 1 to n and changes the source of subnets for worker machine deployments to workermachinedetails variable.