### PR TITLE
Update release artifact workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
       run: |
         PTAGS=`echo $TAGS | sed 's/capi-nutanix://g'`
         export SOURCE_DATE_EPOCH=$(date +%s)
-        ko build --bare --image-label "$LABELS" -t "$PTAGS" --platform=$PLATFORMS .
+        devbox run -- ko build --bare --image-label "$LABELS" -t "$PTAGS" --platform=$PLATFORMS .
 
     - name: parse semver
       id: semver


### PR DESCRIPTION
release workflows are missing the devbox vendored ko binary.

The release workflow was using `ko` but didn't have `debox run ---` before the `ko build` command leading to the workflow failing with `ko: command not found`