### PR TITLE
Remove stale E2E test

### DIFF
--- a/test/e2e/nutanix_client_test.go
+++ b/test/e2e/nutanix_client_test.go
@@ -131,50 +131,6 @@ var _ = Describe("Nutanix client", Label("capx-feature-test", "nutanix-client"),
 		By("PASSED!")
 	})
 
-	It("Create a cluster without prismCentral attribute (use default credentials)", func() {
-		flavor = "no-nutanix-cluster"
-		Expect(namespace).NotTo(BeNil())
-
-		By("Creating NutanixCluster resource without credentialRef", func() {
-			ntnxCluster := testHelper.createDefaultNutanixCluster(
-				clusterName,
-				namespace.Name,
-				controlplaneEndpointIP,
-				controlplaneEndpointPort,
-			)
-
-			testHelper.createCapiObject(ctx, createCapiObjectParams{
-				creator:    bootstrapClusterProxy.GetClient(),
-				capiObject: ntnxCluster,
-			})
-		})
-
-		By("Creating a workload cluster", func() {
-			testHelper.deployCluster(
-				deployClusterParams{
-					clusterName:           clusterName,
-					namespace:             namespace,
-					flavor:                flavor,
-					clusterctlConfigPath:  clusterctlConfigPath,
-					artifactFolder:        artifactFolder,
-					bootstrapClusterProxy: bootstrapClusterProxy,
-				}, clusterResources)
-		})
-		By("Checking cluster prism client init condition is true", func() {
-			testHelper.verifyConditionOnNutanixCluster(verifyConditionParams{
-				clusterName:           clusterName,
-				namespace:             namespace,
-				bootstrapClusterProxy: bootstrapClusterProxy,
-				expectedCondition: clusterv1.Condition{
-					Type:   infrav1.PrismCentralClientCondition,
-					Status: corev1.ConditionTrue,
-				},
-			})
-		})
-
-		By("PASSED!")
-	})
-
 	It("Create a cluster without secret and add it later", func() {
 		flavor = "no-secret"
 		Expect(namespace).NotTo(BeNil())


### PR DESCRIPTION
With https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/400 we made prismCentral a mandatory field in NutanixCluster. In the PR we did not remove the E2E test that was covering the older behavior of successfully creating a NutanixCluster without credentials using the default credentials from the CAPX controller. As a result, the test is now failing on both periodic jobs since and presubmits on new PRs with the following error:

```
NutanixCluster.infrastructure.cluster.x-k8s.io \"cluster-ntnx-client-qwqlsf\" is invalid: spec.prismCentral: Required value
```
Not quite sure why this failure was not caught and addressed in #400. This PR removes the test that tests the stale example that is no longer supported. 