### PR TITLE
Revert "removed optional annotation from non-optional fields (#400)"

### DIFF
--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -46,12 +46,14 @@ type NutanixClusterSpec struct {
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// host can be either DNS name or ip address
+	// +optional
 	ControlPlaneEndpoint capiv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
 	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
 	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
 	// proxy spec.noProxy list.
+	// +optional
 	PrismCentral *credentialTypes.NutanixPrismEndpoint `json:"prismCentral"`
 
 	// failureDomains configures failure domains information for the Nutanix platform.
@@ -60,7 +62,7 @@ type NutanixClusterSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	// +optional
-	FailureDomains []NutanixFailureDomain `json:"failureDomains,omitempty"`
+	FailureDomains []NutanixFailureDomain `json:"failureDomains"`
 }
 
 // NutanixClusterStatus defines the observed state of NutanixCluster

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -83,7 +83,6 @@ type NutanixMachineSpec struct {
 	Subnets []NutanixResourceIdentifier `json:"subnet"`
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
-	// +optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories,omitempty"`
 	// Add the machine resources to a Prism Central project
 	// +optional
@@ -105,7 +104,6 @@ type NutanixMachineSpec struct {
 
 	// List of GPU devices that need to be added to the machines.
 	// +kubebuilder:validation:Optional
-	// +optional
 	GPUs []NutanixGPU `json:"gpus,omitempty"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -512,9 +512,6 @@ spec:
                 - address
                 - port
                 type: object
-            required:
-            - controlPlaneEndpoint
-            - prismCentral
             type: object
           status:
             description: NutanixClusterStatus defines the observed state of NutanixCluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
@@ -228,9 +228,6 @@ spec:
                         - address
                         - port
                         type: object
-                    required:
-                    - controlPlaneEndpoint
-                    - prismCentral
                     type: object
                 required:
                 - spec

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -22,7 +22,6 @@ import (
 
 	credentialTypes "github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
@@ -53,7 +52,6 @@ func TestControllerHelpers(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: infrav1.NutanixClusterSpec{
-					ControlPlaneEndpoint: capiv1.APIEndpoint{},
 					PrismCentral: &credentialTypes.NutanixPrismEndpoint{
 						// Adding port info to override default value (0)
 						Port: 9440,


### PR DESCRIPTION
This reverts commit f6e079c5dd386256a27974338a111da3b628fb9b.

With https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/400 we made prismCentral a mandatory field in NutanixCluster. As a result, the test is now failing on both periodic jobs since and presubmits on new PRs with the following errors.

```
Expected success, but got an error:
    <*errors.StatusError | 0xc000411cc0>: 
    NutanixCluster.infrastructure.cluster.x-k8s.io "cluster-ntnx-client-qwqlsf" is invalid: spec.prismCentral: Required value
    {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "NutanixCluster.infrastructure.cluster.x-k8s.io \"cluster-ntnx-client-qwqlsf\" is invalid: spec.prismCentral: Required value",
            Reason: "Invalid",
            Details: {
                Name: "cluster-ntnx-client-qwqlsf",
                Group: "infrastructure.cluster.x-k8s.io",
                Kind: "NutanixCluster",
                UID: "",
                Causes: [
                    {
                        Type: "FieldValueRequired",
                        Message: "Required value",
                        Field: "spec.prismCentral",
                    },
                ],
                RetryAfterSeconds: 0,
            },
            Code: 422,
        },
    } failed [FAILED] Timed out after 300.000s.
```

The clusterclass tests are also failing because variables are used to specify values for prismCentral and controlPlaneEndpoint in a a cluster created with a clusterclass reference and clusterclass patches patch those values into the cluster which was not accounted for when making the change. 

```
Running kubectl apply --kubeconfig /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind1856394220 -f -
stderr:
The NutanixClusterTemplate "nutanix-quick-start-nct" is invalid:
* spec.template.spec.controlPlaneEndpoint: Required value
* spec.template.spec.prismCentral: Required value
```

This PR reverts the changes made in https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/400