### PR TITLE
Explicitly set a rate limiter for controller config

### DIFF
--- a/controllers/options.go
+++ b/controllers/options.go
@@ -1,10 +1,15 @@
 package controllers
 
-import "errors"
+import (
+	"errors"
+
+	"k8s.io/client-go/util/workqueue"
+)
 
 // ControllerConfig is the configuration for cluster and machine controllers
 type ControllerConfig struct {
 	MaxConcurrentReconciles int
+	RateLimiter             workqueue.RateLimiter
 }
 
 // ControllerConfigOpts is a function that can be used to configure the controller config
@@ -17,6 +22,17 @@ func WithMaxConcurrentReconciles(max int) ControllerConfigOpts {
 			return errors.New("max concurrent reconciles must be greater than 0")
 		}
 		c.MaxConcurrentReconciles = max
+		return nil
+	}
+}
+
+// WithRateLimiter sets the rate limiter for the controller
+func WithRateLimiter(rateLimiter workqueue.RateLimiter) ControllerConfigOpts {
+	return func(c *ControllerConfig) error {
+		if rateLimiter == nil {
+			return errors.New("rate limiter cannot be nil")
+		}
+		c.RateLimiter = rateLimiter
 		return nil
 	}
 }

--- a/controllers/options_test.go
+++ b/controllers/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/util/workqueue"
 )
 
 func TestWithMaxConcurrentReconciles(t *testing.T) {
@@ -33,6 +34,41 @@ func TestWithMaxConcurrentReconciles(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.MaxConcurrentReconciles, config.MaxConcurrentReconciles)
+			}
+		})
+	}
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	tests := []struct {
+		name         string
+		rateLimiter  workqueue.RateLimiter
+		expectError  bool
+		expectedType interface{}
+	}{
+		{
+			name:         "TestWithRateLimiterNil",
+			rateLimiter:  nil,
+			expectError:  true,
+			expectedType: nil,
+		},
+		{
+			name:         "TestWithRateLimiterSet",
+			rateLimiter:  workqueue.DefaultControllerRateLimiter(),
+			expectError:  false,
+			expectedType: &workqueue.MaxOfRateLimiter{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithRateLimiter(tt.rateLimiter)
+			config := &ControllerConfig{}
+			err := opt(config)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.IsType(t, tt.expectedType, config.RateLimiter)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -119,12 +120,15 @@ func testRunManagerCommon(t *testing.T, ctrl *gomock.Controller) (*mockctlclient
 
 	require.NoError(t, err)
 
+	rateLimiter, err := compositeRateLimiter(500*time.Millisecond, 15*time.Minute, 100, 10)
+	require.NoError(t, err)
 	config := &managerConfig{
 		enableLeaderElection:               false,
 		logger:                             setupLogger(),
 		concurrentReconcilesNutanixCluster: 1,
 		concurrentReconcilesNutanixMachine: 1,
 		restConfig:                         cfg,
+		rateLimiter:                        rateLimiter,
 	}
 
 	client := mockctlclient.NewMockClient(ctrl)
@@ -245,4 +249,83 @@ func TestSetupControllersFailedAddToManager(t *testing.T) {
 	assert.Error(t, err)
 	err = setupNutanixMachineController(context.Background(), mgr, secretInformer, configMapInformer, copts...)
 	assert.Error(t, err)
+}
+
+func TestRateLimiter(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDelay   time.Duration
+		maxDelay    time.Duration
+		maxBurst    int
+		qps         int
+		expectedErr string
+	}{
+		{
+			name:      "valid rate limiter",
+			baseDelay: 500 * time.Millisecond,
+			maxDelay:  15 * time.Minute,
+			maxBurst:  100,
+			qps:       10,
+		},
+		{
+			name:        "negative base delay",
+			baseDelay:   -500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "baseDelay cannot be negative",
+		},
+		{
+			name:        "negative max delay",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    -15 * time.Minute,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "maxDelay cannot be negative",
+		},
+		{
+			name:        "maxDelay should be greater than or equal to baseDelay",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    400 * time.Millisecond,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "maxDelay should be greater than or equal to baseDelay",
+		},
+		{
+			name:        "bucketSize must be positive",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    0,
+			qps:         10,
+			expectedErr: "bucketSize must be positive",
+		},
+		{
+			name:        "qps must be positive",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    100,
+			qps:         0,
+			expectedErr: "minimum QPS must be positive",
+		},
+		{
+			name:        "bucketSize must be greater than or equal to qps",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    10,
+			qps:         100,
+			expectedErr: "bucketSize must be at least as large as the QPS to handle bursts effectively",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compositeRateLimiter(tt.baseDelay, tt.maxDelay, tt.maxBurst, tt.qps)
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The rate limiter is a MaxOfRateLimiter similar to the default one. However, now the base delay, max delay, bucket size, and qps can be configured using flags. The default values are 500ms for base delay and 15min for max delay in the exponential backoff limiter (custom values) and 10 qps and 100 bucket size for the bucket limiter (same as the default one).