### PR TITLE
Enable jobs to run on release-v1.2

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -1,11 +1,12 @@
-name: Test Build
+name: Build, Lint, and Test
 env:
   EXPORT_RESULT: true
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [ "main" ]
 jobs:
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,10 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
   schedule:
     - cron: '30 1 * * 0'
 

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,9 +1,10 @@
 name: Black Duck Policy Check
 on:
-  pull_request:
+  push:
     branches:
       - main
-  push:
+      - 'release-*'
+  pull_request:
 
 jobs:
   security:


### PR DESCRIPTION
Originally, there was no release branch for v1.2.x releases. Each release was cut from the main. As a result jobs were targeting main branch only. Now that we have created a release-v1.2 branch for backporting some patches we need to manually enable jobs in the branch to target the release branch.
