### PR TITLE
Cherry-pick PR #398 to release-v1.3

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -81,11 +81,12 @@ func (n *NutanixClientHelper) BuildClientForNutanixClusterWithFallback(ctx conte
 		return nil, err
 	}
 	creds := prismgoclient.Credentials{
-		URL:      me.Address.Host,
-		Endpoint: me.Address.Host,
-		Insecure: me.Insecure,
-		Username: me.ApiCredentials.Username,
-		Password: me.ApiCredentials.Password,
+		URL:         me.Address.Host,
+		Endpoint:    me.Address.Host,
+		Insecure:    me.Insecure,
+		Username:    me.ApiCredentials.Username,
+		Password:    me.ApiCredentials.Password,
+		SessionAuth: true,
 	}
 	return Build(creds, me.AdditionalTrustBundle)
 }
@@ -191,16 +192,7 @@ func (n *NutanixClientHelper) buildProviderFromFile() (envTypes.Provider, error)
 }
 
 func Build(creds prismgoclient.Credentials, additionalTrustBundle string) (*nutanixClientV3.Client, error) {
-	cli, err := buildClientFromCredentials(creds, additionalTrustBundle)
-	if err != nil {
-		return nil, err
-	}
-	// Check if the client is working
-	_, err = cli.V3.GetCurrentLoggedInUser(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current logged in user with client: %w", err)
-	}
-	return cli, nil
+	return buildClientFromCredentials(creds, additionalTrustBundle)
 }
 
 func buildClientFromCredentials(creds prismgoclient.Credentials, additionalTrustBundle string) (*nutanixClientV3.Client, error) {


### PR DESCRIPTION
### Cherry-Pick Details
- **Original PR Title:** Switch Nutanix Client to use Session Auth instead of Basic Auth
- **Original PR URL:** https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/398
- **Original Commit SHA:** 03c61d34afe159fe91940724e44f821dfeed1d1c
- **Cherry-Pick Reason:** Cherry-picking changes related to session auth to release-v1.3 so when a user upgrades from 1.2.5 to 1.3.4, they don't fall back to basic auth