### PR TITLE
Cherry-pick PR #416 to release-v1.3

### DIFF
--- a/controllers/options.go
+++ b/controllers/options.go
@@ -1,10 +1,15 @@
 package controllers
 
-import "errors"
+import (
+	"errors"
+
+	"k8s.io/client-go/util/workqueue"
+)
 
 // ControllerConfig is the configuration for cluster and machine controllers
 type ControllerConfig struct {
 	MaxConcurrentReconciles int
+	RateLimiter             workqueue.RateLimiter
 }
 
 // ControllerConfigOpts is a function that can be used to configure the controller config
@@ -17,6 +22,17 @@ func WithMaxConcurrentReconciles(max int) ControllerConfigOpts {
 			return errors.New("max concurrent reconciles must be greater than 0")
 		}
 		c.MaxConcurrentReconciles = max
+		return nil
+	}
+}
+
+// WithRateLimiter sets the rate limiter for the controller
+func WithRateLimiter(rateLimiter workqueue.RateLimiter) ControllerConfigOpts {
+	return func(c *ControllerConfig) error {
+		if rateLimiter == nil {
+			return errors.New("rate limiter cannot be nil")
+		}
+		c.RateLimiter = rateLimiter
 		return nil
 	}
 }

--- a/controllers/options_test.go
+++ b/controllers/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/util/workqueue"
 )
 
 func TestWithMaxConcurrentReconciles(t *testing.T) {
@@ -33,6 +34,41 @@ func TestWithMaxConcurrentReconciles(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.MaxConcurrentReconciles, config.MaxConcurrentReconciles)
+			}
+		})
+	}
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	tests := []struct {
+		name         string
+		rateLimiter  workqueue.RateLimiter
+		expectError  bool
+		expectedType interface{}
+	}{
+		{
+			name:         "TestWithRateLimiterNil",
+			rateLimiter:  nil,
+			expectError:  true,
+			expectedType: nil,
+		},
+		{
+			name:         "TestWithRateLimiterSet",
+			rateLimiter:  workqueue.DefaultControllerRateLimiter(),
+			expectError:  false,
+			expectedType: &workqueue.MaxOfRateLimiter{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := WithRateLimiter(tt.rateLimiter)
+			config := &ControllerConfig{}
+			err := opt(config)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.IsType(t, tt.expectedType, config.RateLimiter)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimiter(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDelay   time.Duration
+		maxDelay    time.Duration
+		maxBurst    int
+		qps         int
+		expectedErr string
+	}{
+		{
+			name:      "valid rate limiter",
+			baseDelay: 500 * time.Millisecond,
+			maxDelay:  15 * time.Minute,
+			maxBurst:  100,
+			qps:       10,
+		},
+		{
+			name:        "negative base delay",
+			baseDelay:   -500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "baseDelay cannot be negative",
+		},
+		{
+			name:        "negative max delay",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    -15 * time.Minute,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "maxDelay cannot be negative",
+		},
+		{
+			name:        "maxDelay should be greater than or equal to baseDelay",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    400 * time.Millisecond,
+			maxBurst:    100,
+			qps:         10,
+			expectedErr: "maxDelay should be greater than or equal to baseDelay",
+		},
+		{
+			name:        "bucketSize must be positive",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    0,
+			qps:         10,
+			expectedErr: "bucketSize must be positive",
+		},
+		{
+			name:        "qps must be positive",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    100,
+			qps:         0,
+			expectedErr: "minimum QPS must be positive",
+		},
+		{
+			name:        "bucketSize must be greater than or equal to qps",
+			baseDelay:   500 * time.Millisecond,
+			maxDelay:    15 * time.Minute,
+			maxBurst:    10,
+			qps:         100,
+			expectedErr: "bucketSize must be at least as large as the QPS to handle bursts effectively",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compositeRateLimiter(tt.baseDelay, tt.maxDelay, tt.maxBurst, tt.qps)
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Cherry-Pick Details
- **Original PR Title:** Explicitly set a exponential backoff rate limiter for controller config
- **Original PR URL:** https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/416
- **Commit SHA:** 714c151c10fcb1b6c26031a028198eaf063349c9
- **Cherry-Pick Reason:** Cherry-picking changes related to rate limiter to release-v1.3 so when a user upgrades from 1.2.5 to 1.3.4, they don't fall back to basic auth