### PR TITLE
Set Nutanix CCM cipher-suites to fix sweet32 CVE

### DIFF
--- a/templates/ccm/nutanix-ccm.yaml
+++ b/templates/ccm/nutanix-ccm.yaml
@@ -197,6 +197,7 @@ spec:
           args:
             - "--leader-elect=true"
             - "--cloud-config=/etc/cloud/nutanix_config.json"
+            - "--tls-cipher-suites=${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}"
           resources:
             requests:
               cpu: 100m

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -208,6 +208,7 @@ data:
               args:
                 - "--leader-elect=true"
                 - "--cloud-config=/etc/cloud/nutanix_config.json"
+                - "--tls-cipher-suites=${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}"
               resources:
                 requests:
                   cpu: 100m

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -208,6 +208,7 @@ data:
               args:
                 - "--leader-elect=true"
                 - "--cloud-config=/etc/cloud/nutanix_config.json"
+                - "--tls-cipher-suites=${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}"
               resources:
                 requests:
                   cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforce specific tls-cipher-suite to fix Nutanix CCM SWEET32 CVE



**Release note**:
```release-note
- Fix Nutanix CCM Sweet32 issue
```