### PR TITLE
Cherry-pick PR #438 to release-v1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+*.tmp
 
 # Test binary, build with `go test -c`
 *.test

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -74,5 +74,7 @@ const (
 	// CredentialRefSecretOwnerSetCondition shows the status of setting the Owner
 	CredentialRefSecretOwnerSetCondition capiv1.ConditionType = "CredentialRefSecretOwnerSet"
 
-	CredentialRefSecretOwnerSetFailed = "CredentialRefSecretOwnerSetFailed"
+	CredentialRefSecretOwnerSetFailed  = "CredentialRefSecretOwnerSetFailed"
+	TrustBundleSecretOwnerSetCondition = "TrustBundleSecretOwnerSet"
+	TrustBundleSecretOwnerSetFailed    = "TrustBundleSecretOwnerSetFailed"
 )

--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -164,6 +164,18 @@ func (ncl *NutanixCluster) GetPrismCentralCredentialRef() (*credentialTypes.Nuta
 	return prismCentralInfo.CredentialRef, nil
 }
 
+// GetPrismCentralTrustBundle returns the trust bundle reference for the Nutanix Prism Central.
+func (ncl *NutanixCluster) GetPrismCentralTrustBundle() *credentialTypes.NutanixTrustBundleReference {
+	prismCentralInfo := ncl.Spec.PrismCentral
+	if prismCentralInfo == nil ||
+		prismCentralInfo.AdditionalTrustBundle == nil ||
+		prismCentralInfo.AdditionalTrustBundle.Kind == credentialTypes.NutanixTrustBundleKindString {
+		return nil
+	}
+
+	return prismCentralInfo.AdditionalTrustBundle
+}
+
 // GetNamespacedName returns the namespaced name of the NutanixCluster.
 func (ncl *NutanixCluster) GetNamespacedName() string {
 	namespace := cmp.Or(ncl.Namespace, corev1.NamespaceDefault)

--- a/api/v1beta1/nutanixcluster_types_test.go
+++ b/api/v1beta1/nutanixcluster_types_test.go
@@ -148,3 +148,68 @@ func TestGetNamespacedName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPrismCentralTrustBundle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                string
+		nutanixCluster      *NutanixCluster
+		expectedTrustBundle *credentials.NutanixTrustBundleReference
+	}{
+		{
+			name: "PrismCentral and AdditionalTrustBundle are nil",
+			nutanixCluster: &NutanixCluster{
+				Spec: NutanixClusterSpec{},
+			},
+			expectedTrustBundle: nil,
+		},
+		{
+			name: "AdditionalTrustBundle is nil",
+			nutanixCluster: &NutanixCluster{
+				Spec: NutanixClusterSpec{
+					PrismCentral: &credentials.NutanixPrismEndpoint{},
+				},
+			},
+			expectedTrustBundle: nil,
+		},
+		{
+			name: "AdditionalTrustBundle Kind is NutanixTrustBundleKindString",
+			nutanixCluster: &NutanixCluster{
+				Spec: NutanixClusterSpec{
+					PrismCentral: &credentials.NutanixPrismEndpoint{
+						AdditionalTrustBundle: &credentials.NutanixTrustBundleReference{
+							Kind: credentials.NutanixTrustBundleKindString,
+						},
+					},
+				},
+			},
+			expectedTrustBundle: nil,
+		},
+		{
+			name: "AdditionalTrustBundle is not nil and Kind is not NutanixTrustBundleKindString",
+			nutanixCluster: &NutanixCluster{
+				Spec: NutanixClusterSpec{
+					PrismCentral: &credentials.NutanixPrismEndpoint{
+						AdditionalTrustBundle: &credentials.NutanixTrustBundleReference{
+							Kind:      credentials.NutanixTrustBundleKindConfigMap,
+							Name:      "test",
+							Namespace: "test-namespace",
+						},
+					},
+				},
+			},
+			expectedTrustBundle: &credentials.NutanixTrustBundleReference{
+				Kind:      credentials.NutanixTrustBundleKindConfigMap,
+				Name:      "test",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trustBundle := tt.nutanixCluster.GetPrismCentralTrustBundle()
+			assert.Equal(t, tt.expectedTrustBundle, trustBundle)
+		})
+	}
+}

--- a/test/e2e/clusterctl_move_test.go
+++ b/test/e2e/clusterctl_move_test.go
@@ -1,0 +1,39 @@
+//go:build e2e
+
+/*
+Copyright 2024 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	capie2e "sigs.k8s.io/cluster-api/test/e2e"
+)
+
+var _ = Describe("[clusterctl-move] Create a Self-Hosted CAPX Cluster", Label("capx-feature-test", "clusterctl-move"), func() {
+	// Run the CAPI SelfHostedSpec test suite
+	// This test suite will create a self-hosted CAPX cluster
+	capie2e.SelfHostedSpec(ctx, func() capie2e.SelfHostedSpecInput {
+		return capie2e.SelfHostedSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			SkipUpgrade:           true,
+		}
+	})
+})

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -9,7 +9,7 @@
 
 images:
   # Use local dev images built source tree;
-  - name: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e
+  - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
   # ## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
   # Cluster API v1beta1 Preloads
@@ -249,10 +249,10 @@ providers:
         value: "../../../config/default"
         contract: v1beta1
         replacements:
-          - old: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest
-            new: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:e2e
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
+          - old: "image: ghcr.io/nutanix-cloud-native/cluster-api-provider-nutanix/controller:latest"
+            new: "image: ${MANAGER_IMAGE}"
         files:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1beta1/cluster-template.yaml"


### PR DESCRIPTION
### Cherry-Pick Details
- **Original PR Title:** Set OwnerRef on TrustBundle configmaps and add selfhosted E2E test
- **Original PR URL:** https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/438
- **Commit SHA:** 37d75ebd34e6f3200433b514b20b5c24f35f8b3e
- **Cherry-Pick Reason:** Ensuring we can test clusterctl move in release-v1.3

Note: The cherry-pick excludes the clusterclass flavor move test in the original PR as clusterclass support does not exist in release-v1.3