### PR TITLE
Remove `listMapKey` for subnets list in failure domains

### DIFF
--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -130,8 +130,6 @@ type NutanixFailureDomain struct {
 	// obtained from the Prism Central console or using the prism_central API.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
-	// +listType=map
-	// +listMapKey=type
 	Subnets []NutanixResourceIdentifier `json:"subnets"`
 
 	// indicates if a failure domain is suited for control plane nodes

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -427,9 +427,6 @@ spec:
                         type: object
                       minItems: 1
                       type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
                   required:
                   - cluster
                   - name

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
@@ -140,9 +140,6 @@ spec:
                                 type: object
                               minItems: 1
                               type: array
-                              x-kubernetes-list-map-keys:
-                              - type
-                              x-kubernetes-list-type: map
                           required:
                           - cluster
                           - name


### PR DESCRIPTION
A subnet can either be referenced as a UUID or as Name depending on the type of the reference. As a result we can't rely on either of them as a defacto map key.