### PR TITLE
Make `providerID` in NutanixMachine spec optional

### DIFF
--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -52,7 +52,9 @@ type NutanixMachineSpec struct {
 	// SPEC FIELDS - desired state of NutanixMachine
 	// Important: Run "make" to regenerate code after modifying this file
 
-	ProviderID string `json:"providerID"`
+	// ProviderID is the unique identifier as specified by the cloud provider.
+	// +optional
+	ProviderID string `json:"providerID,omitempty"`
 	// vcpusPerSocket is the number of vCPUs per socket of the VM
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -539,6 +539,8 @@ spec:
                 - type
                 type: object
               providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
                 type: string
               subnet:
                 description: subnet is to identify the cluster's network subnet to
@@ -587,7 +589,6 @@ spec:
             required:
             - image
             - memorySize
-            - providerID
             - systemDiskSize
             - vcpuSockets
             - vcpusPerSocket

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -475,6 +475,8 @@ spec:
                         - type
                         type: object
                       providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
                         type: string
                       subnet:
                         description: subnet is to identify the cluster's network subnet
@@ -527,7 +529,6 @@ spec:
                     required:
                     - image
                     - memorySize
-                    - providerID
                     - systemDiskSize
                     - vcpuSockets
                     - vcpusPerSocket

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -716,7 +716,6 @@ spec:
         name: ""
         type: name
       memorySize: 4Gi
-      providerID: nutanix://vm-uuid
       subnet:
       - name: ""
         type: name
@@ -739,7 +738,6 @@ spec:
         name: ""
         type: name
       memorySize: 4Gi
-      providerID: nutanix://vm-uuid
       subnet:
       - name: ""
         type: name

--- a/templates/clusterclass/nmt-cp.yaml
+++ b/templates/clusterclass/nmt-cp.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   template:
     spec:
-      providerID: "nutanix://vm-uuid"
       # Supported options for boot type: legacy and uefi
       # Defaults to legacy if not set
       bootType: legacy

--- a/templates/clusterclass/nmt-md.yaml
+++ b/templates/clusterclass/nmt-md.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   template:
     spec:
-      providerID: "nutanix://vm-uuid"
       # Supported options for boot type: legacy and uefi
       # Defaults to legacy if not set
       bootType: legacy


### PR DESCRIPTION
Also remove filler `providerID` from NutanixMachineTemplate.
The `providerID` value is used by CAPI reconciler for events
and having a filler one set by default could hamper CAPI processes.