### PR TITLE
Ensure template-test target uses latest CAPX CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOTOOL=$(GOCMD) tool
 EXPORT_RESULT?=false # for CI please set EXPORT_RESULT to true
 
 GIT_COMMIT_HASH=$(shell git rev-parse HEAD)
-LOCAL_IMAGE_REGISTRY ?= localhost:5000
+LOCAL_IMAGE_REGISTRY ?= ko.local
 IMG_REPO=${LOCAL_IMAGE_REGISTRY}/cluster-api-provider-nutanix
 IMG_TAG=e2e-${GIT_COMMIT_HASH}
 MANAGER_IMAGE=${IMG_REPO}:${IMG_TAG}
@@ -279,6 +279,7 @@ prepare-local-clusterctl: manifests cluster-templates  ## Prepare overide file f
 	kustomize build config/default > ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/infrastructure-components.yaml
 	cp ./metadata.yaml ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/
 	cp ./templates/cluster-template*.yaml ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/
+	cp ./clusterctl.yaml.tmpl ./clusterctl.yaml
 	env LOCAL_PROVIDER_VERSION=$(LOCAL_PROVIDER_VERSION) \
 		envsubst -no-unset -no-empty -no-digit < ./clusterctl.yaml > ~/.cluster-api/clusterctl.yaml
 
@@ -309,7 +310,7 @@ ifeq ($(EXPORT_RESULT), true)
 endif
 
 .PHONY: template-test
-template-test: cluster-templates ## Run the template tests
+template-test: docker-build prepare-local-clusterctl ## Run the template tests
 	GOPROXY=off ginkgo --trace --v run templates
 
 .PHONY: test-e2e

--- a/Makefile
+++ b/Makefile
@@ -311,12 +311,16 @@ endif
 
 .PHONY: template-test
 template-test: docker-build prepare-local-clusterctl ## Run the template tests
-	GOPROXY=off ginkgo --trace --v run templates
+	GOPROXY=off \
+	LOCAL_PROVIDER_VERSION=$(LOCAL_PROVIDER_VERSION) \
+		ginkgo --trace --v run templates
 
 .PHONY: test-e2e
 test-e2e: docker-build-e2e cluster-e2e-templates cluster-templates ## Run the end-to-end tests
 	echo "Image tag for E2E test is ${IMG_TAG}"
-	MANAGER_IMAGE=$(MANAGER_IMAGE) envsubst < ${E2E_CONF_FILE} > ${E2E_CONF_FILE_TMP}
+	LOCAL_PROVIDER_VERSION=$(LOCAL_PROVIDER_VERSION) \
+		MANAGER_IMAGE=$(MANAGER_IMAGE) \
+		envsubst < ${E2E_CONF_FILE} > ${E2E_CONF_FILE_TMP}
 	docker tag ko.local/cluster-api-provider-nutanix:${IMG_TAG} ${IMG_REPO}:${IMG_TAG}
 	docker push ${IMG_REPO}:${IMG_TAG}
 	mkdir -p $(ARTIFACTS)

--- a/templates/testdata/clusterctl-init.yaml
+++ b/templates/testdata/clusterctl-init.yaml
@@ -1,7 +1,12 @@
----
 CLUSTERCTL_LOG_LEVEL: 10
 EXP_CLUSTER_RESOURCE_SET: 'true'
 CLUSTER_TOPOLOGY: 'true'
 NUTANIX_ENDPOINT: ''  # IP or FQDN of Prism Central
 NUTANIX_USER: ''  # Prism Central user
 NUTANIX_PASSWORD: ''  # Prism Central password
+providers:
+  # add a custom provider
+  # TODO(release-blocker): modify the version to the latest release
+  - name: "nutanix"
+    url: "file://${HOME}/.cluster-api/overrides/infrastructure-nutanix/v1.4.99/infrastructure-components.yaml"
+    type: "InfrastructureProvider"

--- a/templates/testdata/clusterctl-init.yaml
+++ b/templates/testdata/clusterctl-init.yaml
@@ -6,7 +6,6 @@ NUTANIX_USER: ''  # Prism Central user
 NUTANIX_PASSWORD: ''  # Prism Central password
 providers:
   # add a custom provider
-  # TODO(release-blocker): modify the version to the latest release
   - name: "nutanix"
-    url: "file://${HOME}/.cluster-api/overrides/infrastructure-nutanix/v1.4.99/infrastructure-components.yaml"
+    url: "file://${HOME}/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/infrastructure-components.yaml"
     type: "InfrastructureProvider"

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -188,7 +188,7 @@ providers:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/infrastructure-nutanix/v1.3.0/cluster-template.yaml"
           - sourcePath: "../data/infrastructure-nutanix/ccm-update.yaml"
-      - name: v1.4.99 # # TODO(release-blocker): update this when you make a new release and change the version to higher than the latest release
+      - name: ${LOCAL_PROVIDER_VERSION}
         type: kustomize
         value: "../../../config/default"
         contract: v1beta1


### PR DESCRIPTION
This ensures that when we make changes to the CRDs, the template test target leverages CAPX CRDs that include those changes.
