### PR TITLE
remove triggering mechanism for pull_request and add periodic tests

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - 'release-*'
-  pull_request:
   pull_request_target:
 jobs:
   build-container:

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -85,6 +85,7 @@ jobs:
     uses: ./.github/workflows/e2e.yaml
     with:
       e2e-labels: ${{ matrix.e2e-labels }}
+      make-target: test-e2e-calico
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -79,8 +79,6 @@ jobs:
         e2e-labels:
           - "clusterctl-upgrade"
           - "clusterclass"
-          - "conformance"
-          - "cluster-upgrade-conformance"
           - "capx-feature-test"
           - "scaling"
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,7 +5,10 @@ on:
         description: Labels to filter e2e tests
         type: string
         required: true
-
+      make-target:
+        description: Make target to run
+        type: string
+        required: true
 jobs:
   e2e-test:
     runs-on:
@@ -54,7 +57,6 @@ jobs:
 
       - name: Get Control Plane endpoint IP for clusterctl upgrade test
         id: get-control-plane-endpoint-ip-clusterctl-upgrade
-        if: inputs.e2e-labels == 'clusterctl-upgrade'
         run: |
           export CONTROL_PLANE_ENDPOINT_RANGE_START="${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_START }}"
           export CONTROL_PLANE_ENDPOINT_RANGE_END="${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_END }}"
@@ -62,7 +64,6 @@ jobs:
           echo "control_plane_endpoint_ip_clusterctl_upgrade=${control_plane_endpoint_ip}" >> "${GITHUB_OUTPUT}"
 
       - name: Check Control Plane endpoint IP for clusterctl upgrade
-        if: inputs.e2e-labels == 'clusterctl-upgrade'
         run: |
           if [[ -z "${{ steps.get-control-plane-endpoint-ip-clusterctl-upgrade.outputs.control_plane_endpoint_ip_clusterctl_upgrade }}" ]]; then
             echo "control_plane_endpoint_ip_clusterctl_upgrade is empty; cannot proceed with e2e tests"
@@ -70,7 +71,7 @@ jobs:
           fi
 
       - name: Test build
-        run: devbox run -- make test-e2e-calico LABEL_FILTERS='${{ inputs.e2e-labels }}'
+        run: devbox run -- make ${{ inputs.make-target }} LABEL_FILTERS='${{ inputs.e2e-labels }}'
         env:
           NUTANIX_USER: ${{ secrets.NUTANIX_USER }}
           NUTANIX_PASSWORD: ${{ secrets.NUTANIX_PASSWORD }}

--- a/.github/workflows/periodic/calico-conformance.yaml
+++ b/.github/workflows/periodic/calico-conformance.yaml
@@ -1,0 +1,14 @@
+name: Periodic Conformance Test with Calico
+on:
+  schedule:
+    - cron: "0 6 * * *" # 6 AM
+jobs:
+  e2e:
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      e2e-labels: "conformance || cluster-upgrade-conformance"
+      make-target: "test-e2e-calico"
+    secrets: inherit
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/periodic/cilium-conformance.yaml
+++ b/.github/workflows/periodic/cilium-conformance.yaml
@@ -1,0 +1,14 @@
+name: Periodic Conformance Test with Cilium
+on:
+  schedule:
+    - cron: "0 0 * * *" # Midnight
+jobs:
+  e2e:
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      e2e-labels: "conformance || cluster-upgrade-conformance"
+      make-target: "test-e2e-cilium"
+    secrets: inherit
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/periodic/cilium-without-kubeproxy-conformance.yaml
+++ b/.github/workflows/periodic/cilium-without-kubeproxy-conformance.yaml
@@ -1,0 +1,14 @@
+name: Periodic Conformance Test with Cilium without KubeProxy
+on:
+  schedule:
+    - cron: "0 18 * * *" # 6 PM
+jobs:
+  e2e:
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      e2e-labels: "conformance || cluster-upgrade-conformance"
+      make-target: "test-e2e-cilium-no-kubeproxy"
+    secrets: inherit
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/periodic/flannel-conformance.yaml
+++ b/.github/workflows/periodic/flannel-conformance.yaml
@@ -1,0 +1,14 @@
+name: Periodic Conformance Test with Flannel
+on:
+  schedule:
+    - cron: "0 12 * * *" # Noon
+jobs:
+  e2e:
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      e2e-labels: "conformance || cluster-upgrade-conformance"
+      make-target: "test-e2e-flannel"
+    secrets: inherit
+    permissions:
+      contents: read
+      checks: write

--- a/.github/workflows/periodic/synopsys-schedule.yaml
+++ b/.github/workflows/periodic/synopsys-schedule.yaml
@@ -1,8 +1,7 @@
 name: Black Duck Daily Policy Check
 on:
   schedule:
-    - cron: "0 0 * * *"
-
+    - cron: "0 0 * * *" # Midnight
 jobs:
   security:
     if: github.repository == 'nutanix-cloud-native/cluster-api-provider-nutanix'

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,6 +1,5 @@
 name: Black Duck Policy Check
 on:
-  pull_request:
   pull_request_target:
   push:
     branches:


### PR DESCRIPTION
- pull_request_target is now the main pull request triggering mechanism for secure workflow executions
- remove conformance and cluster-upgrade-conformance from presubmit e2es
- add conformance and cluster-upgrade-conformance as periodic e2es
