### PR TITLE
fix blackduck token key

### DIFF
--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -20,7 +20,7 @@ jobs:
         run: devbox run -- make build
 
       - name: Black Duck Full Scan
-        uses: synopsys-sig/synopsys-action@v1.7.0
+        uses: synopsys-sig/synopsys-action@v1.10.0
         with:
           blackduck_url: ${{ secrets.BLACKDUCK_URL }}
           blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}

--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: synopsys-sig/synopsys-action@v1.7.0
         with:
           blackduck_url: ${{ secrets.BLACKDUCK_URL }}
-          blackduck_apiToken: ${{ secrets.BLACKDUCK_API_TOKEN }}
+          blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           blackduck_scan_full: true
           blackduck_scan_failure_severities: 'BLOCKER,CRITICAL'

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Black Duck Full Scan
         if: ${{ github.event_name != 'pull_request' }}
-        uses: synopsys-sig/synopsys-action@v1.7.0
+        uses: synopsys-sig/synopsys-action@v1.10.0
         with:
           blackduck_url: ${{ secrets.BLACKDUCK_URL }}
           blackduck_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Black Duck PR Scan
         if: ${{ github.event_name == 'pull_request' }}
-        uses: synopsys-sig/synopsys-action@v1.7.0
+        uses: synopsys-sig/synopsys-action@v1.10.0
         env:
           DETECT_PROJECT_VERSION_NAME: ${{ github.base_ref }}
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

remove deprecated `blackduck_apiToken` key and replace by `blackduck_token`
update blackduck action to v1.10.0
 
**How Has This Been Tested?**:

check workflow success

**Release note**:

```release-note
NONE
```