### PR TITLE
Swap out busybox image to non-dockerhub

### DIFF
--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi"), func()
 				Containers: []corev1.Container{
 					{
 						Name:            "busybox",
-						Image:           "busybox",
+						Image:           "cgr.dev/chainguard/busybox:latest",
 						Command:         []string{"sleep", "3600"},
 						ImagePullPolicy: "IfNotPresent",
 						VolumeMounts: []corev1.VolumeMount{
@@ -487,7 +487,7 @@ var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi"), func()
 				Containers: []corev1.Container{
 					{
 						Name:            "busybox",
-						Image:           "busybox",
+						Image:           "cgr.dev/chainguard/busybox:latest",
 						Command:         []string{"sleep", "3600"},
 						ImagePullPolicy: "IfNotPresent",
 						VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
This is to ensure fewer rate limit issues via dockerhub.