### PR TITLE
fix(controller)!: Set UEFI as the default BootType

### DIFF
--- a/api/v1beta1/nutanix_types.go
+++ b/api/v1beta1/nutanix_types.go
@@ -22,6 +22,9 @@ type NutanixIdentifierType string
 // NutanixBootType is an enumeration of different boot types.
 type NutanixBootType string
 
+// BootDeviceType is an enumeration of different boot device types.
+type BootDeviceType string
+
 // NutanixGPUIdentifierType is an enumeration of different resource identifier types for GPU entities.
 type NutanixGPUIdentifierType string
 
@@ -37,6 +40,9 @@ const (
 
 	// NutanixBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
 	NutanixBootTypeUEFI NutanixBootType = "uefi"
+
+	// NutanixBootTypeSecureBoot is a resource identifier identifying the Secure Boot type for virtual machines.
+	NutanixBootTypeSecureBoot NutanixBootType = "SecureBoot"
 
 	// NutanixGPUIdentifierName is a resource identifier identifying a GPU by Name.
 	NutanixGPUIdentifierName NutanixGPUIdentifierType = "name"
@@ -55,6 +61,15 @@ const (
 
 	// ObsoleteDefaultCAPICategoryOwnedValue is the obsolete default category value used for CAPI clusters.
 	ObsoleteDefaultCAPICategoryOwnedValue = "owned"
+
+	// BootDeviceTypeDisk is a boot device type identifying the disk as the boot device.
+	BootDeviceTypeDisk BootDeviceType = "DISK"
+
+	// BootDeviceTypeCDROM is a boot device type identifying the CD-ROM as the boot device.
+	BootDeviceTypeCDROM BootDeviceType = "CDROM"
+
+	// BootDeviceTypeNetwork is a boot device type identifying the network as the boot device.
+	BootDeviceTypeNetwork BootDeviceType = "NETWORK"
 )
 
 // NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)

--- a/api/v1beta1/nutanixmachine_types.go
+++ b/api/v1beta1/nutanixmachine_types.go
@@ -92,6 +92,7 @@ type NutanixMachineSpec struct {
 	// Defines the boot type of the virtual machine. Only supports UEFI and Legacy
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:=legacy;uefi
+	// +kubebuilder:default:=uefi
 	BootType NutanixBootType `json:"bootType,omitempty"`
 
 	// systemDiskSize is size (in Quantity format) of the system disk of the VM

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -66,6 +66,7 @@ spec:
                   type: object
                 type: array
               bootType:
+                default: uefi
                 description: Defines the boot type of the virtual machine. Only supports
                   UEFI and Legacy
                 enum:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -83,6 +83,7 @@ spec:
                           type: object
                         type: array
                       bootType:
+                        default: uefi
                         description: Defines the boot type of the virtual machine.
                           Only supports UEFI and Legacy
                         enum:

--- a/templates/base/nmt.yaml
+++ b/templates/base/nmt.yaml
@@ -8,8 +8,8 @@ spec:
     spec:
       providerID: "nutanix://${CLUSTER_NAME}-m1"
       # Supported options for boot type: legacy and uefi
-      # Defaults to legacy if not set
-      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      # Defaults to uefi if not set
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=uefi}
       vcpusPerSocket: ${NUTANIX_MACHINE_VCPU_PER_SOCKET=1}
       vcpuSockets: ${NUTANIX_MACHINE_VCPU_SOCKET=2}
       memorySize: "${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}"

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -708,7 +708,7 @@ metadata:
 spec:
   template:
     spec:
-      bootType: legacy
+      bootType: uefi
       cluster:
         name: ""
         type: name
@@ -730,7 +730,7 @@ metadata:
 spec:
   template:
     spec:
-      bootType: legacy
+      bootType: uefi
       cluster:
         name: ""
         type: name

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -2204,7 +2204,7 @@ metadata:
 spec:
   template:
     spec:
-      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=uefi}
       cluster:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -2653,7 +2653,7 @@ metadata:
 spec:
   template:
     spec:
-      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=uefi}
       cluster:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -572,7 +572,7 @@ metadata:
 spec:
   template:
     spec:
-      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
+      bootType: ${NUTANIX_MACHINE_BOOT_TYPE=uefi}
       cluster:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name

--- a/templates/clusterclass/nmt-cp.yaml
+++ b/templates/clusterclass/nmt-cp.yaml
@@ -6,8 +6,8 @@ spec:
   template:
     spec:
       # Supported options for boot type: legacy and uefi
-      # Defaults to legacy if not set
-      bootType: legacy
+      # Defaults to uefi if not set
+      bootType: uefi
       vcpusPerSocket: 1
       vcpuSockets: 2
       memorySize: 4Gi

--- a/templates/clusterclass/nmt-md.yaml
+++ b/templates/clusterclass/nmt-md.yaml
@@ -6,8 +6,8 @@ spec:
   template:
     spec:
       # Supported options for boot type: legacy and uefi
-      # Defaults to legacy if not set
-      bootType: legacy
+      # Defaults to uefi if not set
+      bootType: uefi
       vcpusPerSocket: 1
       vcpuSockets: 2
       memorySize: 4Gi

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -59,7 +59,7 @@ const (
 	defaultVCPUSockets    = int32(2)
 	defaultMemorySize     = "4Gi"
 	defaultSystemDiskSize = "40Gi"
-	defaultBootType       = "legacy"
+	defaultBootType       = "uefi"
 
 	categoryKeyVarKey   = "NUTANIX_ADDITIONAL_CATEGORY_KEY"
 	categoryValueVarKey = "NUTANIX_ADDITIONAL_CATEGORY_VALUE"


### PR DESCRIPTION
As we have switched to UEFI as the default Boot Type in Prism Central, we should do the same with CAPX to stay aligned with the direction of the product.