### PR TITLE
fix(controller): ignore category value delete error

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -503,9 +503,11 @@ func deleteCategoryKeyValues(ctx context.Context, client *prismclientv3.Client, 
 
 			err = client.V3.DeleteCategoryValue(ctx, key, value)
 			if err != nil {
-				errorMsg := fmt.Errorf("failed to delete category with key %s. error: %v", key, err)
-				log.Error(errorMsg, "failed to delete category")
-				return errorMsg
+				errorMsg := fmt.Errorf("failed to delete category value with key:value %s:%s. error: %v", key, value, err)
+				log.Error(errorMsg, "failed to delete category value")
+				// NCN-101935: If the category value still has VMs assigned, do not delete the category key:value
+				// TODO:deepakmntnx Add a check for specific error mentioned in NCN-101935
+				return nil
 			}
 		}
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -64,6 +64,14 @@ func setupSpecNamespace(ctx context.Context, specName string, clusterProxy frame
 	return namespace, cancelWatches
 }
 
+func unsetupNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, namespace *corev1.Namespace) {
+	Byf("Deleting namespace used for hosting the %q test spec", specName)
+	framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+		Deleter: clusterProxy.GetClient(),
+		Name:    namespace.Name,
+	})
+}
+
 func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace *corev1.Namespace, cancelWatches context.CancelFunc, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, skipCleanup bool) {
 	Byf("Dumping logs from the %q workload cluster", cluster.Name)
 
@@ -89,11 +97,7 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 			Namespace: namespace.Name,
 		}, intervalsGetter(specName, "wait-delete-cluster")...)
 
-		Byf("Deleting namespace used for hosting the %q test spec", specName)
-		framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
-			Deleter: clusterProxy.GetClient(),
-			Name:    namespace.Name,
-		})
+		unsetupNamespace(ctx, specName, clusterProxy, namespace)
 	}
 	cancelWatches()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
It was observed that if we create 2 clusters with same name then single category key:value is used to tag the vms. and when we delete one cluster then it fails to delete category key:value as there are other resources still tagged. this PR ignores the error at this time till we come up with better strategy in future

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes ncn-101935

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_
<pre>
make test-e2e-calico LABEL_FILTERS="same-name-clusters"
</pre>

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```