### PR TITLE
build(lint): Update golangci-lint-action version to v6

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -39,7 +39,9 @@ jobs:
         run: devbox run -- make generate fmt vet build
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
 
       - name: Lint
         run: devbox run -- make lint-yaml

--- a/devbox.json
+++ b/devbox.json
@@ -8,6 +8,7 @@
     "gnumake@4.4.1",
     "ginkgo@2.19.0",
     "go@1.22.1",
+    "golangci-lint@1.59.1",
     "gotestsum@1.6.4",
     "kubernetes-helm@latest",
     "kind@0.23.0",
@@ -23,7 +24,6 @@
     "path:./hack/flakes#go-junit-report",
     "path:./hack/flakes#gocov",
     "path:./hack/flakes#gocov-xml",
-    "path:./hack/flakes#golangci-lint",
     "path:./hack/flakes#yamllint-checkstyle",
     "path:./hack/flakes#setup-envtest"
   ]

--- a/devbox.lock
+++ b/devbox.lock
@@ -269,6 +269,54 @@
         }
       }
     },
+    "golangci-lint@1.59.1": {
+      "last_modified": "2024-07-20T09:11:00Z",
+      "resolved": "github:NixOS/nixpkgs/6e14bbce7bea6c4efd7adfa88a40dac750d80100#golangci-lint",
+      "source": "devbox-search",
+      "version": "1.59.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/80cn62vqs99adkpvjv5qmv9nvkahcy0s-golangci-lint-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/80cn62vqs99adkpvjv5qmv9nvkahcy0s-golangci-lint-1.59.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f91hm1xlmjy5y18lavfn9889azxam4mp-golangci-lint-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/f91hm1xlmjy5y18lavfn9889azxam4mp-golangci-lint-1.59.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pn0lpm53xffqvdfd72n4mfn8ja4kmf1h-golangci-lint-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pn0lpm53xffqvdfd72n4mfn8ja4kmf1h-golangci-lint-1.59.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fx4p42sdx70hzpzsl71r5zwh8az0p74a-golangci-lint-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fx4p42sdx70hzpzsl71r5zwh8az0p74a-golangci-lint-1.59.1"
+        }
+      }
+    },
     "gotestsum@1.6.4": {
       "last_modified": "2021-07-26T10:49:44Z",
       "resolved": "github:NixOS/nixpkgs/2030abed5863fc11eccac0735f27a0828376c84e#gotestsum",

--- a/hack/flakes/flake.nix
+++ b/hack/flakes/flake.nix
@@ -10,8 +10,6 @@
     flake-utils.lib.eachDefaultSystem (system:
       with nixpkgs.legacyPackages.${system}; rec {
         packages = rec {
-          golangci-lint = pkgs.golangci-lint.override { buildGoModule = buildGo121Module; };
-
           go-apidiff = buildGo121Module {
             name = "go-apidiff";
             src = fetchFromGitHub {


### PR DESCRIPTION
The current lint action has started failing so we are updating the lint action
to v6 and the underlying golangci-lint version to v1.59