### PR TITLE
fix(template): add CONTROL_PLANE_ENDPOINT_IP to ignoredNodeIPs list in CCM

### DIFF
--- a/templates/ccm/nutanix-ccm.yaml
+++ b/templates/ccm/nutanix-ccm.yaml
@@ -41,7 +41,10 @@ data:
       "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
       "topologyDiscovery": {
         "type": "Prism"
-      }
+      },
+      "ignoredNodeIPs": [
+        "${CONTROL_PLANE_ENDPOINT_IP}"
+      ]
     }
 ---
 # Source: nutanix-cloud-provider/templates/rbac.yaml

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -52,7 +52,10 @@ data:
           "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
           "topologyDiscovery": {
             "type": "Prism"
-          }
+          },
+          "ignoredNodeIPs": [
+            "${CONTROL_PLANE_ENDPOINT_IP}"
+          ]
         }
     ---
     # Source: nutanix-cloud-provider/templates/rbac.yaml

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -52,7 +52,10 @@ data:
           "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
           "topologyDiscovery": {
             "type": "Prism"
-          }
+          },
+          "ignoredNodeIPs": [
+            "${CONTROL_PLANE_ENDPOINT_IP}"
+          ]
         }
     ---
     # Source: nutanix-cloud-provider/templates/rbac.yaml

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -51,7 +51,10 @@ data:
           "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
           "topologyDiscovery": {
             "type": "Prism"
-          }
+          },
+          "ignoredNodeIPs": [
+            "${CONTROL_PLANE_ENDPOINT_IP}"
+          ]
         }
     ---
     # Source: nutanix-cloud-provider/templates/rbac.yaml

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -52,7 +52,10 @@ data:
           "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
           "topologyDiscovery": {
             "type": "Prism"
-          }
+          },
+          "ignoredNodeIPs": [
+            "${CONTROL_PLANE_ENDPOINT_IP}"
+          ]
         }
     ---
     # Source: nutanix-cloud-provider/templates/rbac.yaml

--- a/test/e2e/data/infrastructure-nutanix/ccm-update.yaml
+++ b/test/e2e/data/infrastructure-nutanix/ccm-update.yaml
@@ -44,7 +44,10 @@ data:
           "enableCustomLabeling": ${CCM_CUSTOM_LABEL=false},
           "topologyDiscovery": {
             "type": "Prism"
-          }
+          },
+          "ignoredNodeIPs": [
+            "${CONTROL_PLANE_ENDPOINT_IP}"
+          ]
         }
     ---
     # Source: nutanix-cloud-provider/templates/rbac.yaml
@@ -223,7 +226,8 @@ metadata:
   name: nutanix-ccm-secret
   namespace: ${PATCH_NAMESPACE=clusterctl-upgrade}
 stringData:
-  nutanix-ccm-secret.yaml: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: nutanix-creds\n
+  nutanix-ccm-secret.yaml:
+    "apiVersion: v1\nkind: Secret\nmetadata:\n  name: nutanix-creds\n
     \ namespace: kube-system\nstringData:\n  credentials: |\n    [\n      {\n        \"type\":
     \"basic_auth\", \n        \"data\": { \n          \"prismCentral\":{\n            \"username\":
     \"${NUTANIX_USER}\",\n            \"password\": \"${NUTANIX_PASSWORD}\"\n          },\n
@@ -240,10 +244,10 @@ spec:
     matchLabels:
       ccm: nutanix
   resources:
-  - kind: ConfigMap
-    name: nutanix-ccm
-  - kind: Secret
-    name: nutanix-ccm-secret
-  - kind: ConfigMap
-    name: user-ca-bundle
+    - kind: ConfigMap
+      name: nutanix-ccm
+    - kind: Secret
+      name: nutanix-ccm-secret
+    - kind: ConfigMap
+      name: user-ca-bundle
   strategy: ApplyOnce


### PR DESCRIPTION
**What this PR does / why we need it**:

By adding CONTROL_PLANE_ENDPOINT_IP to the ignoredNodeIPs in the CCM config, we ensure
CCM will not assign the CONTROL_PLANE_ENDPOINT_IP as the node IP for any node. This could
previously happen as both CONTROL_PLANE_ENDPOINT_IP and node IP on an external DHCP network
would be learned IPs. In case of a slow DHCP assignment, the CONTROL_PLANE_ENDPOINT_IP
could be assigned as the first learned IP on the VM leading to potential issues when the CCM would then
assign the first IP as the node IP even though it was a floating IP.
It also causing issue with IPAM mode and third-party tools who are using IP from nodes


**How Has This Been Tested?**:

manual deployment of modified ressources


**Release note**:

```release-note
- Set CCM to ignore Control Plane IP
```