### PR TITLE
fix(bug): Encode name in filter by name FIQL Query

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -664,7 +665,8 @@ func GetProjectUUID(ctx context.Context, client *prismclientv3.Client, projectNa
 }
 
 func getFilterForName(name string) string {
-	return fmt.Sprintf("name==%s", name)
+	encodedName := url.QueryEscape(name)
+	return fmt.Sprintf("name==%s", encodedName)
 }
 
 func hasPEClusterServiceEnabled(peCluster *prismclientv3.ClusterIntentResponse, serviceName string) bool {

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -229,3 +229,39 @@ func TestGetPrismCentralClientForCluster(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestGetFilterForName(t *testing.T) {
+	tt := []struct {
+		name     string
+		expected string
+		testName string
+	}{
+		{
+			name:     "test-name",
+			expected: "name==test-name",
+			testName: "ReturnsCorrectFilterForValidName",
+		},
+		{
+			name:     "test name with spaces",
+			expected: "name==test+name+with+spaces",
+			testName: "ReturnsCorrectFilterForNameWithSpecialCharacters",
+		},
+		{
+			name:     "",
+			expected: "name==",
+			testName: "ReturnsCorrectFilterForEmptyName",
+		},
+		{
+			name:     "test|name=with?special#characters",
+			expected: "name==test%7Cname%3Dwith%3Fspecial%23characters",
+			testName: "ReturnsCorrectFilterForNameWithURLCharacters",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			filter := getFilterForName(tc.name)
+			assert.Equal(t, tc.expected, filter)
+		})
+	}
+}


### PR DESCRIPTION
Not encoding the name can cause errors when non-standard characters are present in the name.

**How has this been tested?**
Unter testing
* Create a new subnet with escapable characters in the name: `vlan173|ncn|dev|sandbox`
* Create a new cluster with a machine deployment pointing to that subnet
* Observe the cluster come up successfully

Current status: with these changes we are still seeing failed machines with:
```
  failureMessage: 'Failure detected from referenced resource infrastructure.cluster.x-k8s.io/v1beta1,
    Kind=NutanixMachine with name "quick-start-0j5mcd-zb6l8-k6fqs": failed to retrieve
    subnet by name vlan173|ncn|dev|sandbox'
```