### PR TITLE
fix(build): add local image registry credentials to e2e step

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,6 +72,13 @@ jobs:
             exit 1
           fi
 
+      - name: Login to Internal Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.LOCAL_IMAGE_REGISTRY }}
+          username: ${{ secrets.LOCAL_IMAGE_REGISTRY_USERNAME }}
+          password: ${{ secrets.LOCAL_IMAGE_REGISTRY_TOKEN }}
+
       - name: Test build
         run: devbox run -- make ${{ inputs.make-target }} LABEL_FILTERS='${{ inputs.e2e-labels }}'
         env:


### PR DESCRIPTION
E2E needs a local image registry to push the images for upgrade and self-hosted cluster testing.
actions are on pull_request_target so failures in the PR are expected failures.