### PR TITLE
fix: Parse flags before loading kubeconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,13 +306,14 @@ func initializeManager(config *managerConfig) (manager.Manager, error) {
 func main() {
 	logger := setupLogger()
 
-	restConfig := ctrl.GetConfigOrDie()
-
-	config := &managerConfig{
-		logger:     logger,
-		restConfig: restConfig,
-	}
+	config := &managerConfig{}
 	parseFlags(config)
+
+	// Flags must be parsed before calling GetConfigOrDie, because
+	// it reads the value of the--kubeconfig flag.
+	config.restConfig = ctrl.GetConfigOrDie()
+
+	config.logger = logger
 
 	logger.Info("Initializing Nutanix Cluster API Infrastructure Provider", "Git Hash", gitCommitHash)
 	mgr, err := initializeManager(config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
To respect the --kubeconfig flag, we must parse it before loading the kubeconfig.

This fixes a bug introduced by #383, where we begin parsing flags _after_ loading the kubeconfig.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```