### PR TITLE
feat: Add optional VSCode integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,13 +337,21 @@ mocks: ## Generate mocks for the project
 
 GOTESTPKGS = $(shell go list ./... | grep -v /mocks | grep -v /templates)
 
+KUBEBUILDER_ASSETS=$(shell setup-envtest use --print path $(ENVTEST_K8S_VERSION) --arch=amd64)
+
+.PHONY: print-envtest
+print-envtest: ## Set up envtest (download kubebuilder assets)
+	@echo KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)
+
 .PHONY: unit-test
 unit-test: mocks  ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION)  --arch=amd64 -p path)" $(GOTEST) $(GOTESTPKGS)
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
+	$(GOTEST) $(GOTESTPKGS)
 
 .PHONY: coverage
 coverage: mocks ## Run the tests of the project and export the coverage
-	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION)  --arch=amd64 -p path)" $(GOTEST) -race -coverprofile=coverage.out -covermode=atomic $(GOTESTPKGS)
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
+	$(GOTEST) -race -coverprofile=coverage.out -covermode=atomic $(GOTESTPKGS)
 
 .PHONY: template-test
 template-test: docker-build prepare-local-clusterctl ## Run the template tests

--- a/docs/vscode-integration/README.md
+++ b/docs/vscode-integration/README.md
@@ -1,0 +1,13 @@
+# VSCode Integration
+
+Some of the unit tests use the [envtest package](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) from the controller-runtime project to create a temporary Kubernetes API server.
+
+Envtest reads the location of the necessary binaries, i.e. etcd and kube-apiserver, from an environment variable. This environment variable is initialized by our make targets, but VSCode does not run tests using make.
+
+We can use a VSCode task to write the location to a file, and configure vscode-go, which runs the tests, to initialize its environment from this file.
+
+To run envtest-based tests from VSCode, follow these steps:
+
+1. Install setup-envtest (and other build/test dependencies) by running `devbox install`.
+2. Copy `settings.json` and `tasks.json` in this directory into the `.vscode` folder at the root of the repository.
+3. Restart VSCode.

--- a/docs/vscode-integration/settings.json
+++ b/docs/vscode-integration/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.testEnvFile": "${workspaceFolder}/.vscode/test.env"
+}

--- a/docs/vscode-integration/tasks.json
+++ b/docs/vscode-integration/tasks.json
@@ -1,0 +1,32 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "Prepare vscode to run envtest-based tests",
+            "detail": "Install envtest and configure the vscode-go test environment.",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "command": [
+                "echo $(make print-envtest) > ${workspaceFolder}/.vscode/test.env",
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "runOptions": {
+                "runOn": "folderOpen",
+                "instanceLimit": 1,
+            },
+            "promptOnClose": true,
+        }
+    ]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Document explains how to make it possible to run our envtest-based tests using VSCode.

If you develop using VSCode, enabling the integration makes it possible to do the following _with envtest-based tests_:
- Run them
- Debug them
- See directly in the editor how changes affect code coverage

A couple of years ago, I contributed a similar optional integration to Cluster API (https://github.com/kubernetes-sigs/cluster-api/pull/8088).
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

I have run envtest-based tests from VSCode.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```