### PR TITLE
build: Allow internal contributors to test workflows that use pull_request_target

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -6,7 +6,12 @@ on:
     branches:
       - main
       - 'release-*'
+  pull_request:
+    paths:
+    - '.github/**'
   pull_request_target:
+    paths-ignore:
+    - '.github/**'
 jobs:
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,10 +1,15 @@
 name: Black Duck Policy Check
 on:
-  pull_request_target:
   push:
     branches:
       - main
       - 'release-*'
+  pull_request:
+    paths:
+    - '.github/**'
+  pull_request_target:
+    paths-ignore:
+    - '.github/**'
 
 jobs:
   security:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Allows internal contributors to test workflow changes. Workflow changes will run using pull_request event. If a workflow uses secrets and is run in an external PR, the workflow will not be able to read the secrets. Non-workflow changes will run using pull_request_target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:
- We **cannot** test these changes in the context of the PR, because the workflows are from the `main` branch, as the result of being triggered by the `pull_request_target` event.
- However, I am able to test that the changes work as expected by opening two separate PRs, with this PR's branch as the target. 
   - #503 demonstrates that a PR that does not change files under `.github` (i.e., workflows) triggers actions using `pull_request_target`.
   - #504 demonstrates that a PR that changes files under `.github` (i.e., workflows) triggers actions using `pull_request`.

For example, when I pushed a commit that changed a workflow, the action was triggered by the event `pull_request`:
![image](https://github.com/user-attachments/assets/a01470d0-31d7-4883-bb5e-7042b11f599b)

Later, when I pushed a commit that did not change a workflow, the action was triggered by the event `pull_request_target`: 
![image](https://github.com/user-attachments/assets/d997f1ff-c8c2-452f-ac67-cdee96c2680f)



_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```