### PR TITLE
fix(build): update devbox.lock

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -285,6 +285,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/dad564433178067be1fbdfcce23b546254b6d641?lastModified=1740019556&narHash=sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g%3D"
+    },
     "gnumake@latest": {
       "last_modified": "2024-07-07T07:43:47Z",
       "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#gnumake",


### PR DESCRIPTION
new version of devbox is out and it makes a small change to the devbox.lock. Committing the change to prevent failing builds.