### PR TITLE
fix(bug): Remove crude check for prism central version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ The API itself is shared across multiple cloud providers allowing for true Nutan
 ## How to Deploy a Kubernetes Cluster on Nutanix Cloud Infrastucture
 Check out the [getting started guide](https://opendocs.nutanix.com/capx/latest/getting_started/) for launching a cluster on Nutanix Cloud Infrastructure.
 
-## Features
+## Compatibility with Prism Central & Prism Element
 
-## Compatibility with Cluster API and Kubernetes Versions
+| CAPX Version | Min. Prism Central Version | Min. Prism Element Version |
+|--------------|----------------------------|----------------------------|
+| 1.5.x        | pc2024.1+                  | 6.5+                       |
+| 1.6.x        | pc2024.2+                  | 6.5+                       |
 
 ## Documentation
 Visit the `Cluster API Provider: Nutanix (CAPX)` section on [opendocs.nutanix.com](https://opendocs.nutanix.com/) for all documentation related to CAPX.

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -19,12 +19,10 @@ package controllers
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -1135,67 +1133,6 @@ func getPrismCentralV4ClientForCluster(ctx context.Context, cluster *infrav1.Nut
 
 	conditions.MarkTrue(cluster, infrav1.PrismCentralV4ClientCondition)
 	return client, nil
-}
-
-// isPrismCentralV4Compatible checks if the Prism Central is v4 API compatible
-func isPrismCentralV4Compatible(ctx context.Context, v3Client *prismclientv3.Client) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-	internalPCNames := []string{"master", "fraser"}
-	pcVersion, err := getPrismCentralVersion(ctx, v3Client)
-	if err != nil {
-		return false, fmt.Errorf("failed to get Prism Central version: %w", err)
-	}
-
-	// Check if the version is v4 compatible
-	// PC versions look like pc.2024.1.0.1
-	// We can check if the version is greater than or equal to 2024
-
-	if pcVersion == "" {
-		return false, errors.New("prism central version is empty")
-	}
-
-	for _, internalPCName := range internalPCNames {
-		// TODO(sid): This is a naive check to see if the PC version is an internal build. This can potentially lead to failures
-		// if internal fraser build is not v4 compatible.
-		if strings.Contains(pcVersion, internalPCName) {
-			log.Info(fmt.Sprintf("Prism Central version %s is an internal build; assuming it is v4 compatible", pcVersion))
-			return true, nil
-		}
-	}
-
-	// Remove the prefix "pc."
-	version := strings.TrimPrefix(pcVersion, "pc.")
-	// Split the version string by "." to extract the year part
-	parts := strings.Split(version, ".")
-	if len(parts) < 1 {
-		return false, errors.New("invalid version format")
-	}
-
-	// Convert the year part to an integer
-	year, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return false, errors.New("invalid version: failed to parse year from PC version")
-	}
-
-	if year >= 2024 {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// getPrismCentralVersion returns the version of the Prism Central instance
-func getPrismCentralVersion(ctx context.Context, v3Client *prismclientv3.Client) (string, error) {
-	pcInfo, err := v3Client.V3.GetPrismCentral(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	if pcInfo.Resources == nil || pcInfo.Resources.Version == nil {
-		return "", fmt.Errorf("failed to get Prism Central version")
-	}
-
-	return *pcInfo.Resources.Version, nil
 }
 
 func detachVolumeGroupsFromVM(ctx context.Context, v4Client *prismclientv4.Client, vmName string, vmUUID string, vmDiskList []*prismclientv3.VMDisk) error {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -408,15 +408,6 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 }
 
 func (r *NutanixMachineReconciler) detachVolumeGroups(rctx *nctx.MachineContext, vmName string, vmUUID string, vmDiskList []*prismclientv3.VMDisk) error {
-	createV4Client, err := isPrismCentralV4Compatible(rctx.Context, rctx.NutanixClient)
-	if err != nil {
-		return fmt.Errorf("error occurred while checking compatibility for Prism Central v4 APIs: %w", err)
-	}
-
-	if !createV4Client {
-		return nil
-	}
-
 	v4Client, err := getPrismCentralV4ClientForCluster(rctx.Context, rctx.NutanixCluster, r.SecretInformer, r.ConfigMapInformer)
 	if err != nil {
 		return fmt.Errorf("error occurred while fetching Prism Central v4 client: %w", err)

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -24,7 +24,6 @@ import (
 
 	credentialTypes "github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
 	prismclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
-	"github.com/nutanix-cloud-native/prism-go-client/v3/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -240,102 +239,6 @@ func TestNutanixMachineReconciler(t *testing.T) {
 					NutanixCluster: ntnxCluster,
 				})
 				g.Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("Detaches a volume group on deletion", func() {
-			It("should error if get prism central returns error", func() {
-				mockctrl := gomock.NewController(t)
-				mockv3Service := mocknutanixv3.NewMockService(mockctrl)
-				mockv3Service.EXPECT().GetPrismCentral(gomock.Any()).Return(nil, errors.New("error"))
-
-				v3Client := &prismclientv3.Client{
-					V3: mockv3Service,
-				}
-				err := reconciler.detachVolumeGroups(&nctx.MachineContext{
-					NutanixClient: v3Client,
-				},
-					"",
-					ntnxMachine.Status.VmUUID,
-					[]*prismclientv3.VMDisk{},
-				)
-				g.Expect(err).To(HaveOccurred())
-			})
-
-			It("should error if prism central version is empty", func() {
-				mockctrl := gomock.NewController(t)
-				mockv3Service := mocknutanixv3.NewMockService(mockctrl)
-				mockv3Service.EXPECT().GetPrismCentral(gomock.Any()).Return(&models.PrismCentral{Resources: &models.PrismCentralResources{
-					Version: ptr.To(""),
-				}}, nil)
-
-				v3Client := &prismclientv3.Client{
-					V3: mockv3Service,
-				}
-				err := reconciler.detachVolumeGroups(&nctx.MachineContext{
-					NutanixClient: v3Client,
-				}, "",
-					ntnxMachine.Status.VmUUID,
-					[]*prismclientv3.VMDisk{},
-				)
-				g.Expect(err).To(HaveOccurred())
-			})
-
-			It("should error if prism central version value is absent", func() {
-				mockctrl := gomock.NewController(t)
-				mockv3Service := mocknutanixv3.NewMockService(mockctrl)
-				mockv3Service.EXPECT().GetPrismCentral(gomock.Any()).Return(&models.PrismCentral{Resources: &models.PrismCentralResources{
-					Version: ptr.To("pc."),
-				}}, nil)
-
-				v3Client := &prismclientv3.Client{
-					V3: mockv3Service,
-				}
-				err := reconciler.detachVolumeGroups(&nctx.MachineContext{
-					NutanixClient: v3Client,
-				}, "",
-					ntnxMachine.Status.VmUUID,
-					[]*prismclientv3.VMDisk{},
-				)
-				g.Expect(err).To(HaveOccurred())
-			})
-
-			It("should error if prism central version is invalid", func() {
-				mockctrl := gomock.NewController(t)
-				mockv3Service := mocknutanixv3.NewMockService(mockctrl)
-				mockv3Service.EXPECT().GetPrismCentral(gomock.Any()).Return(&models.PrismCentral{Resources: &models.PrismCentralResources{
-					Version: ptr.To("not.a.valid.version"),
-				}}, nil)
-
-				v3Client := &prismclientv3.Client{
-					V3: mockv3Service,
-				}
-				err := reconciler.detachVolumeGroups(&nctx.MachineContext{
-					NutanixClient: v3Client,
-				}, "",
-					ntnxMachine.Status.VmUUID,
-					[]*prismclientv3.VMDisk{},
-				)
-				g.Expect(err).To(HaveOccurred())
-			})
-
-			It("should not error if prism central is not v4 compatible", func() {
-				mockctrl := gomock.NewController(t)
-				mockv3Service := mocknutanixv3.NewMockService(mockctrl)
-				mockv3Service.EXPECT().GetPrismCentral(gomock.Any()).Return(&models.PrismCentral{Resources: &models.PrismCentralResources{
-					Version: ptr.To("pc.2023.4.0.1"),
-				}}, nil)
-
-				v3Client := &prismclientv3.Client{
-					V3: mockv3Service,
-				}
-				err := reconciler.detachVolumeGroups(&nctx.MachineContext{
-					NutanixClient: v3Client,
-				}, "",
-					ntnxMachine.Status.VmUUID,
-					[]*prismclientv3.VMDisk{},
-				)
-				g.Expect(err).To(Not(HaveOccurred()))
 			})
 		})
 	})


### PR DESCRIPTION
Earlier we had a crude check on prism central version which checked if prism central version is higher than 2024.1. We remove this check and assume that the underlying prism central is within support lifespan (EOL policy) and has v4 API support. This fixes the false positive issues where this check fails for newer PC versioning scheme of following AOS version i.e. PC7.3. As of now the only v4 API calls we make are Detach VG From VM which are supported on all AOS versions past 6.5. Also added clarity on versioning compatibility in README.