### PR TITLE
Conditionally Add API Server Flag Based on Kubernetes Version(<=1.33.0) in Kubeadm Configuration

### DIFF
--- a/templates/base/ccm-patch.yaml
+++ b/templates/base/ccm-patch.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external

--- a/templates/base/kcp.yaml
+++ b/templates/base/kcp.yaml
@@ -124,6 +124,18 @@ spec:
             sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
           fi
         fi
+      - |
+        KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+        VERSION_TO_COMPARE=1.33.0
+        # Add cloud-provider flag only for Kubernetes versions <= 1.33.0
+        if [ "$(printf '%s\n' "$VERSION_TO_COMPARE" "$KUBERNETES_VERSION_NO_V" | sort -V | head -n1)" = "$KUBERNETES_VERSION_NO_V" ]; then
+          if [ -f /run/kubeadm/kubeadm.yaml ]; then
+            # Insert cloud-provider in the proper list format used by the kubeadm.yaml file
+            sed -i '/apiServer:/,/extraArgs:/s/extraArgs:/extraArgs:\n  - name: cloud-provider\n    value: external/' /run/kubeadm/kubeadm.yaml
+            # Add logging for debugging
+            echo "Added cloud-provider: external to apiServer configuration in list format" > /var/log/cloud-provider-config.log
+          fi
+        fi
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
       - |

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -2054,7 +2054,6 @@ spec:
         - 127.0.0.1
         - 0.0.0.0
         extraArgs:
-          cloud-provider: external
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       controllerManager:
         extraArgs:
@@ -2161,6 +2160,18 @@ spec:
       if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
         if [ -f /run/kubeadm/kubeadm.yaml ]; then
           sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.33.0
+      # Add cloud-provider flag only for Kubernetes versions <= 1.33.0
+      if [ "$(printf '%s\n' "$VERSION_TO_COMPARE" "$KUBERNETES_VERSION_NO_V" | sort -V | head -n1)" = "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          # Insert cloud-provider in the proper list format used by the kubeadm.yaml file
+          sed -i '/apiServer:/,/extraArgs:/s/extraArgs:/extraArgs:\n  - name: cloud-provider\n    value: external/' /run/kubeadm/kubeadm.yaml
+          # Add logging for debugging
+          echo "Added cloud-provider: external to apiServer configuration in list format" > /var/log/cloud-provider-config.log
         fi
       fi
     useExperimentalRetryJoin: true

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -2503,7 +2503,6 @@ spec:
         - 127.0.0.1
         - 0.0.0.0
         extraArgs:
-          cloud-provider: external
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       controllerManager:
         extraArgs:
@@ -2610,6 +2609,18 @@ spec:
       if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
         if [ -f /run/kubeadm/kubeadm.yaml ]; then
           sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.33.0
+      # Add cloud-provider flag only for Kubernetes versions <= 1.33.0
+      if [ "$(printf '%s\n' "$VERSION_TO_COMPARE" "$KUBERNETES_VERSION_NO_V" | sort -V | head -n1)" = "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          # Insert cloud-provider in the proper list format used by the kubeadm.yaml file
+          sed -i '/apiServer:/,/extraArgs:/s/extraArgs:/extraArgs:\n  - name: cloud-provider\n    value: external/' /run/kubeadm/kubeadm.yaml
+          # Add logging for debugging
+          echo "Added cloud-provider: external to apiServer configuration in list format" > /var/log/cloud-provider-config.log
         fi
       fi
     useExperimentalRetryJoin: true

--- a/templates/cluster-template-image-lookup.yaml
+++ b/templates/cluster-template-image-lookup.yaml
@@ -422,7 +422,6 @@ spec:
         - 127.0.0.1
         - 0.0.0.0
         extraArgs:
-          cloud-provider: external
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       controllerManager:
         extraArgs:
@@ -529,6 +528,18 @@ spec:
       if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
         if [ -f /run/kubeadm/kubeadm.yaml ]; then
           sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.33.0
+      # Add cloud-provider flag only for Kubernetes versions <= 1.33.0
+      if [ "$(printf '%s\n' "$VERSION_TO_COMPARE" "$KUBERNETES_VERSION_NO_V" | sort -V | head -n1)" = "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          # Insert cloud-provider in the proper list format used by the kubeadm.yaml file
+          sed -i '/apiServer:/,/extraArgs:/s/extraArgs:/extraArgs:\n  - name: cloud-provider\n    value: external/' /run/kubeadm/kubeadm.yaml
+          # Add logging for debugging
+          echo "Added cloud-provider: external to apiServer configuration in list format" > /var/log/cloud-provider-config.log
         fi
       fi
     useExperimentalRetryJoin: true

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -422,7 +422,6 @@ spec:
         - 127.0.0.1
         - 0.0.0.0
         extraArgs:
-          cloud-provider: external
           tls-cipher-suites: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       controllerManager:
         extraArgs:
@@ -529,6 +528,18 @@ spec:
       if [ "$(printf '%s\n' "$KUBERNETES_VERSION_NO_V" "$VERSION_TO_COMPARE" | sort -V | head -n1)" != "$KUBERNETES_VERSION_NO_V" ]; then
         if [ -f /run/kubeadm/kubeadm.yaml ]; then
           sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
+        fi
+      fi
+    - |
+      KUBERNETES_VERSION_NO_V=${KUBERNETES_VERSION#v}
+      VERSION_TO_COMPARE=1.33.0
+      # Add cloud-provider flag only for Kubernetes versions <= 1.33.0
+      if [ "$(printf '%s\n' "$VERSION_TO_COMPARE" "$KUBERNETES_VERSION_NO_V" | sort -V | head -n1)" = "$KUBERNETES_VERSION_NO_V" ]; then
+        if [ -f /run/kubeadm/kubeadm.yaml ]; then
+          # Insert cloud-provider in the proper list format used by the kubeadm.yaml file
+          sed -i '/apiServer:/,/extraArgs:/s/extraArgs:/extraArgs:\n  - name: cloud-provider\n    value: external/' /run/kubeadm/kubeadm.yaml
+          # Add logging for debugging
+          echo "Added cloud-provider: external to apiServer configuration in list format" > /var/log/cloud-provider-config.log
         fi
       fi
     useExperimentalRetryJoin: true


### PR DESCRIPTION


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #520

**How Has This Been Tested?**:
Removes existing api server flag, and added it as conditional parameter for versions <= 1.33.0

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output

I followed the development workflow and deployed my changes.
After the Nutanix control machine was provisioned, I SSHed into it and checked /run/kubeadm/kubeadm.yaml.
The value was added for versions <= 1.33.0, and for other versions, it was not added.