### PR TITLE
Feature/enable secure metrics (#3)

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,5 +1,5 @@
-# This patch inject a sidecar container which is a HTTP proxy for the
-# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+# This patch modifies the manager deployment to expose the metrics port securely
+# using controller-runtime's built-in authentication and authorization
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,26 +9,15 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--diagnostics-address=127.0.0.1:8080"
-        - "--insecure-diagnostics"
+        - "--diagnostics-address=:8443"
         - "--leader-elect"
         - "--zap-log-level=${NUTANIX_LOG_LEVEL=info}"
         - "--zap-devel=${NUTANIX_LOG_DEVELOPMENT=true}"
         - "--zap-stacktrace-level=${NUTANIX_LOG_STACKTRACE_LEVEL=panic}"
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
@@ -190,6 +191,7 @@ func initializeConfig(opts *options) (*managerConfig, error) {
 	if metricsServerOpts == nil {
 		return nil, errors.New("parsed manager options are nil")
 	}
+	metricsServerOpts.FilterProvider = filters.WithAuthenticationAndAuthorization
 	config.metricsServerOpts = *metricsServerOpts
 
 	config.concurrentReconcilesNutanixCluster = opts.maxConcurrentReconciles


### PR DESCRIPTION
* secures metrics endpoint
*removes kube-rbac-proxy

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #488

**How Has This Been Tested?**:

After running 'make deploy', the sidecar container was successfully removed. I tested the authentication by creating a pod for curl requests, executing into it, and accessing the metrics endpoint both with and without a bearer token to verify the authentication is functioning as expected.