### PR TITLE
fix(api): the mis-tagged controlPlaneFailureDomains field in NutanixCluster

### DIFF
--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -71,7 +71,8 @@ type NutanixClusterSpec struct {
 
 	// controlPlaneFailureDomains configures references to the NutanixFailureDomain objects
 	// that the cluster uses to deploy its control-plane machines.
-	// +listType=set
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	ControlPlaneFailureDomains []corev1.LocalObjectReference `json:"controlPlaneFailureDomains,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -95,7 +95,9 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               failureDomains:
                 description: |-
                   failureDomains configures failure domains information for the Nutanix platform.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
@@ -88,7 +88,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       failureDomains:
                         description: |-
                           failureDomains configures failure domains information for the Nutanix platform.


### PR DESCRIPTION
NCN-108153: fixing the mis-tagged controlPlaneFailureDomains field in NutanixCluster