### PR TITLE
fix(e2e): break capx-feature test into two

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -107,7 +107,9 @@ jobs:
           - "clusterctl-upgrade"
           - "clusterclass"
           - "capx-feature-test"
+          - "nutanix-feature-test"
           - "scaling"
+          - "kubernetes-upgrade"
       fail-fast: false
     needs: check_approvals
     uses: ./.github/workflows/e2e.yaml

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -36,7 +36,7 @@ const (
 	defaultNonExistingAdditionalCategoryValue = "nonExistingCategoryValueCAPX"
 )
 
-var _ = Describe("Nutanix categories", Label("capx-feature-test", "categories"), func() {
+var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories"), func() {
 	const (
 		specName = "cluster-categories"
 	)

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -55,7 +55,7 @@ var _ = Describe("When upgrading a workload cluster and testing K8S conformance"
 // 	})
 // })
 
-var _ = Describe("When upgrading a workload cluster with a single control plane machine", Label("cluster-upgrade-conformance"), func() {
+var _ = Describe("When upgrading a workload cluster with a single control plane machine", Label("kubernetes-upgrade"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -72,7 +72,7 @@ var _ = Describe("When upgrading a workload cluster with a single control plane 
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster with a HA control plane", Label("cluster-upgrade-conformance"), func() {
+var _ = Describe("When upgrading a workload cluster with a HA control plane", Label("kubernetes-upgrade"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -89,7 +89,7 @@ var _ = Describe("When upgrading a workload cluster with a HA control plane", La
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster with a HA control plane using scale-in rollout", Label("cluster-upgrade-conformance"), func() {
+var _ = Describe("When upgrading a workload cluster with a HA control plane using scale-in rollout", Label("kubernetes-upgrade"), func() {
 	capi_e2e.ClusterUpgradeConformanceSpec(ctx, func() capi_e2e.ClusterUpgradeConformanceSpecInput {
 		return capi_e2e.ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -25,7 +25,7 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("When mutating ClusterClass fields", Label("clusterclass", "capx-feature-test"), func() {
+var _ = Describe("When mutating ClusterClass fields", Label("clusterclass"), func() {
 	capi_e2e.ClusterClassChangesSpec(ctx, func() capi_e2e.ClusterClassChangesSpecInput {
 		return capi_e2e.ClusterClassChangesSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Nutanix flavor CSI", Label("capx-feature-test", "csi"), func() {
+var _ = Describe("Nutanix flavor CSI", Label("nutanix-feature-test", "csi"), func() {
 	const (
 		specName = "cluster-csi"
 

--- a/test/e2e/data_disks_test.go
+++ b/test/e2e/data_disks_test.go
@@ -31,7 +31,7 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
-var _ = Describe("Nutanix machine data disks", Label("capx-feature-test", "data-disks"), func() {
+var _ = Describe("Nutanix machine data disks", Label("nutanix-feature-test", "data-disks"), func() {
 	const specName = "cluster-data-disks"
 
 	var (

--- a/test/e2e/gpu_test.go
+++ b/test/e2e/gpu_test.go
@@ -35,7 +35,7 @@ const (
 	nutanixGPUVirtualNameEnv     = "NUTANIX_GPU_VIRTUAL_NAME"
 )
 
-var _ = Describe("Nutanix Passthrough GPU", Label("capx-feature-test", "only-for-validation", "passthrough", "gpu"), func() {
+var _ = Describe("Nutanix Passthrough GPU", Label("nutanix-feature-test", "only-for-validation", "passthrough", "gpu"), func() {
 	const specName = "cluster-gpu-passthrough"
 
 	var (
@@ -187,7 +187,7 @@ var _ = Describe("Nutanix Passthrough GPU", Label("capx-feature-test", "only-for
 	})
 })
 
-var _ = Describe("Nutanix Virtual GPU", Label("capx-feature-test", "only-for-validation", "virtual", "gpu"), func() {
+var _ = Describe("Nutanix Virtual GPU", Label("nutanix-feature-test", "only-for-validation", "virtual", "gpu"), func() {
 	const specName = "cluster-gpu-virtual"
 
 	var (

--- a/test/e2e/multi_nic_test.go
+++ b/test/e2e/multi_nic_test.go
@@ -35,7 +35,7 @@ const (
 	additionalSubnetVarKey = "NUTANIX_ADDITIONAL_SUBNET_NAME"
 )
 
-var _ = Describe("Nutanix Subnets", Label("capx-feature-test", "multi-nic"), func() {
+var _ = Describe("Nutanix Subnets", Label("nutanix-feature-test", "multi-nic"), func() {
 	const specName = "cluster-multi-nic"
 
 	var (

--- a/test/e2e/projects_test.go
+++ b/test/e2e/projects_test.go
@@ -31,7 +31,7 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 )
 
-var _ = Describe("Nutanix projects", Label("capx-feature-test", "projects"), func() {
+var _ = Describe("Nutanix projects", Label("nutanix-feature-test", "projects"), func() {
 	const (
 		specName               = "cluster-projects"
 		nonExistingProjectName = "nonExistingProjectNameCAPX"


### PR DESCRIPTION
capx-feature-test takes too long. it's now split between tests that solely exercise CAPX features and tests that solely exercise nutanix ahv features.