### PR TITLE
feat(api): Add clusterctl move label to NutanixFailureDomain  CRD

### DIFF
--- a/api/v1beta1/nutanixfailuredomain_types.go
+++ b/api/v1beta1/nutanixfailuredomain_types.go
@@ -56,6 +56,7 @@ type NutanixFailureDomainStatus struct {
 // +kubebuilder:resource:path=nutanixfailuredomains,shortName=nfd,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
 
 // NutanixFailureDomain is the Schema for the NutanixFailureDomain API.
 type NutanixFailureDomain struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixfailuredomains.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixfailuredomains.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
   name: nutanixfailuredomains.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/e2e/nutanix_failure_domain_move_test.go
+++ b/test/e2e/nutanix_failure_domain_move_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+
+/*
+Copyright 2025 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+var _ = Describe("NutanixFailureDomain clusterctl move", Label("capx-feature-test", "clusterctl-move", "failure-domain"), func() {
+	const specName = "nutanix-failure-domain-move"
+
+	var (
+		ctx               = context.TODO()
+		targetCluster     framework.ClusterProxy
+		targetProvider    bootstrap.ClusterProvider
+		sourceNamespace   *corev1.Namespace
+		targetNamespace   *corev1.Namespace
+		failureDomainName string
+		testHelper        testHelperInterface
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper(e2eConfig)
+		failureDomainName = fmt.Sprintf("test-fd-%s", testHelper.generateTestClusterName(specName))
+
+		By("Creating target kind cluster")
+		targetProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
+			Name:               "target-cluster",
+			KubernetesVersion:  e2eConfig.MustGetVariable(KubernetesVersionManagement),
+			RequiresDockerSock: e2eConfig.HasDockerProvider(),
+			Images:             e2eConfig.Images,
+			IPFamily:           e2eConfig.MustGetVariable(IPFamily),
+			LogFolder:          filepath.Join(artifactFolder, "kind", "target"),
+		})
+		Expect(targetProvider).ToNot(BeNil())
+
+		targetCluster = framework.NewClusterProxy("target", targetProvider.GetKubeconfigPath(), initScheme())
+		Expect(targetCluster).ToNot(BeNil())
+
+		By("Initializing target cluster with clusterctl")
+		clusterctl.InitManagementClusterAndWatchControllerLogs(ctx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+			ClusterProxy:            targetCluster,
+			ClusterctlConfigPath:    clusterctlConfigPath,
+			InfrastructureProviders: e2eConfig.InfrastructureProviders(),
+			LogFolder:               filepath.Join(artifactFolder, "clusters", "target"),
+		}, e2eConfig.GetIntervals("target", "wait-controllers")...)
+
+		By("Creating namespaces")
+		// Use default namespace for simplicity
+		sourceNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		targetNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if !skipCleanup {
+			By("Cleaning up target cluster")
+			if targetProvider != nil {
+				targetProvider.Dispose(ctx)
+			}
+		}
+	})
+
+	It("should successfully move NutanixFailureDomain between clusters", func() {
+		By("Creating a NutanixFailureDomain in source cluster (bootstrap)")
+		failureDomain := &infrav1.NutanixFailureDomain{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      failureDomainName,
+				Namespace: sourceNamespace.Name,
+			},
+			Spec: infrav1.NutanixFailureDomainSpec{
+				PrismElementCluster: infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierName,
+					Name: stringPtr("test-cluster"),
+				},
+				Subnets: []infrav1.NutanixResourceIdentifier{
+					{
+						Type: infrav1.NutanixIdentifierName,
+						Name: stringPtr("test-subnet"),
+					},
+				},
+			},
+		}
+
+		Expect(bootstrapClusterProxy.GetClient().Create(ctx, failureDomain)).To(Succeed())
+
+		By("Verifying NutanixFailureDomain exists in source cluster (bootstrap)")
+		Eventually(func() error {
+			fd := &infrav1.NutanixFailureDomain{}
+			return bootstrapClusterProxy.GetClient().Get(ctx,
+				client.ObjectKey{Name: failureDomainName, Namespace: sourceNamespace.Name}, fd)
+		}, "30s", "1s").Should(Succeed())
+
+		By("Verifying NutanixFailureDomain does not exist in target cluster")
+		fd := &infrav1.NutanixFailureDomain{}
+		err := targetCluster.GetClient().Get(ctx,
+			client.ObjectKey{Name: failureDomainName, Namespace: targetNamespace.Name}, fd)
+		Expect(err).To(HaveOccurred())
+
+		By("Moving NutanixFailureDomain from source (bootstrap) to target cluster")
+		clusterctl.Move(ctx, clusterctl.MoveInput{
+			LogFolder:            filepath.Join(artifactFolder, "clusters"),
+			ClusterctlConfigPath: clusterctlConfigPath,
+			FromKubeconfigPath:   bootstrapClusterProxy.GetKubeconfigPath(),
+			ToKubeconfigPath:     targetCluster.GetKubeconfigPath(),
+			Namespace:            sourceNamespace.Name,
+		})
+
+		By("Verifying NutanixFailureDomain no longer exists in source cluster (bootstrap)")
+		Eventually(func() bool {
+			fd := &infrav1.NutanixFailureDomain{}
+			err := bootstrapClusterProxy.GetClient().Get(ctx,
+				client.ObjectKey{Name: failureDomainName, Namespace: sourceNamespace.Name}, fd)
+			return err != nil
+		}, "30s", "1s").Should(BeTrue())
+
+		By("Verifying NutanixFailureDomain now exists in target cluster")
+		Eventually(func() error {
+			fd := &infrav1.NutanixFailureDomain{}
+			return targetCluster.GetClient().Get(ctx,
+				client.ObjectKey{Name: failureDomainName, Namespace: targetNamespace.Name}, fd)
+		}, "30s", "1s").Should(Succeed())
+
+		By("Verifying moved NutanixFailureDomain has correct spec")
+		fd = &infrav1.NutanixFailureDomain{}
+		Expect(targetCluster.GetClient().Get(ctx,
+			client.ObjectKey{Name: failureDomainName, Namespace: targetNamespace.Name}, fd)).To(Succeed())
+
+		Expect(fd.Spec.PrismElementCluster.Name).To(Equal(stringPtr("test-cluster")))
+		Expect(fd.Spec.Subnets).To(HaveLen(1))
+		Expect(fd.Spec.Subnets[0].Name).To(Equal(stringPtr("test-subnet")))
+
+		By("PASSED!")
+	})
+})
+
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
This will ensure clusterctl move always moves NutanixFailureDomain CRs.

**How has this been tested?**
```
$ make test-e2e LABEL_FILTERS='clusterctl-move && failure-domain'
echo "Git commit hash: 68bc2f47a93435d4ed9a520fde776168f632f27f"
Git commit hash: 68bc2f47a93435d4ed9a520fde776168f632f27f
DOCKER_HOST=unix:///Users/sid.shukla/.docker/run/docker.sock KO_DOCKER_REPO=ko.local GOFLAGS="-ldflags=-X=main.gitCommitHash=68bc2f47a93435d4ed9a520fde776168f632f27f" ko build -B --platform=linux/amd64 -t e2e-68bc2f47a93435d4ed9a520fde776168f632f27f .
2025/07/23 20:11:28 Using base cgr.dev/chainguard/static:latest@sha256:93b70336be10c325d5a96016971b71b38d8e79e5148af2144f2aae93ee9367c3 for github.com/nutanix-cloud-native/cluster-api-provider-nutanix

2025/07/23 20:11:29 Building github.com/nutanix-cloud-native/cluster-api-provider-nutanix for linux/amd64
2025/07/23 20:11:35 Loading ko.local/cluster-api-provider-nutanix:9b22a0ee788a1b0bda1cfa150fb36b478e767d10cf2e5da91c92c1e4f08d2184
2025/07/23 20:11:35 Loaded ko.local/cluster-api-provider-nutanix:9b22a0ee788a1b0bda1cfa150fb36b478e767d10cf2e5da91c92c1e4f08d2184
2025/07/23 20:11:35 Adding tag e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
2025/07/23 20:11:35 Added tag e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
ko.local/cluster-api-provider-nutanix:9b22a0ee788a1b0bda1cfa150fb36b478e767d10cf2e5da91c92c1e4f08d2184
docker tag ko.local/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-secret.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nutanix-cluster --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nutanix-cluster.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-no-nmt.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-project.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-upgrades.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-md-remediation.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-remediation.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-kcp-scale-in.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi3 --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-csi3.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-failure-domains --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-failure-domains.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-clusterclass --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-clusterclass.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-clusterclass --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/clusterclass-nutanix-quick-start.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-topology --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-topology.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-image-lookup --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-image-lookup.yaml
kustomize build /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1.6.1/cluster-template --load-restrictor LoadRestrictionsNone > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/infrastructure-nutanix/v1.6.1/cluster-template.yaml
kustomize build templates/base > templates/cluster-template.yaml
kustomize build templates/csi > templates/cluster-template-csi.yaml
kustomize build templates/csi3 > templates/cluster-template-csi3.yaml
kustomize build templates/clusterclass > templates/cluster-template-clusterclass.yaml
kustomize build templates/topology > templates/cluster-template-topology.yaml
kustomize build templates/image-lookup/ > templates/cluster-template-image-lookup.yaml
echo "Image tag for E2E test is e2e-68bc2f47a93435d4ed9a520fde776168f632f27f"
Image tag for E2E test is e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
LOCAL_PROVIDER_VERSION=v1.7.99 \
	MANAGER_IMAGE=harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f \
	envsubst < /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml > /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml.tmp
docker tag ko.local/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
docker push harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f
The push refers to repository [harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix]
6ba1746346e5: Layer already exists 
ffe56a1c5f38: Layer already exists 
a56394a846a2: Layer already exists 
e2e-68bc2f47a93435d4ed9a520fde776168f632f27f: digest: sha256:5aadd1fd305258db02f3c7c65ec6d82d26364be4e4dafc5e6ea354c6edc3ac47 size: 946
mkdir -p /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts
NUTANIX_LOG_LEVEL=debug ginkgo -v \
	--trace \
	--tags=e2e \
	--label-filter="!only-for-validation && clusterctl-move && failure-domain" \
	--skip="" \
	--focus="" \
	--nodes=1 \
	--no-color=false \
	--output-dir="/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" \
	--junit-report="junit.e2e_suite.1.xml" \
	--timeout="24h" \
	 \
	./test/e2e -- \
	-e2e.artifacts-folder="/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" \
	-e2e.config="/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml.tmp" \
	-e2e.skip-resource-cleanup=false \
	-e2e.use-existing-cluster=false
2025/07/23 20:11:42 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Running Suite: capx-e2e - /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e
========================================================================================================================
Random Seed: 1753294302

Will run 1 of 109 specs
------------------------------
[SynchronizedBeforeSuite] 
/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:63
  STEP: Initializing a runtime.Scheme with all the GVK relevant for this test @ 07/23/25 20:11:49.08
  STEP: Loading the e2e test configuration from "/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml.tmp" @ 07/23/25 20:11:49.08
  STEP: Creating a clusterctl local repository into "/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" @ 07/23/25 20:11:49.082
  STEP: Reading the ClusterResourceSet manifest ./data/cni/kindnet/kindnet.yaml @ 07/23/25 20:11:49.082
  STEP: Setting up the bootstrap cluster @ 07/23/25 20:11:50.654
  STEP: Creating the bootstrap cluster @ 07/23/25 20:11:50.654
  INFO: Creating a kind cluster with name "test-3xg9di"
Creating cluster "test-3xg9di" ...
 • Ensuring node image (kindest/node:v1.33.0) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.33.0) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
  INFO: The kubeconfig file for the kind cluster is /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind527078753
  INFO: Loading image: "harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f"
  INFO: Image harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/cluster-api-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/cluster-api-controller:v1.10.3 is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.3 is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.3 is present in local container image cache
  STEP: Initializing the bootstrap cluster @ 07/23/25 20:12:25.624
  INFO: clusterctl init --config /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts/repository/clusterctl-config.yaml --kubeconfig /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind527078753 --wait-providers --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure nutanix
  INFO: Waiting for provider controllers to be running
  STEP: Waiting for deployment capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager to be available @ 07/23/25 20:13:02.636
  INFO: Creating log watcher for controller capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager, pod capi-kubeadm-bootstrap-controller-manager-64986ff879-x2fng, container manager
  STEP: Waiting for deployment capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager to be available @ 07/23/25 20:13:02.752
  INFO: Creating log watcher for controller capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager, pod capi-kubeadm-control-plane-controller-manager-856f6c9446-5kw4n, container manager
  STEP: Waiting for deployment capi-system/capi-controller-manager to be available @ 07/23/25 20:13:02.761
  INFO: Creating log watcher for controller capi-system/capi-controller-manager, pod capi-controller-manager-5596875ccf-dj77w, container manager
  STEP: Waiting for deployment capx-system/capx-controller-manager to be available @ 07/23/25 20:13:02.768
  INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-864f4f84bc-5ghv8, container manager
[SynchronizedBeforeSuite] PASSED [73.971 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
NutanixFailureDomain clusterctl move should successfully move NutanixFailureDomain between clusters [capx-feature-test, clusterctl-move, failure-domain]
/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/nutanix_failure_domain_move_test.go:101
  STEP: Creating target kind cluster @ 07/23/25 20:13:03.052
  INFO: Creating a kind cluster with name "target-cluster"
Creating cluster "target-cluster" ...
 • Ensuring node image (kindest/node:v1.33.0) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.33.0) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
  INFO: The kubeconfig file for the kind cluster is /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind2726263073
  INFO: Loading image: "harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f"
  INFO: Image harbor.eng.nutanix.com/ncn-ci/cluster-api-provider-nutanix:e2e-68bc2f47a93435d4ed9a520fde776168f632f27f is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/cluster-api-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/cluster-api-controller:v1.10.3 is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.3 is present in local container image cache
  INFO: Loading image: "registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.3"
  INFO: Image registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.3 is present in local container image cache
  STEP: Initializing target cluster with clusterctl @ 07/23/25 20:13:30.204
  INFO: clusterctl init --config /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts/repository/clusterctl-config.yaml --kubeconfig /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind2726263073 --wait-providers --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure nutanix
  INFO: Waiting for provider controllers to be running
  STEP: Waiting for deployment capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager to be available @ 07/23/25 20:14:06.588
  INFO: Creating log watcher for controller capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager, pod capi-kubeadm-bootstrap-controller-manager-64986ff879-qcq27, container manager
  STEP: Waiting for deployment capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager to be available @ 07/23/25 20:14:06.708
  INFO: Creating log watcher for controller capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager, pod capi-kubeadm-control-plane-controller-manager-856f6c9446-bsnh8, container manager
  STEP: Waiting for deployment capi-system/capi-controller-manager to be available @ 07/23/25 20:14:06.713
  INFO: Creating log watcher for controller capi-system/capi-controller-manager, pod capi-controller-manager-5596875ccf-qg9dk, container manager
  STEP: Waiting for deployment capx-system/capx-controller-manager to be available @ 07/23/25 20:14:06.722
  INFO: Creating log watcher for controller capx-system/capx-controller-manager, pod capx-controller-manager-864f4f84bc-m5nbf, container manager
  STEP: Creating namespaces @ 07/23/25 20:14:07
  STEP: Creating a NutanixFailureDomain in source cluster (bootstrap) @ 07/23/25 20:14:07
  STEP: Verifying NutanixFailureDomain exists in source cluster (bootstrap) @ 07/23/25 20:14:07.018
  STEP: Verifying NutanixFailureDomain does not exist in target cluster @ 07/23/25 20:14:07.026
  STEP: Moving NutanixFailureDomain from source (bootstrap) to target cluster @ 07/23/25 20:14:07.034
  STEP: Moving workload clusters @ 07/23/25 20:14:07.035
  INFO: clusterctl move --from-kubeconfig /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind527078753 --to-kubeconfig /var/folders/g3/lb827bt96z10xz_m_c2xn93w0000gp/T/e2e-kind2726263073 --namespace default
  STEP: Verifying NutanixFailureDomain no longer exists in source cluster (bootstrap) @ 07/23/25 20:14:07.391
  STEP: Verifying NutanixFailureDomain now exists in target cluster @ 07/23/25 20:14:07.394
  STEP: Verifying moved NutanixFailureDomain has correct spec @ 07/23/25 20:14:07.398
  STEP: PASSED! @ 07/23/25 20:14:07.403
  STEP: Cleaning up target cluster @ 07/23/25 20:14:07.403
W0723 20:14:07.510296   92797 reflector.go:492] pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: watch of *v1.Pod ended with: very short watch: pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Unexpected watch close - watch lasted less than a second and no items received
• [65.357 seconds]
------------------------------
SSS
------------------------------
[SynchronizedAfterSuite] 
/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:118
  STEP: Dumping logs from the bootstrap cluster @ 07/23/25 20:14:08.409
W0723 20:14:08.430063   92797 reflector.go:569] pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: failed to list *v1.Pod: Get "https://127.0.0.1:50548/api/v1/pods?resourceVersion=1066": dial tcp 127.0.0.1:50548: connect: connection refused
E0723 20:14:08.430139   92797 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1.Pod: failed to list *v1.Pod: Get \"https://127.0.0.1:50548/api/v1/pods?resourceVersion=1066\": dial tcp 127.0.0.1:50548: connect: connection refused" logger="UnhandledError"
  STEP: Tearing down the management cluster @ 07/23/25 20:14:08.516
  INFO: Error getting pod capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager-64986ff879-qcq27, container manager: Get "https://127.0.0.1:50548/api/v1/namespaces/capi-kubeadm-bootstrap-system/pods/capi-kubeadm-bootstrap-controller-manager-64986ff879-qcq27": dial tcp 127.0.0.1:50548: connect: connection refused
  INFO: Error getting pod capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager-856f6c9446-bsnh8, container manager: Get "https://127.0.0.1:50548/api/v1/namespaces/capi-kubeadm-control-plane-system/pods/capi-kubeadm-control-plane-controller-manager-856f6c9446-bsnh8": dial tcp 127.0.0.1:50548: connect: connection refused
  INFO: Error getting pod capi-system/capi-controller-manager-5596875ccf-qg9dk, container manager: Get "https://127.0.0.1:50548/api/v1/namespaces/capi-system/pods/capi-controller-manager-5596875ccf-qg9dk": dial tcp 127.0.0.1:50548: connect: connection refused
  INFO: Error getting pod capx-system/capx-controller-manager-864f4f84bc-m5nbf, container manager: Get "https://127.0.0.1:50548/api/v1/namespaces/capx-system/pods/capx-controller-manager-864f4f84bc-m5nbf": dial tcp 127.0.0.1:50548: connect: connection refused
[SynchronizedAfterSuite] PASSED [1.029 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.008 seconds]
------------------------------

Ran 1 of 109 Specs in 140.357 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 108 Skipped
PASS

Ginkgo ran 1 suite in 2m26.484332125s
Test Suite Passed
```