### PR TITLE
fix(api): Ensure failureDomains and controlPlaneFailureDomains are mutually exclusive

### DIFF
--- a/api/v1beta1/nutanixcluster_types.go
+++ b/api/v1beta1/nutanixcluster_types.go
@@ -44,6 +44,7 @@ const (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // NutanixClusterSpec defines the desired state of NutanixCluster
+// +kubebuilder:validation:XValidation:rule="!(has(self.failureDomains) && has(self.controlPlaneFailureDomains))",message="Cannot set both 'failureDomains' and 'controlPlaneFailureDomains' fields simultaneously. Use 'controlPlaneFailureDomains' as 'failureDomains' is deprecated."
 type NutanixClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -257,6 +257,11 @@ spec:
                 - port
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: Cannot set both 'failureDomains' and 'controlPlaneFailureDomains'
+                fields simultaneously. Use 'controlPlaneFailureDomains' as 'failureDomains'
+                is deprecated.
+              rule: '!(has(self.failureDomains) && has(self.controlPlaneFailureDomains))'
           status:
             description: NutanixClusterStatus defines the observed state of NutanixCluster
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
@@ -257,6 +257,11 @@ spec:
                         - port
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: Cannot set both 'failureDomains' and 'controlPlaneFailureDomains'
+                        fields simultaneously. Use 'controlPlaneFailureDomains' as
+                        'failureDomains' is deprecated.
+                      rule: '!(has(self.failureDomains) && has(self.controlPlaneFailureDomains))'
                 required:
                 - spec
                 type: object


### PR DESCRIPTION
Ensure only one of failureDomains or controlPlaneFailureDomains can be set on NutanixCluster

**How has this been tested?**
- Create a cluster with legacy failure domains
- Add controlPlaneFailureDomains on top of legacy failure domains in NutanixCluster
- Observe the error `spec: Invalid value: "object": Cannot set both 'failureDomains' and 'controlPlaneFailureDomains' fields simultaneously. Use 'controlPlaneFailureDomains' as 'failureDomains' is deprecated.`
- Remove the old legacy failure domains and see migration was successful