### PR TITLE
NCN-108631: Adding rule to include either name or uuid in NutanixResourceIdentifier

### DIFF
--- a/api/v1beta1/nutanix_types.go
+++ b/api/v1beta1/nutanix_types.go
@@ -61,6 +61,7 @@ const (
 
 // NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)
 // +union
+// +kubebuilder:validation:XValidation:rule="(!has(self.name) && has(self.uuid)) || (has(self.name) && !has(self.uuid))", message="exactly one of 'name' or 'uuid' must be specified"
 type NutanixResourceIdentifier struct {
 	// Type is the identifier type to use for this resource.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclusters.yaml
@@ -132,6 +132,10 @@ spec:
                       required:
                       - type
                       type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of 'name' or 'uuid' must be specified
+                        rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                          && !has(self.uuid))
                     controlPlane:
                       description: indicates if a failure domain is suited for control
                         plane nodes
@@ -172,6 +176,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of 'name' or 'uuid' must be specified
+                          rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                            && !has(self.uuid))
                       minItems: 1
                       type: array
                   required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixclustertemplates.yaml
@@ -128,6 +128,10 @@ spec:
                               required:
                               - type
                               type: object
+                              x-kubernetes-validations:
+                              - message: exactly one of 'name' or 'uuid' must be specified
+                                rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                                  && !has(self.uuid))
                             controlPlane:
                               description: indicates if a failure domain is suited
                                 for control plane nodes
@@ -171,6 +175,11 @@ spec:
                                 required:
                                 - type
                                 type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of 'name' or 'uuid' must be
+                                    specified
+                                  rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                                    && !has(self.uuid))
                               minItems: 1
                               type: array
                           required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixfailuredomains.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixfailuredomains.yaml
@@ -68,6 +68,9 @@ spec:
                 x-kubernetes-validations:
                 - message: prismElementCluster is immutable once set
                   rule: self == oldSelf
+                - message: exactly one of 'name' or 'uuid' must be specified
+                  rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                    !has(self.uuid))
               subnets:
                 description: |-
                   subnets holds a list of identifiers (one or more) of the PE cluster's network subnets
@@ -91,6 +94,10 @@ spec:
                   required:
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of 'name' or 'uuid' must be specified
+                    rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                      !has(self.uuid))
                 minItems: 1
                 type: array
                 x-kubernetes-validations:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachines.yaml
@@ -148,6 +148,10 @@ spec:
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of 'name' or 'uuid' must be specified
+                  rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                    !has(self.uuid))
               dataDisks:
                 description: dataDisks hold the list of data disks to be attached
                   to the VM
@@ -175,6 +179,10 @@ spec:
                       required:
                       - type
                       type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of 'name' or 'uuid' must be specified
+                        rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                          && !has(self.uuid))
                     deviceProperties:
                       description: deviceProperties are the properties of the disk
                         device.
@@ -259,6 +267,10 @@ spec:
                           required:
                           - type
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of 'name' or 'uuid' must be specified
+                            rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                              && !has(self.uuid))
                       required:
                       - diskMode
                       type: object
@@ -308,6 +320,10 @@ spec:
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of 'name' or 'uuid' must be specified
+                  rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                    !has(self.uuid))
               imageLookup:
                 description: imageLookup is a container that holds how to look up
                   rhcos images for the cluster.
@@ -363,6 +379,10 @@ spec:
                 required:
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: exactly one of 'name' or 'uuid' must be specified
+                  rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                    !has(self.uuid))
               providerID:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
@@ -391,6 +411,10 @@ spec:
                   required:
                   - type
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of 'name' or 'uuid' must be specified
+                    rule: (!has(self.name) && has(self.uuid)) || (has(self.name) &&
+                      !has(self.uuid))
                 type: array
               systemDiskSize:
                 anyOf:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmachinetemplates.yaml
@@ -165,6 +165,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of 'name' or 'uuid' must be specified
+                          rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                            && !has(self.uuid))
                       dataDisks:
                         description: dataDisks hold the list of data disks to be attached
                           to the VM
@@ -193,6 +197,10 @@ spec:
                               required:
                               - type
                               type: object
+                              x-kubernetes-validations:
+                              - message: exactly one of 'name' or 'uuid' must be specified
+                                rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                                  && !has(self.uuid))
                             deviceProperties:
                               description: deviceProperties are the properties of
                                 the disk device.
@@ -278,6 +286,11 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: exactly one of 'name' or 'uuid' must
+                                      be specified
+                                    rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                                      && !has(self.uuid))
                               required:
                               - diskMode
                               type: object
@@ -330,6 +343,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of 'name' or 'uuid' must be specified
+                          rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                            && !has(self.uuid))
                       imageLookup:
                         description: imageLookup is a container that holds how to
                           look up rhcos images for the cluster.
@@ -387,6 +404,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of 'name' or 'uuid' must be specified
+                          rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                            && !has(self.uuid))
                       providerID:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
@@ -417,6 +438,10 @@ spec:
                           required:
                           - type
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of 'name' or 'uuid' must be specified
+                            rule: (!has(self.name) && has(self.uuid)) || (has(self.name)
+                              && !has(self.uuid))
                         type: array
                       systemDiskSize:
                         anyOf:


### PR DESCRIPTION
What this PR does / why we need it:
Preventing undocumented behaviour in customer environments when both name and uuid are specified on nutanix resource identifier

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #NCN-108631

How Has This Been Tested?:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output

Special notes for your reviewer:

Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Release note: