### PR TITLE
fix(lint): ensure PRs follow conventional commits 

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: "conventional-pr-title"
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     types:


### PR DESCRIPTION
Add a Github workflow that lints PR Titles to ensure 
they follow  https://www.conventionalcommits.org/en/v1.0.0/
We don't need to lint each commit as we require squash and merge
for PRs where the title of the commit is the title of the PR.