### PR TITLE
ci: Fix the triggering logic for e2e

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -7,11 +7,12 @@ on:
       - main
       - 'release-*'
   pull_request:
-    paths:
-    - '.github/**'
+    types: [opened, synchronize, reopened, labeled]
   pull_request_target:
-    paths-ignore:
-    - '.github/**'
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - main
+      - 'release-*'
 jobs:
   check_approvals:
     runs-on: ubuntu-latest
@@ -108,8 +109,7 @@ jobs:
           - "capx-feature-test"
           - "scaling"
       fail-fast: false
-    if: ${{ (github.event_name == 'pull_request' && needs.check_approvals.outputs.external_pr == 'false') || (github.event_name == 'pull_request_target' && needs.check_approvals.outputs.external_pr == 'true' && needs.check_approvals.outputs.check_approvals == 'true') }}
-    needs: check_approvals  
+    needs: check_approvals
     uses: ./.github/workflows/e2e.yaml
     with:
       e2e-labels: ${{ matrix.e2e-labels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```