### PR TITLE
fix: Support multiple values by category (#575)

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -783,11 +784,19 @@ func getOrCreateCategory(ctx context.Context, client *prismclientv3.Client, cate
 	return categoryValue, nil
 }
 
-// GetCategoryVMSpec returns a flatmap of categories and their values
-func GetCategoryVMSpec(ctx context.Context, client *prismclientv3.Client, categoryIdentifiers []*infrav1.NutanixCategoryIdentifier) (map[string]string, error) {
+// GetCategoryVMSpec returns the categories_mapping supporting multiple values per key.
+func GetCategoryVMSpec(
+	ctx context.Context,
+	client *prismclientv3.Client,
+	categoryIdentifiers []*infrav1.NutanixCategoryIdentifier,
+) (map[string][]string, error) {
 	log := ctrl.LoggerFrom(ctx)
-	categorySpec := map[string]string{}
+	categorySpec := map[string][]string{}
+
 	for _, ci := range categoryIdentifiers {
+		if ci == nil {
+			return nil, fmt.Errorf("category identifier cannot be nil")
+		}
 		categoryValue, err := getCategoryValue(ctx, client, ci.Key, ci.Value)
 		if err != nil {
 			errorMsg := fmt.Errorf("error occurred while to retrieving category value %s in category %s. error: %v", ci.Value, ci.Key, err)
@@ -799,8 +808,11 @@ func GetCategoryVMSpec(ctx context.Context, client *prismclientv3.Client, catego
 			log.Error(errorMsg, "category value not found")
 			return nil, errorMsg
 		}
-		categorySpec[ci.Key] = ci.Value
+		if !slices.Contains(categorySpec[ci.Key], ci.Value) {
+			categorySpec[ci.Key] = append(categorySpec[ci.Key], ci.Value)
+		}
 	}
+
 	return categorySpec, nil
 }
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -894,6 +894,33 @@ func TestListStorageContainers(t *testing.T) {
 	}
 }
 
+func TestGetCategoryVMSpecMapping_MultiValues(t *testing.T) {
+	t.Run("returns flat map first value and mapping with all values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mockv3 := mocknutanixv3.NewMockService(ctrl)
+		client := &prismclientv3.Client{V3: mockv3}
+
+		key := "CategoryKey"
+		v1 := "CategoryValue1"
+		v2 := "CategoryValue2"
+
+		ids := []*infrav1.NutanixCategoryIdentifier{{Key: key, Value: v1}, {Key: key, Value: v2}, {Key: key, Value: v1}}
+
+		// Expect lookups for both values to succeed
+		mockv3.EXPECT().GetCategoryValue(ctx, key, v1).Return(&prismclientv3.CategoryValueStatus{Value: &v1}, nil)
+		mockv3.EXPECT().GetCategoryValue(ctx, key, v2).Return(&prismclientv3.CategoryValueStatus{Value: &v2}, nil)
+		mockv3.EXPECT().GetCategoryValue(ctx, key, v1).Return(&prismclientv3.CategoryValueStatus{Value: &v1}, nil)
+
+		mapping, err := GetCategoryVMSpec(ctx, client, ids)
+		require.NoError(t, err)
+		assert.Len(t, mapping[key], 2)
+		assert.ElementsMatch(t, []string{v1, v2}, mapping[key])
+	})
+}
+
 func TestGetStorageContainerByNtnxResourceIdentifier(t *testing.T) {
 	mockctl := gomock.NewController(t)
 

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -827,8 +827,8 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*pr
 		}
 	}
 
-	// Set Categories to VM Sepc before creating VM
-	categories, err := GetCategoryVMSpec(ctx, v3Client, r.getMachineCategoryIdentifiers(rctx))
+	// Set categories on VM; support multiple values via categories_mapping when possible
+	categoriesMapping, err := GetCategoryVMSpec(ctx, v3Client, r.getMachineCategoryIdentifiers(rctx))
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while creating category spec for vm %s: %v", vmName, err)
 		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
@@ -836,9 +836,10 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*pr
 	}
 
 	vmMetadata := &prismclientv3.Metadata{
-		Kind:        utils.StringPtr("vm"),
-		SpecVersion: utils.Int64Ptr(1),
-		Categories:  categories,
+		Kind:                 utils.StringPtr("vm"),
+		SpecVersion:          utils.Int64Ptr(1),
+		UseCategoriesMapping: ptr.To(true),
+		CategoriesMapping:    categoriesMapping,
 	}
 	// Set Project in VM Spec before creating VM
 	err = r.addVMToProject(rctx, vmMetadata)

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -1119,3 +1119,32 @@ func TestNutanixClusterReconcilerGetDiskList(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcile_VMMetadataCategoriesMapping_MultipleValues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockV3 := mocknutanixv3.NewMockService(ctrl)
+	client := &prismclientv3.Client{V3: mockV3}
+
+	// Prepare inputs
+	clusterName := "TestCluster"
+
+	// Default category key/value lookups used by GetCategoryVMSpecMapping
+	defaultKey := infrav1.DefaultCAPICategoryKeyForName
+	mockV3.EXPECT().GetCategoryValue(ctx, defaultKey, clusterName).Return(&prismclientv3.CategoryValueStatus{Value: &clusterName}, nil)
+	mockV3.EXPECT().GetCategoryValue(ctx, "TestCategory", "TestValue1").Return(&prismclientv3.CategoryValueStatus{Value: ptr.To("TestValue1")}, nil)
+	mockV3.EXPECT().GetCategoryValue(ctx, "TestCategory", "TestValue2").Return(&prismclientv3.CategoryValueStatus{Value: ptr.To("TestValue2")}, nil)
+	mockV3.EXPECT().GetCategoryValue(ctx, "TestCategory", "TestValue1").Return(&prismclientv3.CategoryValueStatus{Value: ptr.To("TestValue1")}, nil)
+
+	ids := []*infrav1.NutanixCategoryIdentifier{
+		{Key: defaultKey, Value: clusterName},
+		{Key: "TestCategory", Value: "TestValue1"},
+		{Key: "TestCategory", Value: "TestValue2"},
+		{Key: "TestCategory", Value: "TestValue1"},
+	}
+	mapping, err := GetCategoryVMSpec(ctx, client, ids)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"TestValue1", "TestValue2"}, mapping["TestCategory"])
+}

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -94,8 +94,8 @@ var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories
 		})
 
 		By("Checking if there are VMs assigned to this category", func() {
-			expectedCategories := map[string]string{
-				expectedClusterNameCategoryKey: clusterName,
+			expectedCategories := map[string][]string{
+				expectedClusterNameCategoryKey: {clusterName},
 			}
 			testHelper.verifyCategoriesNutanixMachines(ctx, clusterName, namespace.Name, expectedCategories)
 		})
@@ -121,10 +121,10 @@ var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories
 
 		By("Verify if additional categories are assigned to the vms", func() {
 			expectedClusterNameCategoryKey := infrav1.DefaultCAPICategoryKeyForName
-			expectedCategories := map[string]string{
-				expectedClusterNameCategoryKey: clusterName,
-				"AppType":                      "Kubernetes",
-				"Environment":                  "Dev",
+			expectedCategories := map[string][]string{
+				expectedClusterNameCategoryKey: {clusterName},
+				"AppType":                      {"Kubernetes"},
+				"Environment":                  {"Dev", "Testing"},
 			}
 
 			testHelper.verifyCategoriesNutanixMachines(ctx, clusterName, namespace.Name, expectedCategories)
@@ -209,8 +209,8 @@ var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories
 		})
 
 		By("Checking if there are VMs assigned to this category", func() {
-			expectedCategories := map[string]string{
-				expectedClusterNameCategoryKey: clusterName,
+			expectedCategories := map[string][]string{
+				expectedClusterNameCategoryKey: {clusterName},
 			}
 			testHelper.verifyCategoriesNutanixMachines(ctx, clusterName, namespace.Name, expectedCategories)
 		})
@@ -266,8 +266,8 @@ var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories
 		})
 
 		By("Checking if there are VMs assigned to this category", func() {
-			expectedCategories := map[string]string{
-				expectedClusterNameCategoryKey: clusterName,
+			expectedCategories := map[string][]string{
+				expectedClusterNameCategoryKey: {clusterName},
 			}
 			testHelper.verifyCategoriesNutanixMachines(ctx, clusterName, namespace2.Name, expectedCategories)
 		})

--- a/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/nmt.yaml
+++ b/test/e2e/data/infrastructure-nutanix/v1beta1/cluster-template-additional-categories/nmt.yaml
@@ -14,3 +14,6 @@ spec:
         # Use System category Environment:Dev
         - key: Environment
           value: Dev
+        # Use System category Environment:Testing
+        - key: Environment
+          value: Testing

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -150,7 +150,7 @@ type testHelperInterface interface {
 	updateVariableInE2eConfig(variableKey string, variableValue string)
 	stripNutanixIDFromProviderID(providerID string) string
 	verifyCategoryExists(ctx context.Context, categoryKey, categoyValue string)
-	verifyCategoriesNutanixMachines(ctx context.Context, clusterName, namespace string, expectedCategories map[string]string)
+	verifyCategoriesNutanixMachines(ctx context.Context, clusterName, namespace string, expectedCategories map[string][]string)
 	verifyConditionOnNutanixCluster(params verifyConditionParams)
 	verifyConditionOnNutanixMachines(params verifyConditionParams)
 	verifyDisksOnNutanixMachines(ctx context.Context, params verifyDisksOnNutanixMachinesParams)
@@ -641,19 +641,30 @@ func (t testHelper) verifyCategoryExists(ctx context.Context, categoryKey, categ
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func (t testHelper) verifyCategoriesNutanixMachines(ctx context.Context, clusterName, namespace string, expectedCategories map[string]string) {
-	nutanixMachines := t.getMachinesForCluster(ctx, clusterName, namespace, bootstrapClusterProxy)
-	for _, m := range nutanixMachines.Items {
-		machineProviderID := m.Spec.ProviderID
-		Expect(machineProviderID).NotTo(BeNil())
-		machineVmUUID := t.stripNutanixIDFromProviderID(*machineProviderID)
-		vm, err := t.nutanixClient.V3.GetVM(ctx, machineVmUUID)
-		Expect(err).ShouldNot(HaveOccurred())
-		categoriesMeta := vm.Metadata.Categories
-		for k, v := range expectedCategories {
-			Expect(categoriesMeta).To(HaveKeyWithValue(k, v))
-		}
-	}
+func (t testHelper) verifyCategoriesNutanixMachines(ctx context.Context, clusterName, namespace string, expectedCategories map[string][]string) {
+	Eventually(
+		func(g Gomega) {
+			nutanixMachines := t.getMachinesForCluster(ctx, clusterName, namespace, bootstrapClusterProxy)
+			for _, m := range nutanixMachines.Items {
+				machineProviderID := m.Spec.ProviderID
+				g.Expect(machineProviderID).NotTo(BeNil())
+				machineVmUUID := t.stripNutanixIDFromProviderID(*machineProviderID)
+				vm, err := t.nutanixClient.V3.GetVM(ctx, machineVmUUID)
+				g.Expect(err).ShouldNot(HaveOccurred())
+				categoriesMappingMeta := vm.Metadata.CategoriesMapping
+				for k, v := range expectedCategories {
+					g.Expect(categoriesMappingMeta).To(HaveKey(k))
+					vals := make([]any, len(v))
+					for i := range v {
+						vals[i] = v[i]
+					}
+					g.Expect(categoriesMappingMeta[k]).To(ConsistOf(vals...))
+				}
+			}
+		},
+		defaultTimeout,
+		defaultInterval,
+	).Should(Succeed())
 }
 
 type verifyResourceConfigOnNutanixMachinesParams struct {


### PR DESCRIPTION
fix: Support multiple values by category

- Support multiple value for same category key
- Uses CategoryMapping for extending support for multiple value from same categoryKey.