### PR TITLE
refactor: removing prism-go-client/utils

### DIFF
--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/nutanix-cloud-native/prism-go-client/utils"
 	prismclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -815,14 +814,14 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*pr
 	}
 
 	vmInput := &prismclientv3.VMIntentInput{}
-	vmSpec := &prismclientv3.VM{Name: utils.StringPtr(vmName)}
+	vmSpec := &prismclientv3.VM{Name: ptr.To(vmName)}
 
 	nicList := make([]*prismclientv3.VMNic, len(subnetUUIDs))
 	for idx, subnetUUID := range subnetUUIDs {
 		nicList[idx] = &prismclientv3.VMNic{
 			SubnetReference: &prismclientv3.Reference{
-				UUID: utils.StringPtr(subnetUUID),
-				Kind: utils.StringPtr("subnet"),
+				UUID: ptr.To(subnetUUID),
+				Kind: ptr.To("subnet"),
 			},
 		}
 	}
@@ -836,8 +835,8 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*pr
 	}
 
 	vmMetadata := &prismclientv3.Metadata{
-		Kind:                 utils.StringPtr("vm"),
-		SpecVersion:          utils.Int64Ptr(1),
+		Kind:                 ptr.To("vm"),
+		SpecVersion:          ptr.To(int64(1)),
 		UseCategoriesMapping: ptr.To(true),
 		CategoriesMapping:    categoriesMapping,
 	}
@@ -866,18 +865,18 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*pr
 
 	memorySizeMib := GetMibValueOfQuantity(rctx.NutanixMachine.Spec.MemorySize)
 	vmSpec.Resources = &prismclientv3.VMResources{
-		PowerState:            utils.StringPtr("ON"),
-		HardwareClockTimezone: utils.StringPtr("UTC"),
-		NumVcpusPerSocket:     utils.Int64Ptr(int64(rctx.NutanixMachine.Spec.VCPUsPerSocket)),
-		NumSockets:            utils.Int64Ptr(int64(rctx.NutanixMachine.Spec.VCPUSockets)),
-		MemorySizeMib:         utils.Int64Ptr(memorySizeMib),
+		PowerState:            ptr.To("ON"),
+		HardwareClockTimezone: ptr.To("UTC"),
+		NumVcpusPerSocket:     ptr.To(int64(rctx.NutanixMachine.Spec.VCPUsPerSocket)),
+		NumSockets:            ptr.To(int64(rctx.NutanixMachine.Spec.VCPUSockets)),
+		MemorySizeMib:         ptr.To(memorySizeMib),
 		NicList:               nicList,
 		DiskList:              diskList,
 		GpuList:               gpuList,
 	}
 	vmSpec.ClusterReference = &prismclientv3.Reference{
-		Kind: utils.StringPtr("cluster"),
-		UUID: utils.StringPtr(peUUID),
+		Kind: ptr.To("cluster"),
+		UUID: ptr.To(peUUID),
 	}
 
 	if err := r.addGuestCustomizationToVM(rctx, vmSpec); err != nil {
@@ -964,10 +963,10 @@ func (r *NutanixMachineReconciler) addGuestCustomizationToVM(rctx *nctx.MachineC
 		metadataEncoded := base64.StdEncoding.EncodeToString([]byte(metadata))
 
 		vmSpec.Resources.GuestCustomization = &prismclientv3.GuestCustomization{
-			IsOverridable: utils.BoolPtr(true),
+			IsOverridable: ptr.To(true),
 			CloudInit: &prismclientv3.GuestCustomizationCloudInit{
-				UserData: utils.StringPtr(bsdataEncoded),
-				MetaData: utils.StringPtr(metadataEncoded),
+				UserData: ptr.To(bsdataEncoded),
+				MetaData: ptr.To(metadataEncoded),
 			},
 		}
 	}
@@ -1198,7 +1197,7 @@ func (r *NutanixMachineReconciler) addBootTypeToVM(rctx *nctx.MachineContext, vm
 		// Only modify VM spec if boot type is UEFI. Otherwise, assume default Legacy mode
 		if bootType == infrav1.NutanixBootTypeUEFI {
 			vmSpec.Resources.BootConfig = &prismclientv3.VMBootConfig{
-				BootType: utils.StringPtr(strings.ToUpper(string(bootType))),
+				BootType: ptr.To(strings.ToUpper(string(bootType))),
 			}
 		}
 	}
@@ -1231,8 +1230,8 @@ func (r *NutanixMachineReconciler) addVMToProject(rctx *nctx.MachineContext, vmM
 	}
 
 	vmMetadata.ProjectReference = &prismclientv3.Reference{
-		Kind: utils.StringPtr(projectKind),
-		UUID: utils.StringPtr(projectUUID),
+		Kind: ptr.To(projectKind),
+		UUID: ptr.To(projectUUID),
 	}
 	conditions.MarkTrue(rctx.NutanixMachine, infrav1.ProjectAssignedCondition)
 	return nil

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nutanix-cloud-native/prism-go-client/utils"
 	nutanixClientV3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -53,7 +53,7 @@ func GetTaskStatus(ctx context.Context, client *nutanixClientV3.Client, uuid str
 
 	if *v.Status == "INVALID_UUID" || *v.Status == "FAILED" {
 		return *v.Status,
-			fmt.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(v.ErrorDetail), utils.StringValue(v.ProgressMessage))
+			fmt.Errorf("error_detail: %s, progress_message: %s", ptr.Deref(v.ErrorDetail, ""), ptr.Deref(v.ProgressMessage, ""))
 	}
 	taskStatus := *v.Status
 	log.V(1).Info(fmt.Sprintf("Status for task with UUID %s: %s", uuid, taskStatus))

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/nutanix-cloud-native/prism-go-client/utils"
 	prismclientv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+	"k8s.io/utils/ptr"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,14 +93,14 @@ func (clctx *ClusterContext) GetNutanixMachinesInCluster(client ctlclient.Client
 func (clctx *ClusterContext) SetFailureStatus(failureReason string, failureMessage error) {
 	log := ctrl.LoggerFrom(clctx.Context)
 	log.Error(failureMessage, fmt.Sprintf("cluster failed: %s", failureReason))
-	clctx.NutanixCluster.Status.FailureMessage = utils.StringPtr(fmt.Sprintf("%v", failureMessage))
+	clctx.NutanixCluster.Status.FailureMessage = ptr.To(fmt.Sprintf("%v", failureMessage))
 	clctx.NutanixCluster.Status.FailureReason = &failureReason
 }
 
 func (clctx *MachineContext) SetFailureStatus(failureReason string, failureMessage error) {
 	log := ctrl.LoggerFrom(clctx.Context)
 	log.Error(failureMessage, fmt.Sprintf("machine failed: %s", failureReason))
-	clctx.NutanixMachine.Status.FailureMessage = utils.StringPtr(fmt.Sprintf("%v", failureMessage))
+	clctx.NutanixMachine.Status.FailureMessage = ptr.To(fmt.Sprintf("%v", failureMessage))
 	clctx.NutanixMachine.Status.FailureReason = &failureReason
 }
 


### PR DESCRIPTION
Using "k8s.io/utils/ptr" instead of prism-go-client/utils