### PR TITLE
fix(controller): make API errors retryable instead of terminal in NutanixMachine reconciler

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -95,6 +95,14 @@ func isRetryableAPIError(err error) bool {
 	case converged.IsRateLimit(err), converged.IsInternal(err):
 		return true
 	default:
+		// Converged API errors with Kind == nil are parsed HTTP responses that
+		// are not expected to succeed on retry (for example, 4xx validation errors).
+		// Non-API errors (for example, transport/network timeouts) remain
+		// retryable.
+		var apiErr *converged.APIError
+		if errors.As(err, &apiErr) {
+			return false
+		}
 		return true
 	}
 }

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -127,14 +127,14 @@ func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMach
 	if machine != nil && machine.Status.NodeInfo != nil && machine.Status.NodeInfo.SystemUUID != "" {
 		systemUUID := machine.Status.NodeInfo.SystemUUID
 		if _, err := uuid.Parse(systemUUID); err != nil {
-			return "", fmt.Errorf("Machine.Status.NodeInfo.SystemUUID was set but was not a valid UUID: %s err: %v", systemUUID, err)
+			return "", fmt.Errorf("Machine.Status.NodeInfo.SystemUUID was set but was not a valid UUID: %s err: %w", systemUUID, err)
 		}
 		return systemUUID, nil
 	}
 	vmUUID := nutanixMachine.Status.VmUUID
 	if vmUUID != "" {
 		if _, err := uuid.Parse(vmUUID); err != nil {
-			return "", fmt.Errorf("VMUUID was set but was not a valid UUID: %s err: %v", vmUUID, err)
+			return "", fmt.Errorf("VMUUID was set but was not a valid UUID: %s err: %w", vmUUID, err)
 		}
 		return vmUUID, nil
 	}
@@ -214,7 +214,7 @@ func GetPEUUID(ctx context.Context, client *v4Converged.Client, peName, peUUID *
 			if converged.IsNotFound(err) {
 				return "", fmt.Errorf("failed to find Prism Element cluster with UUID %s: %w", *peUUID, err)
 			}
-			return "", fmt.Errorf("failed to get Prism Element cluster with UUID %s: %v", *peUUID, err)
+			return "", fmt.Errorf("failed to get Prism Element cluster with UUID %s: %w", *peUUID, err)
 		}
 		return *peIntentResponse.ExtId, nil
 	} else if peName != nil && *peName != "" {
@@ -470,7 +470,7 @@ func GetSubnetUUID(ctx context.Context, client *v4Converged.Client, peUUID strin
 			if converged.IsNotFound(err) {
 				return "", fmt.Errorf("failed to find subnet with UUID %s: %w", *subnetUUID, err)
 			}
-			return "", fmt.Errorf("failed to get subnet with UUID %s: %v", *subnetUUID, err)
+			return "", fmt.Errorf("failed to get subnet with UUID %s: %w", *subnetUUID, err)
 		}
 		foundSubnetUUID = *subnetIntentResponse.ExtId
 	} else { // else search by name
@@ -522,7 +522,7 @@ func GetImage(ctx context.Context, client *v4Converged.Client, id infrav1.Nutani
 			if converged.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to find image with UUID %s: %w", *id.UUID, err)
 			}
-			return nil, fmt.Errorf("failed to get image with UUID %s: %v", *id.UUID, err)
+			return nil, fmt.Errorf("failed to get image with UUID %s: %w", *id.UUID, err)
 		}
 		return resp, nil
 	case id.IsName():
@@ -567,7 +567,7 @@ func GetImageByLookup(
 	params := ImageLookup{*imageLookupBaseOS, *k8sVersion}
 	t, err := template.New("k8sTemplate").Parse(*imageTemplate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse template given %s %v", *imageTemplate, err)
+		return nil, fmt.Errorf("failed to parse template given %s: %w", *imageTemplate, err)
 	}
 	var templateBytes bytes.Buffer
 	err = t.Execute(&templateBytes, params)
@@ -719,7 +719,7 @@ func GetOrCreateCategories(ctx context.Context, client *v4Converged.Client, cate
 func getCategory(ctx context.Context, client *v4Converged.Client, key, value string) (*prismModels.Category, error) {
 	categories, err := client.Categories.List(ctx, converged.WithFilter(fmt.Sprintf("key eq '%s' and value eq '%s'", key, value)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve category value %s in category %s. error: %v", value, key, err)
+		return nil, fmt.Errorf("failed to retrieve category value %s in category %s. error: %w", value, key, err)
 	}
 	if len(categories) == 0 {
 		return nil, nil
@@ -745,7 +745,7 @@ func deleteCategoryKeyValues(ctx context.Context, client *v4Converged.Client, ca
 		for _, value := range values {
 			prismCategory, err := getCategory(ctx, client, key, value)
 			if err != nil {
-				errorMsg := fmt.Errorf("failed to retrieve category value %s in category %s. error: %v", value, key, err)
+				errorMsg := fmt.Errorf("failed to retrieve category value %s in category %s. error: %w", value, key, err)
 				log.Error(errorMsg, "failed to retrieve category value")
 				return errorMsg
 			}
@@ -756,7 +756,7 @@ func deleteCategoryKeyValues(ctx context.Context, client *v4Converged.Client, ca
 
 			err = client.Categories.Delete(ctx, *prismCategory.ExtId)
 			if err != nil {
-				errorMsg := fmt.Errorf("failed to delete category value with key:value %s:%s. error: %v", key, value, err)
+				errorMsg := fmt.Errorf("failed to delete category value with key:value %s:%s. error: %w", key, value, err)
 				log.Error(errorMsg, "failed to delete category value")
 				// NCN-101935: If the category value still has VMs assigned, do not delete the category key:value
 				// TODO:deepakmntnx Add a check for specific error mentioned in NCN-101935
@@ -797,7 +797,7 @@ func getOrCreateCategory(ctx context.Context, client *v4Converged.Client, catego
 	log.V(1).Info(fmt.Sprintf("Checking existence of category with key %s and value %s", categoryIdentifier.Key, categoryIdentifier.Value))
 	prismCategory, err := getCategory(ctx, client, categoryIdentifier.Key, categoryIdentifier.Value)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to retrieve category with key %s. error: %v", categoryIdentifier.Key, err)
+		errorMsg := fmt.Errorf("failed to retrieve category with key %s. error: %w", categoryIdentifier.Key, err)
 		log.Error(errorMsg, "failed to retrieve category")
 		return nil, errorMsg
 	}
@@ -809,7 +809,7 @@ func getOrCreateCategory(ctx context.Context, client *v4Converged.Client, catego
 			Value:       ptr.To(categoryIdentifier.Value),
 		})
 		if err != nil {
-			errorMsg := fmt.Errorf("failed to create category with key %s and value %s. error: %v", categoryIdentifier.Key, categoryIdentifier.Value, err)
+			errorMsg := fmt.Errorf("failed to create category with key %s and value %s. error: %w", categoryIdentifier.Key, categoryIdentifier.Value, err)
 			log.Error(errorMsg, "failed to create category")
 			return nil, errorMsg
 		}
@@ -831,7 +831,7 @@ func GetPrismReferencesOfCategoryIdentifiers(
 		}
 		prismCategory, err := getCategory(ctx, client, ci.Key, ci.Value)
 		if err != nil {
-			errorMsg := fmt.Errorf("error occurred while to retrieving category value %s in category %s. error: %v", ci.Value, ci.Key, err)
+			errorMsg := fmt.Errorf("error occurred while to retrieving category value %s in category %s. error: %w", ci.Value, ci.Key, err)
 			log.Error(errorMsg, "failed to retrieve category")
 			return nil, errorMsg
 		}
@@ -866,9 +866,9 @@ func GetProjectUUID(ctx context.Context, client *prismclientv3.Client, projectNa
 		projectIntentResponse, err := client.V3.GetProject(ctx, *projectUUID)
 		if err != nil {
 			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
-				return "", fmt.Errorf("failed to find project with UUID %s: %v", *projectUUID, err)
+				return "", fmt.Errorf("failed to find project with UUID %s: %w", *projectUUID, err)
 			}
-			return "", fmt.Errorf("failed to get project with UUID %s: %v", *projectUUID, err)
+			return "", fmt.Errorf("failed to get project with UUID %s: %w", *projectUUID, err)
 		}
 		foundProjectUUID = *projectIntentResponse.Metadata.UUID
 	} else { // else search by name

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -73,6 +73,18 @@ type StorageContainerIntentResponse struct {
 	ClusterUUID *string
 }
 
+func isRetryableAPIError(err error) bool {
+	switch {
+	case converged.IsNotFound(err):
+		return false
+	case converged.IsRateLimit(err), converged.IsInternal(err):
+		return true
+	default:
+		// Keep unknown API errors retryable to avoid terminalizing transient outages.
+		return true
+	}
+}
+
 // DeleteVM deletes a VM and is invoked by the NutanixMachineReconciler
 func DeleteVM(ctx context.Context, client *v4Converged.Client, vmName, vmUUID string) (string, error) {
 	log := ctrl.LoggerFrom(ctx)

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -73,14 +74,27 @@ type StorageContainerIntentResponse struct {
 	ClusterUUID *string
 }
 
+// terminalError represents a deterministic, non-retryable error caused by
+// invalid user configuration (e.g. referenced resource does not exist).
+// It is distinct from converged.APIError which represents HTTP-level failures.
+type terminalError struct {
+	message string
+}
+
+func (e *terminalError) Error() string { return e.message }
+
+func isTerminalError(err error) bool {
+	var te *terminalError
+	return errors.As(err, &te)
+}
+
 func isRetryableAPIError(err error) bool {
 	switch {
-	case converged.IsNotFound(err):
+	case converged.IsNotFound(err), isTerminalError(err):
 		return false
 	case converged.IsRateLimit(err), converged.IsInternal(err):
 		return true
 	default:
-		// Keep unknown API errors retryable to avoid terminalizing transient outages.
 		return true
 	}
 }
@@ -245,7 +259,7 @@ func GetPEUUID(ctx context.Context, client *v4Converged.Client, peName, peUUID *
 			return *foundPEs[0].ExtId, nil
 		}
 		if len(foundPEs) == 0 {
-			return "", fmt.Errorf("failed to retrieve Prism Element cluster by name %s", *peName)
+			return "", &terminalError{message: fmt.Sprintf("failed to retrieve Prism Element cluster by name %s", *peName)}
 		} else {
 			return "", fmt.Errorf("more than one Prism Element cluster found with name %s", *peName)
 		}
@@ -511,7 +525,7 @@ func GetSubnetUUID(ctx context.Context, client *v4Converged.Client, peUUID strin
 		}
 
 		if len(foundSubnets) == 0 {
-			return "", fmt.Errorf("failed to retrieve subnet by name %s", *subnetName)
+			return "", &terminalError{message: fmt.Sprintf("failed to retrieve subnet by name %s", *subnetName)}
 		} else if len(foundSubnets) > 1 {
 			return "", fmt.Errorf("more than one subnet found with name %s", *subnetName)
 		} else {
@@ -550,7 +564,7 @@ func GetImage(ctx context.Context, client *v4Converged.Client, id infrav1.Nutani
 			}
 		}
 		if len(foundImages) == 0 {
-			return nil, fmt.Errorf("found no image with name %s", *id.Name)
+			return nil, &terminalError{message: fmt.Sprintf("found no image with name %s", *id.Name)}
 		} else if len(foundImages) > 1 {
 			return nil, fmt.Errorf("more than one image found with name %s", *id.Name)
 		} else {
@@ -604,7 +618,7 @@ func GetImageByLookup(
 	}
 	sorted := sortImagesByLatestCreationTime(foundImages)
 	if len(sorted) == 0 {
-		return nil, fmt.Errorf("failed to find image with filter %s", templateBytes.String())
+		return nil, &terminalError{message: fmt.Sprintf("failed to find image with filter %s", templateBytes.String())}
 	}
 	return sorted[0], nil
 }
@@ -848,7 +862,7 @@ func GetPrismReferencesOfCategoryIdentifiers(
 			return nil, errorMsg
 		}
 		if prismCategory == nil || prismCategory.ExtId == nil {
-			errorMsg := fmt.Errorf("category value %s not found in category %s. error", ci.Value, ci.Key)
+			errorMsg := &terminalError{message: fmt.Sprintf("category value %s not found in category %s", ci.Value, ci.Key)}
 			log.Error(errorMsg, "category value not found")
 			return nil, errorMsg
 		}
@@ -878,7 +892,7 @@ func GetProjectUUID(ctx context.Context, client *prismclientv3.Client, projectNa
 		projectIntentResponse, err := client.V3.GetProject(ctx, *projectUUID)
 		if err != nil {
 			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
-				return "", fmt.Errorf("failed to find project with UUID %s: %w", *projectUUID, err)
+				return "", &terminalError{message: fmt.Sprintf("failed to find project with UUID %s: %v", *projectUUID, err)}
 			}
 			return "", fmt.Errorf("failed to get project with UUID %s: %w", *projectUUID, err)
 		}
@@ -896,7 +910,7 @@ func GetProjectUUID(ctx context.Context, client *prismclientv3.Client, projectNa
 			}
 		}
 		if len(foundProjects) == 0 {
-			return "", fmt.Errorf("failed to retrieve project by name %s", *projectName)
+			return "", &terminalError{message: fmt.Sprintf("failed to retrieve project by name %s", *projectName)}
 		} else if len(foundProjects) > 1 {
 			return "", fmt.Errorf("more than one project found with name %s", *projectName)
 		} else {
@@ -949,7 +963,7 @@ func GetGPU(ctx context.Context, client *v4Converged.Client, peUUID string, gpu 
 		return nil, err
 	}
 	if len(allUnusedGPUs) == 0 {
-		return nil, fmt.Errorf("no available GPUs found in Prism Element cluster with UUID %s", peUUID)
+		return nil, &terminalError{message: fmt.Sprintf("no available GPUs found in Prism Element cluster with UUID %s", peUUID)}
 	}
 
 	randomIndex := rand.Intn(len(allUnusedGPUs))
@@ -1062,7 +1076,7 @@ func GetStorageContainerInCluster(ctx context.Context, client *v4Converged.Clien
 	}
 
 	if len(storageContainers) == 0 {
-		return nil, fmt.Errorf("found no storage container using filter: %s", filter)
+		return nil, &terminalError{message: fmt.Sprintf("found no storage container using filter: %s", filter)}
 	}
 
 	return &storageContainers[0], nil

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -57,6 +57,41 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
+func Test_isRetryableAPIError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "not found is not retryable",
+			err:      &converged.APIError{Kind: converged.ErrNotFound, Message: "not found"},
+			expected: false,
+		},
+		{
+			name:     "rate limit is retryable",
+			err:      &converged.APIError{Kind: converged.ErrRateLimit, Message: "rate limited"},
+			expected: true,
+		},
+		{
+			name:     "internal is retryable",
+			err:      &converged.APIError{Kind: converged.ErrInternal, Message: "internal error"},
+			expected: true,
+		},
+		{
+			name:     "unknown errors default to retryable",
+			err:      errors.New("timeout awaiting headers"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isRetryableAPIError(tt.err))
+		})
+	}
+}
+
 func TestControllerHelpers(t *testing.T) {
 	g := NewWithT(t)
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -28,6 +28,7 @@ import (
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	mockconverged "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/converged"
 	mockk8sclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/k8sclient"
+	mocknutanixv3 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/nutanix"
 	nutanixclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/client"
 	converged "github.com/nutanix-cloud-native/prism-go-client/converged"
 	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
@@ -82,6 +83,11 @@ func Test_isRetryableAPIError(t *testing.T) {
 			name:     "unknown errors default to retryable",
 			err:      errors.New("timeout awaiting headers"),
 			expected: true,
+		},
+		{
+			name:     "terminal error is not retryable",
+			err:      &terminalError{message: "resource not found"},
+			expected: false,
 		},
 	}
 
@@ -1953,6 +1959,7 @@ func TestGetStorageContainerInCluster(t *testing.T) {
 		want               *clusterModels.StorageContainer
 		wantErr            bool
 		errorMessage       string
+		assertNotFound     bool
 	}{
 		{
 			name: "GetStorageContainerInCluster succeeds with ID UUID",
@@ -2029,6 +2036,26 @@ func TestGetStorageContainerInCluster(t *testing.T) {
 			want:         &storageContainers[0],
 			wantErr:      false,
 			errorMessage: "",
+		},
+		{
+			name: "GetStorageContainerInCluster returns classified not found when no containers match",
+			mockBuilder: func() *v4Converged.Client {
+				mockClientWrapper := NewMockConvergedClient(mockctl)
+				mockClientWrapper.MockStorageContainers.EXPECT().List(gomock.Any(), gomock.Any()).Return([]clusterModels.StorageContainer{}, nil)
+				return mockClientWrapper.Client
+			},
+			clusterId: infrav1.NutanixResourceIdentifier{
+				Type: infrav1.NutanixIdentifierUUID,
+				UUID: ptr.To("00062e56-b9ac-7253-1946-7cc25586eeee"),
+			},
+			storageContainerId: infrav1.NutanixResourceIdentifier{
+				Type: infrav1.NutanixIdentifierUUID,
+				UUID: ptr.To("2a61b02a-54a6-475e-93b9-5efc895b48e3"),
+			},
+			want:           nil,
+			wantErr:        true,
+			errorMessage:   "found no storage container using filter",
+			assertNotFound: true,
 		},
 		{
 			name: "GetStorageContainerInCluster fails",
@@ -2149,8 +2176,71 @@ func TestGetStorageContainerInCluster(t *testing.T) {
 			if tt.errorMessage != "" {
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			}
+			if tt.assertNotFound {
+				assert.True(t, isTerminalError(err))
+			}
 		})
 	}
+}
+
+func TestGetPrismReferencesOfCategoryIdentifiers_NotFoundClassification(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockClient := NewMockConvergedClient(ctrl)
+	mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return([]prismModels.Category{}, nil)
+
+	_, err := GetPrismReferencesOfCategoryIdentifiers(ctx, mockClient.Client, []*infrav1.NutanixCategoryIdentifier{
+		{
+			Key:   "cluster-name",
+			Value: "missing",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in category")
+	assert.True(t, isTerminalError(err))
+}
+
+func TestGetProjectUUID_NotFoundClassification(t *testing.T) {
+	t.Run("returns classified not found for missing project UUID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mockV3Client := mocknutanixv3.NewMockService(ctrl)
+		client := &prismclientv3.Client{V3: mockV3Client}
+		projectUUID := "missing-project-uuid"
+
+		mockV3Client.EXPECT().GetProject(ctx, projectUUID).Return(nil, errors.New("ENTITY_NOT_FOUND"))
+
+		_, err := GetProjectUUID(ctx, client, nil, &projectUUID)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to find project with UUID")
+		assert.True(t, isTerminalError(err))
+	})
+
+	t.Run("returns classified not found for missing project name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mockV3Client := mocknutanixv3.NewMockService(ctrl)
+		client := &prismclientv3.Client{V3: mockV3Client}
+		projectName := "missing-project-name"
+
+		mockV3Client.EXPECT().ListAllProject(ctx, "").Return(&prismclientv3.ProjectListResponse{
+			Entities: []*prismclientv3.Project{},
+		}, nil)
+
+		_, err := GetProjectUUID(ctx, client, &projectName, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve project by name")
+		assert.True(t, isTerminalError(err))
+	})
 }
 
 func TestDeleteVM(t *testing.T) {
@@ -2399,6 +2489,7 @@ func TestGetGPU(t *testing.T) {
 		_, err := GetGPU(ctx, mockClientWrapper.Client, peUUID, gpu)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no available GPUs found")
+		assert.True(t, isTerminalError(err))
 	})
 }
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -87,6 +88,16 @@ func Test_isRetryableAPIError(t *testing.T) {
 		{
 			name:     "terminal error is not retryable",
 			err:      &terminalError{message: "resource not found"},
+			expected: false,
+		},
+		{
+			name:     "unclassified APIError (Kind nil) is not retryable",
+			err:      &converged.APIError{Kind: nil, Cause: errors.New("400 Bad Request")},
+			expected: false,
+		},
+		{
+			name:     "wrapped unclassified APIError is not retryable",
+			err:      fmt.Errorf("failed to create VM: %w", &converged.APIError{Kind: nil, Cause: errors.New("validation error")}),
 			expected: false,
 		},
 	}

--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -670,7 +670,7 @@ func (r *NutanixClusterReconciler) reconcileCredentialRef(ctx context.Context, n
 	}
 
 	if err := r.Client.Get(ctx, secretKey, secret); err != nil {
-		errorMsg := fmt.Errorf("error occurred while fetching cluster %s secret for credential ref: %v", nutanixCluster.Name, err)
+		errorMsg := fmt.Errorf("error occurred while fetching cluster %s secret for credential ref: %w", nutanixCluster.Name, err)
 		log.Error(errorMsg, "error occurred fetching cluster")
 		return errorMsg
 	}
@@ -699,7 +699,7 @@ func (r *NutanixClusterReconciler) reconcileCredentialRef(ctx context.Context, n
 
 	err = r.Client.Update(ctx, secret)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to update secret for cluster %s: %v", nutanixCluster.Name, err)
+		errorMsg := fmt.Errorf("failed to update secret for cluster %s: %w", nutanixCluster.Name, err)
 		log.Error(errorMsg, "failed to update secret")
 		return errorMsg
 	}

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -322,7 +322,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	})
 	vmUUID, err := GetVMUUID(rctx.Machine, rctx.NutanixMachine)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to get VM UUID during delete: %v", err)
+		errorMsg := fmt.Errorf("failed to get VM UUID during delete: %w", err)
 		log.Error(errorMsg, "failed to delete VM")
 		return reconcile.Result{}, errorMsg
 	}
@@ -338,7 +338,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 
 	vm, err := FindVMByUUID(ctx, convergedClient, vmUUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("error finding VM %s with UUID %s: %v", vmName, vmUUID, err)
+		errorMsg := fmt.Errorf("error finding VM %s with UUID %s: %w", vmName, vmUUID, err)
 		log.Error(errorMsg, "error finding VM")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1beta1.ConditionSeverityWarning, "%s", errorMsg.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -371,7 +371,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 
 	taskInProgress, err := VmHasTaskInProgress(ctx, convergedClient, vmUUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while fetching running task from VM: %v", err)
+		errorMsg := fmt.Errorf("error occurred while fetching running task from VM: %w", err)
 		log.Error(errorMsg, "error fetching running task from VM")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1beta1.ConditionSeverityWarning, "%s", errorMsg.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -398,7 +398,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	}
 	if vgDetachNeeded {
 		if err := r.detachVolumeGroups(rctx, vmName, vmUUID, vm.Disks); err != nil {
-			err := fmt.Errorf("failed to detach volume groups from VM %s with UUID %s: %v", vmName, vmUUID, err)
+			err := fmt.Errorf("failed to detach volume groups from VM %s with UUID %s: %w", vmName, vmUUID, err)
 			log.Error(err, "failed to detach volume groups from VM")
 			v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.VolumeGroupDetachFailed, capiv1beta1.ConditionSeverityWarning, "%s", err.Error())
 			v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -420,7 +420,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	// Delete the VM since the VM was found (err was nil)
 	deleteTaskUUID, err := DeleteVM(ctx, convergedClient, vmName, vmUUID)
 	if err != nil {
-		err := fmt.Errorf("failed to delete VM %s with UUID %s: %v", vmName, vmUUID, err)
+		err := fmt.Errorf("failed to delete VM %s with UUID %s: %w", vmName, vmUUID, err)
 		log.Error(err, "failed to delete VM")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1beta1.ConditionSeverityWarning, "%s", err.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -545,14 +545,14 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 
 	log.V(1).Info(fmt.Sprintf("Patching machine post creation vmUUID: %s", rctx.NutanixMachine.Status.VmUUID))
 	if err := r.patchMachine(rctx); err != nil {
-		errorMsg := fmt.Errorf("failed to patch NutanixMachine %s after creation. %v", rctx.NutanixMachine.Name, err)
+		errorMsg := fmt.Errorf("failed to patch NutanixMachine %s after creation: %w", rctx.NutanixMachine.Name, err)
 		log.Error(errorMsg, "failed to patch")
 		return reconcile.Result{}, errorMsg
 	}
 
 	log.Info(fmt.Sprintf("Assigning IP addresses to VM with name: %s, vmUUID: %s", rctx.NutanixMachine.Name, rctx.NutanixMachine.Status.VmUUID))
 	if err := r.assignAddressesToMachine(rctx, vm); err != nil {
-		errorMsg := fmt.Errorf("failed to assign addresses to VM %s with UUID %s...: %v", rctx.Machine.Name, rctx.NutanixMachine.Status.VmUUID, err)
+		errorMsg := fmt.Errorf("failed to assign addresses to VM %s with UUID %s: %w", rctx.Machine.Name, rctx.NutanixMachine.Status.VmUUID, err)
 		log.Error(errorMsg, "failed to assign addresses")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMAddressesAssignedCondition, infrav1.VMAddressesFailed, capiv1beta1.ConditionSeverityError, "%s", err.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -600,7 +600,7 @@ func (r *NutanixMachineReconciler) syncVmUUID(rctx *nctx.MachineContext, vmExtId
 		log.Info("Updated NutanixMachine VmUUID status", "vmUUID", targetUUID)
 
 		if err := r.patchMachine(rctx); err != nil {
-			return fmt.Errorf("failed to patch NutanixMachine %s after setting VmUUID from %s: %v", rctx.NutanixMachine.Name, targetUUID, err)
+			return fmt.Errorf("failed to patch NutanixMachine %s after setting VmUUID from %s: %w", rctx.NutanixMachine.Name, targetUUID, err)
 		}
 	}
 
@@ -931,8 +931,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	// Set categories on VM
 	categoryReferences, err := GetPrismReferencesOfCategoryIdentifiers(ctx, rctx.ConvergedClient, r.getMachineCategoryIdentifiers(rctx))
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while creating category spec for vm %s: %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		errorMsg := fmt.Errorf("error occurred while creating category spec for vm %s: %w", vmName, err)
 		return nil, errorMsg
 	}
 	vm.Categories = categoryReferences
@@ -940,50 +939,46 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	// Set Project in VM Spec before creating VM
 	err = r.addVMToProject(rctx, vm)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while trying to add VM %s to project: %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		errorMsg := fmt.Errorf("error occurred while trying to add VM %s to project: %w", vmName, err)
+		return nil, errorMsg
 	}
 
 	// Get GPU list
 	gpus, err := GetGPUList(ctx, convergedClient, rctx.NutanixMachine.Spec.GPUs, peUUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to get the GPU list to create the VM %s. %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		errorMsg := fmt.Errorf("failed to get the GPU list to create the VM %s: %w", vmName, err)
+		return nil, errorMsg
 	}
 	vm.Gpus = gpus
 
 	disks, cdRoms, err := getDiskList(rctx, peUUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to get the disk list to create the VM %s. %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		errorMsg := fmt.Errorf("failed to get the disk list to create the VM %s: %w", vmName, err)
+		return nil, errorMsg
 	}
 	vm.Disks = disks
 	vm.CdRoms = cdRoms
 
 	if err := r.addGuestCustomizationToVM(rctx, vm); err != nil {
-		errorMsg := fmt.Errorf("error occurred while adding guest customization to vm spec: %v", err)
+		errorMsg := fmt.Errorf("error occurred while adding guest customization to vm spec: %w", err)
 		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		return nil, errorMsg
 	}
 
 	// Set BootType in VM Spec before creating VM
 	err = r.addBootTypeToVM(rctx, vm)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while adding boot type to vm spec: %v", err)
+		errorMsg := fmt.Errorf("error occurred while adding boot type to vm spec: %w", err)
 		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		return nil, errorMsg
 	}
 
 	// Create the actual VM/Machine
 	log.Info(fmt.Sprintf("Creating VM with name %s for cluster %s", vmName, rctx.NutanixCluster.Name))
 	vm, err = convergedClient.VMs.Create(ctx, vm)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to create VM %s. error: %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		errorMsg := fmt.Errorf("failed to create VM %s: %w", vmName, err)
+		return nil, errorMsg
 	}
 
 	vmUuid := *vm.ExtId
@@ -1015,22 +1010,19 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	log.Info("Powering VM on after creation")
 	powerOnTask, err := convergedClient.VMs.PowerOnVM(vmUuid)
 	if err != nil {
-		errMsg := fmt.Errorf("error occured while powering on VM %s: %v", vmName, err)
-		rctx.SetFailureStatus(powerOnErrorFailureReason, errMsg)
+		errMsg := fmt.Errorf("error occured while powering on VM %s: %w", vmName, err)
 		return nil, errMsg
 	}
 	_, err = powerOnTask.Wait(ctx)
 	if err != nil {
-		errMsg := fmt.Errorf("error occured while waiting for VM %s to power on: %v", vmName, err)
-		rctx.SetFailureStatus(powerOnErrorFailureReason, errMsg)
+		errMsg := fmt.Errorf("error occured while waiting for VM %s to power on: %w", vmName, err)
 		return nil, errMsg
 	}
 
 	log.Info("Fetching VM after creation")
 	vm, err = FindVMByUUID(ctx, convergedClient, vmUuid)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while getting VM %s after creation: %v", vmName, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		errorMsg := fmt.Errorf("error occurred while getting VM %s after creation: %w", vmName, err)
 		return nil, errorMsg
 	}
 
@@ -1139,8 +1131,7 @@ func getSystemDisk(rctx *nctx.MachineContext) (*vmmconfig.Disk, error) {
 	}
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get system disk image %q: %w", rctx.NutanixMachine.Spec.Image, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		return nil, errorMsg
 	}
 
 	// Consider this a precaution. If the image is marked for deletion after we
@@ -1161,7 +1152,7 @@ func getSystemDisk(rctx *nctx.MachineContext) (*vmmconfig.Disk, error) {
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while creating system disk spec: %w", err)
 		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		return nil, errorMsg
 	}
 
 	return systemDisk, nil
@@ -1175,8 +1166,7 @@ func getBootstrapDisk(rctx *nctx.MachineContext) (*vmmconfig.CdRom, error) {
 	bootstrapImage, err := GetImage(rctx.Context, rctx.ConvergedClient, bootstrapImageRef)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get bootstrap disk image %q: %w", bootstrapImageRef, err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, err
+		return nil, errorMsg
 	}
 
 	// Consider this a precaution. If the image is marked for deletion after we
@@ -1205,8 +1195,7 @@ func getDataDisks(rctx *nctx.MachineContext, peUUID string) ([]vmmconfig.Disk, [
 	dataDisks, dataCdRoms, err := CreateDataDiskList(rctx.Context, rctx.ConvergedClient, rctx.NutanixMachine.Spec.DataDisks, peUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while creating data disk spec: %w", err)
-		rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
-		return nil, nil, err
+		return nil, nil, errorMsg
 	}
 
 	return dataDisks, dataCdRoms, nil
@@ -1240,12 +1229,12 @@ func (r *NutanixMachineReconciler) patchMachine(rctx *nctx.MachineContext) error
 	log := ctrl.LoggerFrom(rctx.Context)
 	patchHelper, err := v1beta1patch.NewHelper(rctx.NutanixMachine, r.Client)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to create patch helper to patch machine %s: %v", rctx.NutanixMachine.Name, err)
+		errorMsg := fmt.Errorf("failed to create patch helper to patch machine %s: %w", rctx.NutanixMachine.Name, err)
 		return errorMsg
 	}
 	err = patchHelper.Patch(rctx.Context, rctx.NutanixMachine)
 	if err != nil {
-		errorMsg := fmt.Errorf("failed to patch machine %s: %v", rctx.NutanixMachine.Name, err)
+		errorMsg := fmt.Errorf("failed to patch machine %s: %w", rctx.NutanixMachine.Name, err)
 		return errorMsg
 	}
 	log.V(1).Info(fmt.Sprintf("Patched machine %s: Status %+v Spec %+v", rctx.NutanixMachine.Name, rctx.NutanixMachine.Status, rctx.NutanixMachine.Spec))
@@ -1414,7 +1403,7 @@ func (r *NutanixMachineReconciler) addVMToProject(rctx *nctx.MachineContext, vm 
 
 	projectExtId, err := GetProjectUUID(rctx.Context, rctx.NutanixClient, projectRef.Name, projectRef.UUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while searching for project for VM %s: %v", vmName, err)
+		errorMsg := fmt.Errorf("error occurred while searching for project for VM %s: %w", vmName, err)
 		log.Error(errorMsg, "error occurred while searching for project")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.ProjectAssignedCondition, infrav1.ProjectAssignationFailed, capiv1beta1.ConditionSeverityError, "%s", errorMsg.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -865,6 +865,7 @@ func validateDataDiskDeviceProperties(disk infrav1.NutanixMachineVMDisk, errors 
 }
 
 // GetOrCreateVM creates a VM and is invoked by the NutanixMachineReconciler
+//nolint:gocognit // Keep orchestration in one place; covers VM discovery, spec build, create, and post-create steps.
 func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vmmconfig.Vm, error) {
 	var err error
 	ctx := rctx.Context
@@ -932,6 +933,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	categoryReferences, err := GetPrismReferencesOfCategoryIdentifiers(ctx, rctx.ConvergedClient, r.getMachineCategoryIdentifiers(rctx))
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while creating category spec for vm %s: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 	vm.Categories = categoryReferences
@@ -940,6 +944,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	err = r.addVMToProject(rctx, vm)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while trying to add VM %s to project: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 
@@ -947,6 +954,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	gpus, err := GetGPUList(ctx, convergedClient, rctx.NutanixMachine.Spec.GPUs, peUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get the GPU list to create the VM %s: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 	vm.Gpus = gpus
@@ -954,6 +964,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	disks, cdRoms, err := getDiskList(rctx, peUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get the disk list to create the VM %s: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 	vm.Disks = disks
@@ -978,6 +991,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	vm, err = convergedClient.VMs.Create(ctx, vm)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to create VM %s: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 
@@ -1011,11 +1027,17 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	powerOnTask, err := convergedClient.VMs.PowerOnVM(vmUuid)
 	if err != nil {
 		errMsg := fmt.Errorf("error occured while powering on VM %s: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(powerOnErrorFailureReason, errMsg)
+		}
 		return nil, errMsg
 	}
 	_, err = powerOnTask.Wait(ctx)
 	if err != nil {
 		errMsg := fmt.Errorf("error occured while waiting for VM %s to power on: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(powerOnErrorFailureReason, errMsg)
+		}
 		return nil, errMsg
 	}
 
@@ -1023,6 +1045,9 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	vm, err = FindVMByUUID(ctx, convergedClient, vmUuid)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while getting VM %s after creation: %w", vmName, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 
@@ -1131,6 +1156,9 @@ func getSystemDisk(rctx *nctx.MachineContext) (*vmmconfig.Disk, error) {
 	}
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get system disk image %q: %w", rctx.NutanixMachine.Spec.Image, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 
@@ -1166,6 +1194,9 @@ func getBootstrapDisk(rctx *nctx.MachineContext) (*vmmconfig.CdRom, error) {
 	bootstrapImage, err := GetImage(rctx.Context, rctx.ConvergedClient, bootstrapImageRef)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get bootstrap disk image %q: %w", bootstrapImageRef, err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, errorMsg
 	}
 
@@ -1195,6 +1226,9 @@ func getDataDisks(rctx *nctx.MachineContext, peUUID string) ([]vmmconfig.Disk, [
 	dataDisks, dataCdRoms, err := CreateDataDiskList(rctx.Context, rctx.ConvergedClient, rctx.NutanixMachine.Spec.DataDisks, peUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while creating data disk spec: %w", err)
+		if !isRetryableAPIError(err) {
+			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+		}
 		return nil, nil, errorMsg
 	}
 

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -898,6 +898,17 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	// if VM exists
 	if vmFound != nil {
 		log.Info(fmt.Sprintf("vm %s found with UUID %s", *vmFound.Name, rctx.NutanixMachine.Status.VmUUID))
+
+		// Ensure the VM is powered on. A previous reconcile may have created the
+		// VM but failed to power it on (e.g. transient etag mismatch).
+		if vmFound.PowerState == nil || *vmFound.PowerState != vmmconfig.POWERSTATE_ON {
+			var err error
+			vmFound, err = r.powerOnVM(rctx, *vmFound.ExtId, vmName)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		v1beta1conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMProvisionedCondition)
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
 			Type:   string(infrav1.VMProvisionedCondition),
@@ -1037,9 +1048,31 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 		log.Error(err, fmt.Sprintf("failed to update custom attributes on VM %s with UUID %s, continuing", vmName, vmUuid))
 	}
 
-	// Power on VM
-	log.Info("Powering VM on after creation")
-	powerOnTask, err := convergedClient.VMs.PowerOnVM(vmUuid)
+	// Power on VM and re-fetch updated state
+	vm, err = r.powerOnVM(rctx, vmUuid, vmName)
+	if err != nil {
+		return nil, err
+	}
+
+	v1beta1conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMProvisionedCondition)
+	v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
+		Type:   string(infrav1.VMProvisionedCondition),
+		Status: metav1.ConditionTrue,
+		Reason: capiv1beta1.ProvisionedV1Beta2Reason,
+	})
+	return vm, nil
+}
+
+// powerOnVM powers on the VM, waits for the task to complete, and returns the
+// re-fetched VM. Both the "existing VM found off" and "newly created VM" paths
+// use this so power-on error handling stays in one place.
+func (r *NutanixMachineReconciler) powerOnVM(rctx *nctx.MachineContext, vmUUID, vmName string) (*vmmconfig.Vm, error) {
+	ctx := rctx.Context
+	log := ctrl.LoggerFrom(ctx)
+	convergedClient := rctx.ConvergedClient
+
+	log.Info(fmt.Sprintf("Powering on VM %s", vmName))
+	powerOnTask, err := convergedClient.VMs.PowerOnVM(vmUUID)
 	if err != nil {
 		errMsg := fmt.Errorf("error occured while powering on VM %s: %w", vmName, err)
 		if !isRetryableAPIError(err) {
@@ -1056,22 +1089,15 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 		return nil, errMsg
 	}
 
-	log.Info("Fetching VM after creation")
-	vm, err = FindVMByUUID(ctx, convergedClient, vmUuid)
+	log.Info(fmt.Sprintf("Fetching VM %s after power on", vmName))
+	vm, err := FindVMByUUID(ctx, convergedClient, vmUUID)
 	if err != nil {
-		errorMsg := fmt.Errorf("error occurred while getting VM %s after creation: %w", vmName, err)
+		errorMsg := fmt.Errorf("error occurred while getting VM %s after power on: %w", vmName, err)
 		if !isRetryableAPIError(err) {
-			rctx.SetFailureStatus(createErrorFailureReason, errorMsg)
+			rctx.SetFailureStatus(powerOnErrorFailureReason, errorMsg)
 		}
 		return nil, errorMsg
 	}
-
-	v1beta1conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMProvisionedCondition)
-	v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
-		Type:   string(infrav1.VMProvisionedCondition),
-		Status: metav1.ConditionTrue,
-		Reason: capiv1beta1.ProvisionedV1Beta2Reason,
-	})
 	return vm, nil
 }
 

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -769,6 +769,7 @@ func (r *NutanixMachineReconciler) validateMachineConfig(rctx *nctx.MachineConte
 
 func (r *NutanixMachineReconciler) validateDataDisks(dataDisks []infrav1.NutanixMachineVMDisk) error {
 	errors := []error{}
+	usedDeviceIndexByAdapter := make(map[string]map[int32]struct{})
 	for _, disk := range dataDisks {
 
 		if disk.DiskSize.Cmp(minMachineDataDiskSize) < 0 {
@@ -779,6 +780,20 @@ func (r *NutanixMachineReconciler) validateDataDisks(dataDisks []infrav1.Nutanix
 
 		if disk.DeviceProperties != nil {
 			errors = validateDataDiskDeviceProperties(disk, errors)
+
+			// DeviceIndex 0 means "unspecified" and is auto-assigned later, so we
+			// only detect duplicates for explicitly set non-zero indexes.
+			if disk.DeviceProperties.DeviceIndex != 0 {
+				adapterType := string(disk.DeviceProperties.AdapterType)
+				if _, ok := usedDeviceIndexByAdapter[adapterType]; !ok {
+					usedDeviceIndexByAdapter[adapterType] = make(map[int32]struct{})
+				}
+				if _, ok := usedDeviceIndexByAdapter[adapterType][disk.DeviceProperties.DeviceIndex]; ok {
+					errors = append(errors, fmt.Errorf("index '%d' is already in use", disk.DeviceProperties.DeviceIndex))
+				} else {
+					usedDeviceIndexByAdapter[adapterType][disk.DeviceProperties.DeviceIndex] = struct{}{}
+				}
+			}
 		}
 
 		if disk.DataSource != nil {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -531,6 +531,15 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 	}
 	log.V(1).Info(fmt.Sprintf("Found VM with name: %s, vmUUID: %s", rctx.Machine.Name, *vm.ExtId))
 
+	// Power-on is an explicit reconcile step after VM discovery/creation.
+	if vm.PowerState == nil || *vm.PowerState != vmmconfig.POWERSTATE_ON {
+		vm, err = r.powerOnVM(rctx, *vm.ExtId, rctx.Machine.Name)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to power on VM %s.", rctx.Machine.Name))
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Set and sync VmUUID with SystemUUID to ensure consistency
 	if err := r.syncVmUUID(rctx, *vm.ExtId); err != nil {
 		log.Error(err, "Failed to sync VmUUID")
@@ -880,7 +889,6 @@ func validateDataDiskDeviceProperties(disk infrav1.NutanixMachineVMDisk, errors 
 }
 
 // GetOrCreateVM creates a VM and is invoked by the NutanixMachineReconciler
-//nolint:gocognit // Keep orchestration in one place; covers VM discovery, spec build, create, and post-create steps.
 func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vmmconfig.Vm, error) {
 	var err error
 	ctx := rctx.Context
@@ -898,16 +906,6 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	// if VM exists
 	if vmFound != nil {
 		log.Info(fmt.Sprintf("vm %s found with UUID %s", *vmFound.Name, rctx.NutanixMachine.Status.VmUUID))
-
-		// Ensure the VM is powered on. A previous reconcile may have created the
-		// VM but failed to power it on (e.g. transient etag mismatch).
-		if vmFound.PowerState == nil || *vmFound.PowerState != vmmconfig.POWERSTATE_ON {
-			var err error
-			vmFound, err = r.powerOnVM(rctx, *vmFound.ExtId, vmName)
-			if err != nil {
-				return nil, err
-			}
-		}
 
 		v1beta1conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMProvisionedCondition)
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -1046,12 +1044,6 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	_, err = convergedClient.VMs.AddVmCustomAttributes(ctx, vmUuid, customAttributes)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("failed to update custom attributes on VM %s with UUID %s, continuing", vmName, vmUuid))
-	}
-
-	// Power on VM and re-fetch updated state
-	vm, err = r.powerOnVM(rctx, vmUuid, vmName)
-	if err != nil {
-		return nil, err
 	}
 
 	v1beta1conditions.MarkTrue(rctx.NutanixMachine, infrav1.VMProvisionedCondition)

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -3008,6 +3008,216 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		// The providerID should be set using the actual VM UUID
 		assert.Equal(t, fmt.Sprintf("nutanix://%s", vmUUID), ntnxMachine.Spec.ProviderID)
 	})
+
+	t.Run("should set failure status when category lookup returns not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "test-vm"
+		peUUID := "00056024-f4f2-a6f6-0000-00000000e7f4"
+		subnetUUID := "b8c6d9f0-4c5e-4c5e-8c5e-4c5e4c5e4c5e"
+		imageUUID := "c5e4c5e4-c5e4-c5e4-c5e4-c5e4c5e4c5e4"
+		clusterName := "test-cluster"
+		projectName := "test-project"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.NutanixMachineSpec{
+				VCPUSockets:    2,
+				VCPUsPerSocket: 1,
+				MemorySize:     resource.MustParse("4Gi"),
+				SystemDiskSize: resource.MustParse("40Gi"),
+				BootType:       infrav1.NutanixBootTypeLegacy,
+				Project: &infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierName,
+					Name: &projectName,
+				},
+				Image: &infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierUUID,
+					UUID: &imageUUID,
+				},
+				Cluster: infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierUUID,
+					UUID: &peUUID,
+				},
+				Subnets: []infrav1.NutanixResourceIdentifier{
+					{
+						Type: infrav1.NutanixIdentifierUUID,
+						UUID: &subnetUUID,
+					},
+				},
+				BootstrapRef: &corev1.ObjectReference{
+					Kind:      infrav1.NutanixMachineBootstrapRefKindSecret,
+					Name:      "bootstrap-secret",
+					Namespace: "default",
+				},
+			},
+		}
+
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vmName,
+			},
+			Spec: capiv1beta2.MachineSpec{
+				Version: "v1.28.0",
+			},
+		}
+
+		cluster := &capiv1beta2.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: "default",
+			},
+		}
+
+		ntnxCluster := &infrav1.NutanixCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: "default",
+			},
+		}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+
+		// VM not found, proceed to create flow.
+		mockConvergedClient.MockVMs.EXPECT().List(ctx, gomock.Any()).Return([]vmmModels.Vm{}, nil)
+		mockConvergedClient.MockClusters.EXPECT().Get(ctx, peUUID).Return(&clustermgmtconfig.Cluster{
+			ExtId: &peUUID,
+		}, nil)
+		mockConvergedClient.MockSubnets.EXPECT().Get(ctx, subnetUUID).Return(&subnetModels.Subnet{
+			ExtId: &subnetUUID,
+		}, nil)
+		mockConvergedClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(nil,
+			&converged.APIError{Kind: converged.ErrNotFound, Message: "category not found"},
+		).AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Cluster:         cluster,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		reconciler := &NutanixMachineReconciler{}
+		vm, err := reconciler.getOrCreateVM(rctx)
+
+		require.Error(t, err)
+		assert.Nil(t, vm)
+		require.NotNil(t, ntnxMachine.Status.FailureReason)
+		assert.Equal(t, createErrorFailureReason, *ntnxMachine.Status.FailureReason)
+		require.NotNil(t, ntnxMachine.Status.FailureMessage)
+		assert.Contains(t, *ntnxMachine.Status.FailureMessage, "category spec")
+	})
+
+	t.Run("should not set failure status when category lookup returns internal error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "test-vm"
+		peUUID := "00056024-f4f2-a6f6-0000-00000000e7f4"
+		subnetUUID := "b8c6d9f0-4c5e-4c5e-8c5e-4c5e4c5e4c5e"
+		imageUUID := "c5e4c5e4-c5e4-c5e4-c5e4-c5e4c5e4c5e4"
+		clusterName := "test-cluster"
+		projectName := "test-project"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.NutanixMachineSpec{
+				VCPUSockets:    2,
+				VCPUsPerSocket: 1,
+				MemorySize:     resource.MustParse("4Gi"),
+				SystemDiskSize: resource.MustParse("40Gi"),
+				BootType:       infrav1.NutanixBootTypeLegacy,
+				Project: &infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierName,
+					Name: &projectName,
+				},
+				Image: &infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierUUID,
+					UUID: &imageUUID,
+				},
+				Cluster: infrav1.NutanixResourceIdentifier{
+					Type: infrav1.NutanixIdentifierUUID,
+					UUID: &peUUID,
+				},
+				Subnets: []infrav1.NutanixResourceIdentifier{
+					{
+						Type: infrav1.NutanixIdentifierUUID,
+						UUID: &subnetUUID,
+					},
+				},
+				BootstrapRef: &corev1.ObjectReference{
+					Kind:      infrav1.NutanixMachineBootstrapRefKindSecret,
+					Name:      "bootstrap-secret",
+					Namespace: "default",
+				},
+			},
+		}
+
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vmName,
+			},
+			Spec: capiv1beta2.MachineSpec{
+				Version: "v1.28.0",
+			},
+		}
+
+		cluster := &capiv1beta2.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: "default",
+			},
+		}
+
+		ntnxCluster := &infrav1.NutanixCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: "default",
+			},
+		}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+
+		// VM not found, proceed to create flow.
+		mockConvergedClient.MockVMs.EXPECT().List(ctx, gomock.Any()).Return([]vmmModels.Vm{}, nil)
+		mockConvergedClient.MockClusters.EXPECT().Get(ctx, peUUID).Return(&clustermgmtconfig.Cluster{
+			ExtId: &peUUID,
+		}, nil)
+		mockConvergedClient.MockSubnets.EXPECT().Get(ctx, subnetUUID).Return(&subnetModels.Subnet{
+			ExtId: &subnetUUID,
+		}, nil)
+		mockConvergedClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(nil,
+			&converged.APIError{Kind: converged.ErrInternal, Message: "pc internal error"},
+		).AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Cluster:         cluster,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		reconciler := &NutanixMachineReconciler{}
+		vm, err := reconciler.getOrCreateVM(rctx)
+
+		require.Error(t, err)
+		assert.Nil(t, vm)
+		assert.Nil(t, ntnxMachine.Status.FailureReason)
+		assert.Nil(t, ntnxMachine.Status.FailureMessage)
+	})
 }
 
 func TestNutanixMachineReconciler_assignAddressesToMachine(t *testing.T) {

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2695,10 +2695,11 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		// Create mock clients
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 
-		// Mock FindVM to return existing VM
+		// Mock FindVM to return existing VM (already powered on)
 		expectedVm := vmmModels.NewVm()
 		expectedVm.Name = ptr.To(vmName)
 		expectedVm.ExtId = ptr.To(vmUUID)
+		expectedVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(expectedVm, nil)
 
 		// Create machine context
@@ -2756,10 +2757,11 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		// Create mock clients
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 
-		// Mock FindVMByName
+		// Mock FindVMByName (already powered on)
 		expectedVM := vmmModels.NewVm()
 		expectedVM.Name = ptr.To(vmName)
 		expectedVM.ExtId = ptr.To(vmUUID)
+		expectedVM.PowerState = vmmModels.POWERSTATE_ON.Ref()
 		mockConvergedClient.MockVMs.EXPECT().List(ctx, FilterMatcher{ContainsExtId: vmName}).Return([]vmmModels.Vm{*expectedVM}, nil)
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(expectedVM, nil)
 
@@ -2782,6 +2784,78 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, vm)
 		assert.Equal(t, vmName, *vm.Name)
+	})
+
+	t.Run("should power on existing VM that is not powered on", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "test-vm"
+		vmUUID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.NutanixMachineSpec{
+				ProviderID: fmt.Sprintf("nutanix://%s", vmUUID),
+			},
+			Status: infrav1.NutanixMachineStatus{
+				VmUUID: vmUUID,
+			},
+		}
+
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vmName,
+			},
+		}
+
+		ntnxCluster := &infrav1.NutanixCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+
+		// Mock FindVM to return existing VM that is OFF
+		existingVm := vmmModels.NewVm()
+		existingVm.Name = ptr.To(vmName)
+		existingVm.ExtId = ptr.To(vmUUID)
+		existingVm.PowerState = vmmModels.POWERSTATE_OFF.Ref()
+		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(existingVm, nil)
+
+		// Mock PowerOnVM
+		mockOperation := mockconverged.NewMockOperation[vmmModels.Vm](ctrl)
+		mockConvergedClient.MockVMs.EXPECT().PowerOnVM(vmUUID).Return(mockOperation, nil)
+		mockOperation.EXPECT().Wait(gomock.Any()).Return(nil, nil)
+
+		// Mock re-fetch after power on
+		poweredOnVm := vmmModels.NewVm()
+		poweredOnVm.Name = ptr.To(vmName)
+		poweredOnVm.ExtId = ptr.To(vmUUID)
+		poweredOnVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
+		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(poweredOnVm, nil)
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		reconciler := &NutanixMachineReconciler{}
+		vm, err := reconciler.getOrCreateVM(rctx)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, vm)
+		assert.Equal(t, vmName, *vm.Name)
+		assert.Equal(t, vmUUID, *vm.ExtId)
 	})
 
 	t.Run("should return error when FindVM fails", func(t *testing.T) {
@@ -3553,10 +3627,11 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		// Create mock clients
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 
-		// Mock FindVM to return VM matching systemUUID
+		// Mock FindVM to return VM matching systemUUID (already powered on)
 		expectedVm := vmmModels.NewVm()
 		expectedVm.Name = ptr.To(vmName)
 		expectedVm.ExtId = ptr.To(systemUUID)
+		expectedVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
 		// Should get VM by systemUUID, NOT VmUUID
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, systemUUID).Return(expectedVm, nil)
 
@@ -3621,10 +3696,11 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		// Create mock clients
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 
-		// Mock FindVM to return VM matching VmUUID
+		// Mock FindVM to return VM matching VmUUID (already powered on)
 		expectedVm := vmmModels.NewVm()
 		expectedVm.Name = ptr.To(vmName)
 		expectedVm.ExtId = ptr.To(vmUUID)
+		expectedVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
 		// Should get VM by VmUUID since NodeInfo is nil
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(expectedVm, nil)
 
@@ -3691,10 +3767,11 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		// Create mock clients
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 
-		// Mock FindVM to return VM matching VmUUID
+		// Mock FindVM to return VM matching VmUUID (already powered on)
 		expectedVm := vmmModels.NewVm()
 		expectedVm.Name = ptr.To(vmName)
 		expectedVm.ExtId = ptr.To(vmUUID)
+		expectedVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
 		// Should get VM by VmUUID since SystemUUID is empty
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(expectedVm, nil)
 

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2786,7 +2786,7 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		assert.Equal(t, vmName, *vm.Name)
 	})
 
-	t.Run("should power on existing VM that is not powered on", func(t *testing.T) {
+	t.Run("should return existing VM even when it is powered off", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -2829,18 +2829,6 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		existingVm.PowerState = vmmModels.POWERSTATE_OFF.Ref()
 		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(existingVm, nil)
 
-		// Mock PowerOnVM
-		mockOperation := mockconverged.NewMockOperation[vmmModels.Vm](ctrl)
-		mockConvergedClient.MockVMs.EXPECT().PowerOnVM(vmUUID).Return(mockOperation, nil)
-		mockOperation.EXPECT().Wait(gomock.Any()).Return(nil, nil)
-
-		// Mock re-fetch after power on
-		poweredOnVm := vmmModels.NewVm()
-		poweredOnVm.Name = ptr.To(vmName)
-		poweredOnVm.ExtId = ptr.To(vmUUID)
-		poweredOnVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
-		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(poweredOnVm, nil)
-
 		rctx := &nctx.MachineContext{
 			Context:         ctx,
 			Machine:         machine,
@@ -2856,6 +2844,7 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		assert.NotNil(t, vm)
 		assert.Equal(t, vmName, *vm.Name)
 		assert.Equal(t, vmUUID, *vm.ExtId)
+		assert.Equal(t, vmmModels.POWERSTATE_OFF, *vm.PowerState)
 	})
 
 	t.Run("should return error when FindVM fails", func(t *testing.T) {
@@ -3055,18 +3044,6 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		updatedVM.Name = ptr.To(vmName)
 		updatedVM.ExtId = ptr.To(vmUUID)
 		mockConvergedClient.MockVMs.EXPECT().AddVmCustomAttributes(ctx, vmUUID, gomock.Any()).Return(updatedVM, nil)
-
-		// Mock PowerOnVM
-		mockOperation := mockconverged.NewMockOperation[vmmModels.Vm](ctrl)
-		mockConvergedClient.MockVMs.EXPECT().PowerOnVM(vmUUID).Return(mockOperation, nil)
-		mockOperation.EXPECT().Wait(gomock.Any()).Return(nil, nil)
-
-		// Mock final FindVMByUUID call
-		finalVM := vmmModels.NewVm()
-		finalVM.Name = ptr.To(vmName)
-		finalVM.ExtId = ptr.To(vmUUID)
-		finalVM.PowerState = vmmModels.POWERSTATE_ON.Ref()
-		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(finalVM, nil)
 
 		// Create machine context
 		rctx := &nctx.MachineContext{

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -779,6 +779,49 @@ func TestNutanixMachineValidateDataDisks(t *testing.T) {
 				g.Expect(err.Error()).To(ContainSubstring("invalid device index -1 for data disk"))
 			},
 		},
+		{
+			name: "dataDiskErrorDuplicateDeviceIndex",
+			dataDisks: func() []infrav1.NutanixMachineVMDisk {
+				return []infrav1.NutanixMachineVMDisk{
+					{
+						DiskSize: resource.MustParse("20Gi"),
+						DeviceProperties: &infrav1.NutanixMachineVMDiskDeviceProperties{
+							DeviceType:  infrav1.NutanixMachineDiskDeviceTypeDisk,
+							AdapterType: infrav1.NutanixMachineDiskAdapterTypeSCSI,
+							DeviceIndex: 10,
+						},
+						StorageConfig: &infrav1.NutanixMachineVMStorageConfig{
+							DiskMode: infrav1.NutanixMachineDiskModeStandard,
+							StorageContainer: &infrav1.NutanixResourceIdentifier{
+								UUID: ptr.To("06b1ce03-f384-4488-9ba1-ae17ebcf1f91"),
+								Type: infrav1.NutanixIdentifierUUID,
+							},
+						},
+					},
+					{
+						DiskSize: resource.MustParse("20Gi"),
+						DeviceProperties: &infrav1.NutanixMachineVMDiskDeviceProperties{
+							DeviceType:  infrav1.NutanixMachineDiskDeviceTypeDisk,
+							AdapterType: infrav1.NutanixMachineDiskAdapterTypeSCSI,
+							DeviceIndex: 10,
+						},
+						StorageConfig: &infrav1.NutanixMachineVMStorageConfig{
+							DiskMode: infrav1.NutanixMachineDiskModeStandard,
+							StorageContainer: &infrav1.NutanixResourceIdentifier{
+								UUID: ptr.To("06b1ce03-f384-4488-9ba1-ae17ebcf1f91"),
+								Type: infrav1.NutanixIdentifierUUID,
+							},
+						},
+					},
+				}
+			},
+			description: "Verify NutanixMachine with duplicate data disk device index error",
+			stepDesc:    "should error on validation due to duplicate device index",
+			errCheck: func(g *WithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("index '10' is already in use"))
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
What this PR does / why we need it:
This PR removes terminal failure marking from NutanixMachine paths that depend on Prism Central API calls, so transient PC connectivity failures (timeouts/outages) do not permanently block reconciliation.

Before
A transient Nutanix API error (e.g. network timeout on subnet listing) would:

Call SetFailureStatus("CreateError", err) — set FailureReason in memory
Return error from reconcileNormal
Defer patch would still fire (wrong err variable was nil) — persist failure to API server
Next reconcile: FailureReason != nil → return Result{}, nil — machine permanently dead

Observed failure that motivated this fix

```
Failure Message: failed to list all subnet: API call failed: ... giving up after 1 attempt(s):
                 net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Failure Reason:  CreateError
Phase:           Failed
A single network timeout on a subnet list call permanently killed the machine.

```
Key updates:

1.Removed SetFailureStatus(...) from API-retriable provisioning paths in nutanixmachine_controller.go (VM create/deploy/power-on/task wait and related PC-backed lookups).
2.Kept SetFailureStatus(...) for deterministic/non-retriable failures (spec/validation/boot-type/guest-customization and similar invalid configuration paths).
3.Standardized fmt.Errorf wrapping from %v to %w in touched controller/helper paths to preserve error chains.
4. Introduced isRetryableAPIError() and a terminalError type to distinguish transient API failures (rate limits, 5xx, timeouts) from deterministic config errors (referenced resource does not exist). Transient errors are retried with backoff; deterministic errors set FailureReason/FailureMessage immediately.


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes # https://jira.nutanix.com/browse/NCN-113269

How this was tested:

Scenario 1: Provisioning flow under PC outage:

1.Triggered new cluster creation from bootstrap cluster on my machine.
2.Turned VPN off while machines were in provisioning stages.
3.Observed PC api call failiures like:

`026-03-31T17:17:46Z    ERROR   Failed to create VM mycluster-without-topology-wmd-pxtnv-nzq86. {"controller": "nutanixmachine-controller", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "NutanixMachine", "NutanixMachine": {"name":"mycluster-without-topology-wmd-pxtnv-nzq86","namespace":"ns-topology"}, "namespace": "ns-topology", "name": "mycluster-without-topology-wmd-pxtnv-nzq86", "reconcileID": "bc38fd8c-f299-46be-a145-22725245c534", "error": "error occured while waiting for VM mycluster-without-topology-wmd-pxtnv-nzq86 to power on: failed to get task ZXJnb24=:b720749d-0864-5a8a-bbbe-7e9817a3ae87: api call failed: Get \"https://pc.dev.nkp.sh:9440/api/prism/v4.2/config/tasks/ZXJnb24=:b720749d-0864-5a8a-bbbe-7e9817a3ae87\": GET https://pc.dev.nkp.sh:9440/api/prism/v4.2/config/tasks/ZXJnb24=:b720749d-0864-5a8a-bbbe-7e9817a3ae87 giving up after 1 attempt(s): Get \"https://pc.dev.nkp.sh:9440/api/prism/v4.2/config/tasks/ZXJnb24=:b720749d-0864-5a8a-bbbe-7e9817a3ae87\": context deadline exceeded (Client.Timeout exceeded while awaiting headers) (Client.Timeout exceeded while awaiting headers)"}`

4.Verified impacted NutanixMachine objects were not marked terminal:

```
status.failureReason = empty / <none>
status.failureMessage = empty / <none>
```
5.Turned VPN back on.
6.Reconcile retries continued and machine progressed to Ready:

```
vedansh.kakkar@JW0FWFWGHJ internal-cluster-api-provider-nutanix % kubectl get nutanixmachines -A               
NAMESPACE     NAME                                         ADDRESS         READY   PROVIDERID                                       FAILUREDOMAIN
ns-topology   mycluster-without-topology-kcp-c4ltt         10.22.201.247   true    nutanix://c72d1cfa-90e6-4d2c-4d6b-6f51be32d05a   
ns-topology   mycluster-without-topology-wmd-pxtnv-f85tx   10.22.201.246   true    nutanix://b49d0cd0-548a-435b-423d-48aabf4645f9   
ns-topology   mycluster-without-topology-wmd-pxtnv-khqhq   10.22.201.245   true    nutanix://9a6cf5fc-d253-4934-759b-a44a4e0bb05b   
ns-topology   mycluster-without-topology-wmd-pxtnv-nzq86   10.22.201.244   true    nutanix://2743fc60-9399-4841-7e4f-5f39123fb0ae 
```
Scenario 2: Forced reconcile on already-ready machine (regression check)

1.Restarted the capx pod to trigger forced reconciliation
2.With VPN off, saw reconcile logs including provider/client initialization messages.
3.Reconcile then followed ready path :
```
if rctx.NutanixMachine.Status.Ready {
	infraReady := rctx.Cluster.Status.Initialization.InfrastructureProvisioned != nil && *rctx.Cluster.Status.Initialization.InfrastructureProvisioned
	if !infraReady || rctx.Machine.Spec.ProviderID == "" {
		log.Info("The NutanixMachine is ready, wait for the owner Machine's update.")
		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
	}
	log.Info(fmt.Sprintf("The NutanixMachine is ready, providerID: %s", rctx.NutanixMachine.Spec.ProviderID))

	// Sync VmUUID with SystemUUID if they differ
	if err := r.syncVmUUID(rctx, rctx.NutanixMachine.Status.VmUUID); err != nil {
		log.Error(err, "Failed to sync VmUUID with SystemUUID")
		return reconcile.Result{}, err
	}

	return reconcile.Result{}, nil
}
```
4.No failure status mutation occurred on the machine.