### PR TITLE
fix(backport): Setting VM Image to PLACEHOLDER Value in templates (#641)

### DIFF
--- a/templates/base/nmt.yaml
+++ b/templates/base/nmt.yaml
@@ -16,7 +16,7 @@ spec:
       systemDiskSize: "${NUTANIX_SYSTEMDISK_SIZE=40Gi}"
       image:
         type: name
-        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}"
+        name: "${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME:=placeholder-image}"
       cluster:
         type: name
         name: "${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}"

--- a/templates/cluster-template-csi.yaml
+++ b/templates/cluster-template-csi.yaml
@@ -1925,7 +1925,7 @@ spec:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name
       image:
-        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME:=placeholder-image}
         type: name
       memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
       providerID: nutanix://${CLUSTER_NAME}-m1

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -2095,7 +2095,7 @@ spec:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name
       image:
-        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME:=placeholder-image}
         type: name
       memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
       providerID: nutanix://${CLUSTER_NAME}-m1

--- a/templates/cluster-template-failure-domains.yaml
+++ b/templates/cluster-template-failure-domains.yaml
@@ -632,7 +632,7 @@ spec:
     spec:
       bootType: ${NUTANIX_MACHINE_BOOT_TYPE=legacy}
       image:
-        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME:=placeholder-image}
         type: name
       memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
       providerID: nutanix://${CLUSTER_NAME}-m1

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -591,7 +591,7 @@ spec:
         name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
         type: name
       image:
-        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}
+        name: ${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME:=placeholder-image}
         type: name
       memorySize: ${NUTANIX_MACHINE_MEMORY_SIZE=4Gi}
       providerID: nutanix://${CLUSTER_NAME}-m1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-v1.9`:
 - [fix: Setting VM Image to PLACEHOLDER Value in templates (#641)](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/641)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)