### PR TITLE
fix(backport): update go toolchain to go1.26.4 (#734)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nutanix-cloud-native/cluster-api-provider-nutanix
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-v1.9`:
 - [fix: update go toolchain to go1.26.4 (#734)](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/734)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)