### PR TITLE
feat: customizable webhook port and cert-dir flags for provider consistency

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--health-probe-bind-address=:8081"
+        - "--health-addr=:8081"
         - "--diagnostics-address=:8443"
         - "--leader-elect"
         - "--feature-gates=DefaultToPlaceholderImageName=true,DefaultToPlaceholderImageUUID=true"

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -54,6 +55,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var scheme = runtime.NewScheme()
@@ -72,11 +74,24 @@ func init() {
 const (
 	// DefaultMaxConcurrentReconciles is the default maximum number of concurrent reconciles
 	defaultMaxConcurrentReconciles = 10
+
+	// defaultWebhookPort is the default port the webhook server binds to. It matches the
+	// controller-runtime default and the containerPort in config/default/manager_webhook_patch.yaml.
+	defaultWebhookPort = 9443
+
+	// defaultWebhookCertDir is the default directory that contains the webhook server's
+	// TLS key and certificate. It matches the controller-runtime default.
+	defaultWebhookCertDir = "/tmp/k8s-webhook-server/serving-certs"
+
+	// defaultHealthProbeAddr is the default address the health probe endpoint binds to.
+	defaultHealthProbeAddr = ":8081"
 )
 
 type options struct {
 	enableLeaderElection    bool
 	healthProbeAddr         string
+	webhookPort             int
+	webhookCertDir          string
 	maxConcurrentReconciles int
 
 	rateLimiterBaseDelay  time.Duration
@@ -91,9 +106,12 @@ type options struct {
 type managerConfig struct {
 	enableLeaderElection               bool
 	healthProbeAddr                    string
+	webhookPort                        int
+	webhookCertDir                     string
 	concurrentReconcilesNutanixCluster int
 	concurrentReconcilesNutanixMachine int
 	metricsServerOpts                  server.Options
+	tlsOptions                         []func(*tls.Config)
 	skipNameValidation                 bool
 
 	logger      logr.Logger
@@ -159,7 +177,22 @@ func initializeFlags() *options {
 	opts.zapOptions.BindFlags(flag.CommandLine)
 
 	// Add our own flags to the pflag FlagSet.
-	pflag.StringVar(&opts.healthProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	//
+	// --health-addr is the canonical name, matching the other Cluster API providers
+	// (CAPA/CAPG/CAPZ/CAPV). --health-probe-bind-address is kept as a deprecated alias
+	// for backwards compatibility; both bind to the same target.
+	pflag.StringVar(&opts.healthProbeAddr, "health-addr", defaultHealthProbeAddr,
+		"The address the health probe endpoint binds to.")
+	pflag.StringVar(&opts.healthProbeAddr, "health-probe-bind-address", defaultHealthProbeAddr,
+		"The address the probe endpoint binds to.")
+	if err := pflag.CommandLine.MarkDeprecated("health-probe-bind-address", "use --health-addr instead"); err != nil {
+		panic(fmt.Sprintf("failed to mark --health-probe-bind-address deprecated: %v", err))
+	}
+
+	pflag.IntVar(&opts.webhookPort, "webhook-port", defaultWebhookPort, "The webhook server port.")
+	pflag.StringVar(&opts.webhookCertDir, "webhook-cert-dir", defaultWebhookCertDir,
+		"The directory that contains the webhook server key and certificate.")
+
 	pflag.BoolVar(&opts.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
@@ -188,17 +221,20 @@ func initializeConfig(opts *options) (*managerConfig, error) {
 	config := &managerConfig{
 		enableLeaderElection: opts.enableLeaderElection,
 		healthProbeAddr:      opts.healthProbeAddr,
+		webhookPort:          opts.webhookPort,
+		webhookCertDir:       opts.webhookCertDir,
 	}
 
-	_, metricsServerOpts, err := capiflags.GetManagerOptions(opts.managerOptions)
+	tlsOptions, metricsServerOpts, err := capiflags.GetManagerOptions(opts.managerOptions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get metrics server options: %w", err)
+		return nil, fmt.Errorf("unable to get manager options: %w", err)
 	}
 	if metricsServerOpts == nil {
 		return nil, errors.New("parsed manager options are nil")
 	}
 	metricsServerOpts.FilterProvider = filters.WithAuthenticationAndAuthorization
 	config.metricsServerOpts = *metricsServerOpts
+	config.tlsOptions = tlsOptions
 
 	config.concurrentReconcilesNutanixCluster = opts.maxConcurrentReconciles
 	config.concurrentReconcilesNutanixMachine = opts.maxConcurrentReconciles
@@ -463,8 +499,13 @@ func runManager(ctx context.Context, mgr manager.Manager, config *managerConfig)
 
 func initializeManager(config *managerConfig) (manager.Manager, error) {
 	mgr, err := ctrl.NewManager(config.restConfig, ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                config.metricsServerOpts,
+		Scheme:  scheme,
+		Metrics: config.metricsServerOpts,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    config.webhookPort,
+			CertDir: config.webhookCertDir,
+			TLSOpts: config.tlsOptions,
+		}),
 		HealthProbeBindAddress: config.healthProbeAddr,
 		LeaderElection:         config.enableLeaderElection,
 		LeaderElectionID:       "f265110d.cluster.x-k8s.io",

--- a/main_test.go
+++ b/main_test.go
@@ -58,12 +58,60 @@ func TestInitializeFlags(t *testing.T) {
 				enableLeaderElection:    true,
 				maxConcurrentReconciles: 5,
 				healthProbeAddr:         ":8081",
+				webhookPort:             defaultWebhookPort,
+				webhookCertDir:          defaultWebhookCertDir,
 				rateLimiterBaseDelay:    500 * time.Millisecond,
 				rateLimiterMaxDelay:     10 * time.Second,
 				rateLimiterBucketSize:   1000,
 				rateLimiterQPS:          50,
 			},
 			cmpOpt: cmpopts.IgnoreFields(options{},
+				"managerOptions",
+				"zapOptions",
+			),
+		},
+		{
+			name: "webhook and health flags",
+			args: []string{
+				"cmd",
+				"--health-addr=:9091",
+				"--webhook-port=8443",
+				"--webhook-cert-dir=/etc/certs",
+			},
+			want: &options{
+				healthProbeAddr: ":9091",
+				webhookPort:     8443,
+				webhookCertDir:  "/etc/certs",
+			},
+			cmpOpt: cmpopts.IgnoreFields(options{},
+				"enableLeaderElection",
+				"maxConcurrentReconciles",
+				"rateLimiterBaseDelay",
+				"rateLimiterMaxDelay",
+				"rateLimiterBucketSize",
+				"rateLimiterQPS",
+				"managerOptions",
+				"zapOptions",
+			),
+		},
+		{
+			name: "deprecated health-probe-bind-address alias",
+			args: []string{
+				"cmd",
+				"--health-probe-bind-address=:9092",
+			},
+			want: &options{
+				healthProbeAddr: ":9092",
+				webhookPort:     defaultWebhookPort,
+				webhookCertDir:  defaultWebhookCertDir,
+			},
+			cmpOpt: cmpopts.IgnoreFields(options{},
+				"enableLeaderElection",
+				"maxConcurrentReconciles",
+				"rateLimiterBaseDelay",
+				"rateLimiterMaxDelay",
+				"rateLimiterBucketSize",
+				"rateLimiterQPS",
 				"managerOptions",
 				"zapOptions",
 			),
@@ -80,6 +128,8 @@ func TestInitializeFlags(t *testing.T) {
 					DiagnosticsAddress:  ":9999",
 					InsecureDiagnostics: true,
 				},
+				webhookPort:    defaultWebhookPort,
+				webhookCertDir: defaultWebhookCertDir,
 			},
 			cmpOpt: cmpopts.IgnoreFields(options{},
 				"enableLeaderElection",
@@ -137,6 +187,8 @@ func TestInitializeConfig(t *testing.T) {
 				"--rate-limiter-bucket-size=1000",
 				"--rate-limiter-qps=50",
 				"--feature-gates=DefaultToPlaceholderImageName=true,DefaultToPlaceholderImageUUID=true",
+				"--webhook-port=8443",
+				"--webhook-cert-dir=/etc/certs",
 				// Cluster API options.
 				"--insecure-diagnostics=true",
 				"--diagnostics-address=:9999",
@@ -177,6 +229,8 @@ func TestInitializeConfig(t *testing.T) {
 
 			assert.Equal(t, got.enableLeaderElection, opts.enableLeaderElection)
 			assert.Equal(t, got.healthProbeAddr, opts.healthProbeAddr)
+			assert.Equal(t, got.webhookPort, opts.webhookPort)
+			assert.Equal(t, got.webhookCertDir, opts.webhookCertDir)
 			assert.Equal(t, got.concurrentReconcilesNutanixCluster, opts.maxConcurrentReconciles)
 			assert.Equal(t, got.concurrentReconcilesNutanixMachine, opts.maxConcurrentReconciles)
 			assert.Equal(t, got.metricsServerOpts.BindAddress, opts.managerOptions.DiagnosticsAddress)


### PR DESCRIPTION
## Summary

- Add `--webhook-port` (default `9443`) and `--webhook-cert-dir` (default `/tmp/k8s-webhook-server/serving-certs`) flags, matching the names/defaults used by CAPA/CAPG/CAPZ/CAPV. CAPX previously never configured a webhook server, so these were pinned to controller-runtime defaults and could not be overridden.
- Construct an explicit webhook server in `initializeManager`, which also lets us apply the TLS option mutators (`--tls-min-version` / `--tls-cipher-suites`) returned by `capiflags.GetManagerOptions`. These were previously discarded and never reached the webhook server.
- Add the CAPI-standard `--health-addr` flag, keeping `--health-probe-bind-address` as a deprecated alias for backwards compatibility, and update `config/default/manager_auth_proxy_patch.yaml` to use the new name.

## Why

The flag surface for the webhook server and health endpoint diverged from every other Cluster API infrastructure provider, making CAPX harder to configure consistently (e.g. relocating the webhook port). This aligns the flags without breaking existing deployments.

## Notes

- Defaults are unchanged, so existing deployments behave identically. The webhook default (`9443`) matches the `containerPort` in `manager_webhook_patch.yaml`.
- `--health-probe-bind-address` still works but emits a deprecation warning; it can be removed in a future release.

## Test plan

- [x] `go test -run 'TestInitializeFlags|TestInitializeConfig'` (added cases for the new flags + deprecated alias)
- [x] `go build ./...` / `go vet .`
- [ ] CI: full `make unit-test` / `make lint`