### PR TITLE
chore: kustomize overlays for setting auth secret for basic and API key types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ CNI_PATH_KINDNET ?= "${E2E_DIR}/data/cni/kindnet/kindnet.yaml"
 CCM_VERSION ?= 0.7.0-alpha.1
 # Auto-select credential type: API key takes precedence when set.
 NUTANIX_CREDENTIALS_TYPE ?= $(if $(strip $(NUTANIX_API_KEY)),api_key,basic_auth)
+NUTANIX_CREDENTIALS_OVERLAY ?= $(subst _,-,$(NUTANIX_CREDENTIALS_TYPE))
 export NUTANIX_CREDENTIALS_TYPE
+export NUTANIX_CREDENTIALS_OVERLAY
 
 # CRD_OPTIONS define options to add to the CONTROLLER_GEN
 CRD_OPTIONS ?= "crd:crdVersions=v1"
@@ -158,7 +160,7 @@ manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefin
 .PHONY: release-manifests
 release-manifests: manifests cluster-templates
 	mkdir -p $(RELEASE_DIR)
-	kustomize build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+	kustomize build config/overlays/default/$(NUTANIX_CREDENTIALS_OVERLAY) > $(RELEASE_DIR)/infrastructure-components.yaml
 	cp $(TEMPLATES_DIR)/cluster-template*.yaml $(RELEASE_DIR)
 	cp $(REPO_ROOT)/metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
@@ -338,12 +340,12 @@ cluster-e2e-templates-no-kubeproxy: ##Generate cluster templates without kubepro
 	kustomize build $(NUTANIX_E2E_TEMPLATES)/v1beta1/no-kubeproxy/cluster-template-topology --load-restrictor LoadRestrictionsNone > $(NUTANIX_E2E_TEMPLATES)/v1beta1/cluster-template-topology.yaml
 
 cluster-templates: ## Generate cluster templates for all flavors
-	kustomize build $(TEMPLATES_DIR)/base > $(TEMPLATES_DIR)/cluster-template.yaml
-	kustomize build $(TEMPLATES_DIR)/csi3 > $(TEMPLATES_DIR)/cluster-template-csi3.yaml
+	kustomize build $(TEMPLATES_DIR)/overlays/base/$(NUTANIX_CREDENTIALS_OVERLAY) > $(TEMPLATES_DIR)/cluster-template.yaml
+	kustomize build $(TEMPLATES_DIR)/overlays/csi3/$(NUTANIX_CREDENTIALS_OVERLAY) > $(TEMPLATES_DIR)/cluster-template-csi3.yaml
 	kustomize build $(TEMPLATES_DIR)/clusterclass > $(TEMPLATES_DIR)/cluster-template-clusterclass.yaml
-	kustomize build $(TEMPLATES_DIR)/topology > $(TEMPLATES_DIR)/cluster-template-topology.yaml
-	kustomize build $(TEMPLATES_DIR)/image-lookup/ > $(TEMPLATES_DIR)/cluster-template-image-lookup.yaml
-	kustomize build $(TEMPLATES_DIR)/failure-domains/ > $(TEMPLATES_DIR)/cluster-template-failure-domains.yaml
+	kustomize build $(TEMPLATES_DIR)/overlays/topology/$(NUTANIX_CREDENTIALS_OVERLAY) > $(TEMPLATES_DIR)/cluster-template-topology.yaml
+	kustomize build $(TEMPLATES_DIR)/overlays/image-lookup/$(NUTANIX_CREDENTIALS_OVERLAY) > $(TEMPLATES_DIR)/cluster-template-image-lookup.yaml
+	kustomize build $(TEMPLATES_DIR)/overlays/failure-domains/$(NUTANIX_CREDENTIALS_OVERLAY) > $(TEMPLATES_DIR)/cluster-template-failure-domains.yaml
 
 ##@ Testing
 
@@ -358,7 +360,7 @@ docker-build-e2e: ## Build docker image with the manager with e2e tag.
 prepare-local-clusterctl: manifests cluster-templates  ## Prepare overide file for local clusterctl.
 	mkdir -p ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}
 	cd config/manager && kustomize edit set image controller=${MANAGER_IMAGE}
-	kustomize build config/default > ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/infrastructure-components.yaml
+	kustomize build config/overlays/default/$(NUTANIX_CREDENTIALS_OVERLAY) > ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/infrastructure-components.yaml
 	cp ./metadata.yaml ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/
 	cp ./templates/cluster-template*.yaml ~/.cluster-api/overrides/infrastructure-nutanix/${LOCAL_PROVIDER_VERSION}/
 	cp ./clusterctl.yaml.tmpl ./clusterctl.yaml

--- a/config/overlays/default/api-key/kustomization.yaml
+++ b/config/overlays/default/api-key/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../default
+
+patches:
+- target:
+    kind: Secret
+    name: 'nutanix-creds'
+    namespace: capi-nutanix-system
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/config/overlays/default/basic-auth/kustomization.yaml
+++ b/config/overlays/default/basic-auth/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../default
+
+patches:
+- target:
+    kind: Secret
+    name: 'nutanix-creds'
+    namespace: capi-nutanix-system
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/base/secret.yaml
+++ b/templates/base/secret.yaml
@@ -7,12 +7,11 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
+            "password": "${NUTANIX_PASSWORD}"
           },
           "prismElements": null
         }

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -1699,14 +1699,12 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
-          },
-          "prismElements": null
+            "password": "${NUTANIX_PASSWORD}"
+          }
         }
       }
     ]

--- a/templates/cluster-template-failure-domains.yaml
+++ b/templates/cluster-template-failure-domains.yaml
@@ -238,14 +238,12 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
-          },
-          "prismElements": null
+            "password": "${NUTANIX_PASSWORD}"
+          }
         }
       }
     ]

--- a/templates/cluster-template-image-lookup.yaml
+++ b/templates/cluster-template-image-lookup.yaml
@@ -238,14 +238,12 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
-          },
-          "prismElements": null
+            "password": "${NUTANIX_PASSWORD}"
+          }
         }
       }
     ]

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -235,14 +235,12 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
-          },
-          "prismElements": null
+            "password": "${NUTANIX_PASSWORD}"
+          }
         }
       }
     ]

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -238,14 +238,12 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
-          },
-          "prismElements": null
+            "password": "${NUTANIX_PASSWORD}"
+          }
         }
       }
     ]

--- a/templates/overlays/base/api-key/kustomization.yaml
+++ b/templates/overlays/base/api-key/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../base
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/base/basic-auth/kustomization.yaml
+++ b/templates/overlays/base/basic-auth/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../base
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/csi3/api-key/kustomization.yaml
+++ b/templates/overlays/csi3/api-key/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../csi3
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/csi3/basic-auth/kustomization.yaml
+++ b/templates/overlays/csi3/basic-auth/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../csi3
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/failure-domains/api-key/kustomization.yaml
+++ b/templates/overlays/failure-domains/api-key/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../failure-domains
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/failure-domains/basic-auth/kustomization.yaml
+++ b/templates/overlays/failure-domains/basic-auth/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../failure-domains
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/image-lookup/api-key/kustomization.yaml
+++ b/templates/overlays/image-lookup/api-key/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../image-lookup
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/image-lookup/basic-auth/kustomization.yaml
+++ b/templates/overlays/image-lookup/basic-auth/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../image-lookup
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/topology/api-key/kustomization.yaml
+++ b/templates/overlays/topology/api-key/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../topology
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}-pc-creds'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "api_key",
+            "data": {
+              "prismCentral":{
+                "apiKey": "${NUTANIX_API_KEY}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/overlays/topology/basic-auth/kustomization.yaml
+++ b/templates/overlays/topology/basic-auth/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../topology
+
+patches:
+- target:
+    kind: Secret
+    name: '\$\{CLUSTER_NAME\}-pc-creds'
+  patch: |-
+    - op: replace
+      path: /stringData/credentials
+      value: |
+        [
+          {
+            "type": "basic_auth",
+            "data": {
+              "prismCentral":{
+                "username": "${NUTANIX_USER}",
+                "password": "${NUTANIX_PASSWORD}"
+              },
+              "prismElements": null
+            }
+          }
+        ]

--- a/templates/topology/secret.yaml
+++ b/templates/topology/secret.yaml
@@ -7,12 +7,11 @@ stringData:
   credentials: |
     [
       {
-        "type": "${NUTANIX_CREDENTIALS_TYPE}",
+        "type": "basic_auth",
         "data": {
           "prismCentral":{
             "username": "${NUTANIX_USER}",
-            "password": "${NUTANIX_PASSWORD}",
-            "apiKey": "${NUTANIX_API_KEY}"
+            "password": "${NUTANIX_PASSWORD}"
           },
           "prismElements": null
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

- Adds kustomize overlays for setting auth secret for basic and API key types
- Cleaner approach than env substitution. 
- Revert the templates to basic auth type. No functional change as templates are evaluated based on API key set or not and whole secret values are updated as per expected format.
- Works with both legacy supported basic auth structure if no auth type specified and if API key specified, creates secret of api_key type

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

```
(devbox) ➜  cluster-api-provider-nutanix git:(jira/NCN-113632) ✗ make prepare-local-clusterctl
controller-gen "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
kustomize build templates/overlays/base/basic-auth > templates/cluster-template.yaml
kustomize build templates/overlays/csi3/basic-auth > templates/cluster-template-csi3.yaml
kustomize build templates/clusterclass > templates/cluster-template-clusterclass.yaml
kustomize build templates/overlays/topology/basic-auth > templates/cluster-template-topology.yaml
kustomize build templates/overlays/image-lookup/basic-auth > templates/cluster-template-image-lookup.yaml
kustomize build templates/overlays/failure-domains/basic-auth > templates/cluster-template-failure-domains.yaml
mkdir -p ~/.cluster-api/overrides/infrastructure-nutanix/v1.9.99
cd config/manager && kustomize edit set image controller=ko.local/cluster-api-provider-nutanix:e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82
kustomize build config/overlays/default/basic-auth > ~/.cluster-api/overrides/infrastructure-nutanix/v1.9.99/infrastructure-components.yaml
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
cp ./metadata.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v1.9.99/
cp ./templates/cluster-template*.yaml ~/.cluster-api/overrides/infrastructure-nutanix/v1.9.99/
cp ./clusterctl.yaml.tmpl ./clusterctl.yaml
env LOCAL_PROVIDER_VERSION=v1.9.99 \
        envsubst -no-unset -no-empty -no-digit < ./clusterctl.yaml > ~/.cluster-api/clusterctl.yaml


(devbox) ➜  cluster-api-provider-nutanix git:(jira/NCN-113632) ✗ make deploy
controller-gen "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
Using Docker as container engine
DOCKER_HOST: unix:///Users/manoj.surudwad/.colima/default/docker.sock
DOCKER_HOST=unix:///Users/manoj.surudwad/.colima/default/docker.sock GOOS=linux GOARCH=arm64 KO_DOCKER_REPO=ko.local GOFLAGS="-buildvcs=false" ko build -B -t e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82 .
2026/06/30 18:34:06 Using base cgr.dev/chainguard/static:latest@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b for github.com/nutanix-cloud-native/cluster-api-provider-nutanix
2026/06/30 18:34:07 git is in a dirty state
Please check in your pipeline what can be changing the following files:
M  Makefile
 M config/manager/kustomization.yaml
A  config/overlays/default/api-key/kustomization.yaml
A  config/overlays/default/basic-auth/kustomization.yaml
 M docs/developer_workflow.md
M  templates/base/secret.yaml
MM templates/cluster-template-csi3.yaml
MM templates/cluster-template-failure-domains.yaml
MM templates/cluster-template-image-lookup.yaml
MM templates/cluster-template-topology.yaml
MM templates/cluster-template.yaml
A  templates/overlays/base/api-key/kustomization.yaml
A  templates/overlays/base/basic-auth/kustomization.yaml
A  templates/overlays/csi3/api-key/kustomization.yaml
A  templates/overlays/csi3/basic-auth/kustomization.yaml
A  templates/overlays/failure-domains/api-key/kustomization.yaml
A  templates/overlays/failure-domains/basic-auth/kustomization.yaml
A  templates/overlays/image-lookup/api-key/kustomization.yaml
A  templates/overlays/image-lookup/basic-auth/kustomization.yaml
A  templates/overlays/topology/api-key/kustomization.yaml
A  templates/overlays/topology/basic-auth/kustomization.yaml
M  templates/topology/secret.yaml

2026/06/30 18:34:07 Building github.com/nutanix-cloud-native/cluster-api-provider-nutanix for linux/arm64
2026/06/30 18:34:14 Loading ko.local/cluster-api-provider-nutanix:4e0a6d6cfda19fd4224cc0c3bbbcbf64c06a4f42ccc4f2a0031e2cf1b8772d5e
2026/06/30 18:34:15 Loaded ko.local/cluster-api-provider-nutanix:4e0a6d6cfda19fd4224cc0c3bbbcbf64c06a4f42ccc4f2a0031e2cf1b8772d5e
2026/06/30 18:34:15 Adding tag e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82
2026/06/30 18:34:15 Added tag e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82
ko.local/cluster-api-provider-nutanix:4e0a6d6cfda19fd4224cc0c3bbbcbf64c06a4f42ccc4f2a0031e2cf1b8772d5e
docker tag ko.local/cluster-api-provider-nutanix:e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82 ko.local/cluster-api-provider-nutanix:e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82
kind load docker-image --name capi-test ko.local/cluster-api-provider-nutanix:e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82
Image: "ko.local/cluster-api-provider-nutanix:e2e-2c053b69cf77f67fa5c3b8ceb40c0ea8f9d70f82" with ID "sha256:441779724c96bd9dead3b8af9f3ad6abeb73a61d122c01e7985eea31c76b75b0" not yet present on node "capi-test-control-plane", loading...
clusterctl delete --infrastructure nutanix:v1.9.99 --include-crd || true
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
Checking for CRs Provider={"name":"infrastructure-nutanix","namespace":"capx-system"} providerVersion="v1.9.99"
Error: found existing objects for provider CRDs "infrastructure-nutanix": [, ]. Please delete these objects first before running clusterctl delete with --include-crd
clusterctl init --infrastructure nutanix:v1.9.99 -v 9
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
Fetching providers
Potential override file searchFile="/Users/manoj.surudwad/.cluster-api/overrides/infrastructure-nutanix/v1.9.99/infrastructure-components.yaml" provider="infrastructure-nutanix" version="v1.9.99"
Using override="infrastructure-components.yaml" provider="infrastructure-nutanix" version="v1.9.99"
Potential override file searchFile="/Users/manoj.surudwad/.cluster-api/overrides/cluster-api/v1.13.3/metadata.yaml" provider="cluster-api" version="v1.13.3"
Fetching file="metadata.yaml" provider="cluster-api" type="CoreProvider" version="v1.13.3"
Creating Namespace="cert-manager-test"
Creating Issuer="test-selfsigned" Namespace="cert-manager-test"
Creating Certificate="selfsigned-cert" Namespace="cert-manager-test"
spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`.
Deleting Namespace="cert-manager-test"
Deleting Issuer="test-selfsigned" Namespace="cert-manager-test"
Deleting Certificate="selfsigned-cert" Namespace="cert-manager-test"
Skipping installing cert-manager as it is already installed
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"


(devbox) ➜  cluster-api-provider-nutanix git:(jira/NCN-113632) ✗ make test-cc-cluster-create TEST_TOPOLOGY_CLUSTER_NAME=manoj-nkp
-capx
kustomize build templates/overlays/base/basic-auth > templates/cluster-template.yaml
kustomize build templates/overlays/csi3/basic-auth > templates/cluster-template-csi3.yaml
kustomize build templates/clusterclass > templates/cluster-template-clusterclass.yaml
kustomize build templates/overlays/topology/basic-auth > templates/cluster-template-topology.yaml
kustomize build templates/overlays/image-lookup/basic-auth > templates/cluster-template-image-lookup.yaml
kustomize build templates/overlays/failure-domains/basic-auth > templates/cluster-template-failure-domains.yaml
clusterctl generate cluster my-clusterclass --from ./templates/cluster-template-clusterclass.yaml -n ns-topology > my-clusterclass.yaml
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
clusterctl generate cluster manoj-nkp-capx --from ./templates/cluster-template-topology.yaml -n ns-topology > manoj-nkp-capx.yaml
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
Using configuration file="/Users/manoj.surudwad/.cluster-api/clusterctl.yaml"
kubectl create ns ns-topology --dry-run=client -oyaml | kubectl apply --server-side -f -
namespace/ns-topology serverside-applied
kubectl apply --server-side -f ./my-clusterclass.yaml
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/nutanix-quick-start-kcfg-0 serverside-applied
Warning: cluster.x-k8s.io/v1beta1 ClusterClass is deprecated; use cluster.x-k8s.io/v1beta2 ClusterClass
clusterclass.cluster.x-k8s.io/nutanix-quick-start serverside-applied
kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/nutanix-quick-start-kcpt serverside-applied
nutanixclustertemplate.infrastructure.cluster.x-k8s.io/nutanix-quick-start-nct serverside-applied
nutanixmachinetemplate.infrastructure.cluster.x-k8s.io/nutanix-quick-start-cp-nmt serverside-applied
nutanixmachinetemplate.infrastructure.cluster.x-k8s.io/nutanix-quick-start-md-nmt serverside-applied
kubectl apply --server-side -f ./manoj-nkp-capx.yaml
configmap/manoj-nkp-capx-pc-trusted-ca-bundle serverside-applied
configmap/nutanix-ccm serverside-applied
secret/manoj-nkp-capx-pc-creds serverside-applied
secret/nutanix-ccm-secret serverside-applied
Warning: addons.cluster.x-k8s.io/v1beta1 ClusterResourceSet is deprecated; use addons.cluster.x-k8s.io/v1beta2 ClusterResourceSet
clusterresourceset.addons.cluster.x-k8s.io/nutanix-ccm-crs serverside-applied
Warning: cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster
cluster.cluster.x-k8s.io/manoj-nkp-capx serverside-applied
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```