### PR TITLE
fix: resolve NutanixMetroSite in status.failureDomain for Metro FDs

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -1324,6 +1324,23 @@ func getNutanixMetroSiteObject(ctx context.Context, ctlclient client.Client, obj
 	return metroSiteObj, nil
 }
 
+// findMetroSiteForNativeFD returns the name of the NutanixMetroSite in namespace whose
+// spec.metroRef.name matches metroName and spec.preferredFailureDomain.name matches nativeFDName.
+// An empty string is returned (without error) when no match is found; the caller should fall back
+// to the metro-level failure domain name.
+func findMetroSiteForNativeFD(ctx context.Context, ctlclient client.Client, namespace, metroName, nativeFDName string) (string, error) {
+	siteList := &infrav1.NutanixMetroSiteList{}
+	if err := ctlclient.List(ctx, siteList, client.InNamespace(namespace)); err != nil {
+		return "", fmt.Errorf("failed to list NutanixMetroSites in namespace %q: %w", namespace, err)
+	}
+	for _, site := range siteList.Items {
+		if site.Spec.MetroRef.Name == metroName && site.Spec.PreferredFailureDomain.Name == nativeFDName {
+			return site.Name, nil
+		}
+	}
+	return "", nil
+}
+
 // vHADomainName builds the NutanixVirtualHADomain object name for a (cluster, metro) pair. The name
 // is scoped to the cluster so that distinct clusters referencing the same NutanixMetro do not collide
 // on a single object.

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -690,6 +690,28 @@ func (r *NutanixMachineReconciler) checkFailureDomainStatus(rctx *nctx.MachineCo
 		)
 	}
 
+	// For NutanixMetro failure domains, try to refine status.failureDomain to the specific
+	// NutanixMetroSite that corresponds to the native failure domain the VM was placed on.
+	// This makes it possible to observe which site (and therefore which AHV side) each
+	// worker node is running on without having to inspect the metro.nutanix.com/native-failuredomain
+	// label directly.
+	if isNutanixMetroFailureDomain(fd) {
+		metroName := fd[len(metroFailureDomainPrefix):]
+		if nativeFDName, ok := rctx.NutanixMachine.Labels[metroNativeFailureDomainLabelKey]; ok && nativeFDName != "" {
+			siteName, lookupErr := findMetroSiteForNativeFD(
+				rctx.Context, r.Client, rctx.NutanixMachine.Namespace, metroName, nativeFDName,
+			)
+			if lookupErr != nil {
+				ctrl.LoggerFrom(rctx.Context).V(1).Info(
+					"Could not resolve NutanixMetroSite for native failure domain; keeping metro-level failure domain name",
+					"metro", metroName, "nativeFD", nativeFDName, "error", lookupErr,
+				)
+			} else if siteName != "" {
+				fd = metroSiteFailureDomainPrefix + siteName
+			}
+		}
+	}
+
 	// Set the NutanixMachine.status.failureDomain
 	rctx.NutanixMachine.Status.FailureDomain = &fd
 

--- a/controllers/nutanixmachine_failuredomain_test.go
+++ b/controllers/nutanixmachine_failuredomain_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	fdTestNS   = "default"
+	testMetro0 = "metro0"
+	testFD0    = "fd0"
+	testFD1    = "fd1"
+	testSite0  = "metro0-s0"
+	testSite1  = "metro0-s1"
+)
+
+// newTestMetroSite builds a NutanixMetroSite with the given name, metro reference, and preferred
+// failure domain for use in unit tests.
+func newTestMetroSite(name, metroRef, preferredFD, namespace string) *infrav1.NutanixMetroSite {
+	return &infrav1.NutanixMetroSite{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: infrav1.NutanixMetroSiteSpec{
+			MetroRef:               corev1.LocalObjectReference{Name: metroRef},
+			PreferredFailureDomain: corev1.LocalObjectReference{Name: preferredFD},
+		},
+	}
+}
+
+func TestFindMetroSiteForNativeFD(t *testing.T) {
+	tests := []struct {
+		name       string
+		sites      []*infrav1.NutanixMetroSite
+		metroName  string
+		nativeFD   string
+		wantSite   string
+		wantErr    bool
+	}{
+		{
+			name: "returns matching site when metro and preferred fd both match",
+			sites: []*infrav1.NutanixMetroSite{
+				newTestMetroSite(testSite0, testMetro0, testFD0, fdTestNS),
+				newTestMetroSite(testSite1, testMetro0, testFD1, fdTestNS),
+			},
+			metroName: testMetro0,
+			nativeFD:  testFD0,
+			wantSite:  testSite0,
+		},
+		{
+			name: "returns other site when native fd is the second failure domain",
+			sites: []*infrav1.NutanixMetroSite{
+				newTestMetroSite(testSite0, testMetro0, testFD0, fdTestNS),
+				newTestMetroSite(testSite1, testMetro0, testFD1, fdTestNS),
+			},
+			metroName: testMetro0,
+			nativeFD:  testFD1,
+			wantSite:  testSite1,
+		},
+		{
+			name:      "returns empty string when no sites exist",
+			sites:     nil,
+			metroName: testMetro0,
+			nativeFD:  testFD0,
+			wantSite:  "",
+		},
+		{
+			name: "returns empty string when metro name does not match any site",
+			sites: []*infrav1.NutanixMetroSite{
+				newTestMetroSite(testSite0, "other-metro", testFD0, fdTestNS),
+			},
+			metroName: testMetro0,
+			nativeFD:  testFD0,
+			wantSite:  "",
+		},
+		{
+			name: "returns empty string when preferred fd does not match native fd",
+			sites: []*infrav1.NutanixMetroSite{
+				newTestMetroSite(testSite0, testMetro0, testFD1, fdTestNS),
+			},
+			metroName: testMetro0,
+			nativeFD:  testFD0,
+			wantSite:  "",
+		},
+		{
+			name: "ignores sites in a different namespace",
+			sites: []*infrav1.NutanixMetroSite{
+				newTestMetroSite(testSite0, testMetro0, testFD0, "other-ns"),
+			},
+			metroName: testMetro0,
+			nativeFD:  testFD0,
+			wantSite:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := newPlacementScheme(g)
+
+			objs := make([]client.Object, 0, len(tc.sites))
+			for _, s := range tc.sites {
+				objs = append(objs, s)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+			got, err := findMetroSiteForNativeFD(context.Background(), fakeClient, fdTestNS, tc.metroName, tc.nativeFD)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(got).To(Equal(tc.wantSite))
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a NutanixMachine is placed on a Metro failure domain, the status.failureDomain field previously reflected the coarse metro name (NutanixMetro/<name>). Observers had to inspect the metro.nutanix.com/native-failuredomain label to know which AHV site the node was actually running on.

This PR refines status.failureDomain to the specific NutanixMetroSite (NutanixMetroSite/<site-name>) by looking up the
NutanixMetroSite whose spec.metroRef and spec.preferredFailureDomain match the native FD label on the machine. The lookup is best-effort: if no matching site is found the metro-level name is kept unchanged.


Fixes # https://jira.nutanix.com/browse/NCN-114521

**How Has This Been Tested?**:

Deployed capx build with this change in nkp cluster and tested the fix:
kubectl get nutanixmachines : Failure domains pointing to NutanixMetro
<img width="1044" height="161" alt="beforefix" src="https://github.com/user-attachments/assets/cebaa5a2-19ae-41a5-8fc6-1a7a92055d43" />

Capx with change: Deleted one of the machine/nutanixmachine: capi/capx recreated it with proper metro site reference:
<img width="1062" height="152" alt="afterfix" src="https://github.com/user-attachments/assets/466ae5c9-c032-4de5-95e5-06cc759a8dc0" />



**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```