### PR TITLE
fix: nil-pointer panic in the NutanixMachine controller when reconciling before infrastructure ready

### DIFF
--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -487,7 +487,7 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 
 	// Make sure Cluster.Status.InfrastructureReady is true
 	log.Info("Checking if cluster infrastructure is ready")
-	infraReady := rctx.Cluster.Status.Initialization.InfrastructureProvisioned != nil || *rctx.Cluster.Status.Initialization.InfrastructureProvisioned
+	infraReady := rctx.Cluster.Status.Initialization.InfrastructureProvisioned != nil && *rctx.Cluster.Status.Initialization.InfrastructureProvisioned
 	if !infraReady {
 		log.Info("The cluster infrastructure is not ready yet")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.ClusterInfrastructureNotReady, capiv1beta1.ConditionSeverityInfo, "")


### PR DESCRIPTION
**What this PR does / why we need it**:

`reconcileNormal` computes cluster infrastructure readiness with `||` instead of `&&`:

```go
infraReady := rctx.Cluster.Status.Initialization.InfrastructureProvisioned != nil || *rctx.Cluster.Status.Initialization.InfrastructureProvisioned
```

This is wrong in two ways:

1. **nil-pointer panic:** when `InfrastructureProvisioned` is `nil`, the left operand is `false`, so Go evaluates the right operand `*InfrastructureProvisioned` and dereferences the nil `*bool`. This path runs early in cluster provisioning and again right after `clusterctl move` (pivot), when the `Cluster` status is not yet populated, so every affected `NutanixMachine` reconcile panics (recovered by controller-runtime, but it retry-loops and stalls VM provisioning).
2. **inverted logic:** when the pointer is non-nil, `!= nil` short-circuits `true`, so `infraReady` is always `true` regardless of the actual value — treating infra as ready even when `InfrastructureProvisioned == false`.

The fix uses `&&`, matching the guard already written correctly earlier in the same function, so `infraReady` is `true` only when the pointer is set and points to `true`.

Regression introduced by #637  `Cluster.Status.InfrastructureReady` (plain `bool`) with `Status.Initialization.InfrastructureProvisioned` (`*bool`).

**Which issue(s) this PR fixes**:
NCN-115783 

**How Has This Been Tested?**:
`go build ./controllers/...` passes. The change is a one-operator correctness fix; the corrected expression matches the existing, already-correct nil-guard used elsewhere in `reconcileNormal`.

**Special notes for your reviewer**:
Single-line change. Compare against the correct sibling guard earlier in the same function.

Made with [Cursor](https://cursor.com)