### PR TITLE
fix: prevent duplicate VMs for a single machine (NCN-115785)

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -188,15 +188,16 @@ func GenerateProviderID(uuid string) string {
 //     even after the live ExtId later changes.
 //
 // It intentionally does NOT consult Machine.Status.NodeInfo.SystemUUID. That
-// field is the guest-reported (current) biosUUID, which equals the ExtId only at
-// creation time by coincidence: after an unplanned Prism Element failover the
-// ExtId changes (both versions) while the biosUUID either changes (PC 7.5) or
-// stays put (PC 7.6) - in every post-failover case it is not the current ExtId,
-// so feeding it to VMs.Get would miss. The biosUUID still matters for recovery,
-// but note that providerID is itself pinned to the original biosUUID value, so
-// that value doubles as the biosUUID filter during rediscovery (see
-// findVMByStableIdentifier) - which is why SystemUUID is never needed as a direct
-// lookup key here.
+// field is the guest-reported biosUUID, and its relationship to the live ExtId is
+// version-dependent, which makes it an unreliable VMs.Get key: after an unplanned
+// Prism Element failover PC 7.6 keeps the biosUUID pinned to the original value
+// (so it diverges from the new ExtId), while PC 7.5 re-syncs the biosUUID to the
+// new ExtId (so it happens to equal the current ExtId). On top of that it is only
+// populated once the node has registered, so it is absent during initial
+// provisioning. providerID is the better anchor: it is always present once set,
+// stable per the CAPI contract, and its value (the original biosUUID) doubles as
+// the biosUUID filter during rediscovery (see findVMByStableIdentifier) - so
+// SystemUUID is never needed as a direct lookup key here.
 func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
 	vmUUID := nutanixMachine.Status.VmUUID
 	if vmUUID != "" {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -278,10 +278,12 @@ func FindVM(ctx context.Context, client *v4Converged.Client, nutanixMachine *inf
 //   - PC 7.6+: biosUUID is stable across unplanned failover and is server-side
 //     filterable, so it is used as a cheap, precise lookup. The PC version is
 //     fetched here because it is not otherwise available on this path.
-//   - PC 7.5 (and as a universal fallback): biosUUID is neither stable nor
-//     filterable, but the VM name is unchanged across failover and the
-//     provider-id custom attribute survives it. List by name and disambiguate
-//     by that custom attribute.
+//   - PC 7.5 (and as a universal fallback): on unplanned failover the biosUUID
+//     is re-synced to the new ExtId (both change to the same new value), so the
+//     original biosUUID held in recoveryKey no longer matches the VM - a biosUuid
+//     filter would miss even if 7.5 offered one. What does survive failover is the
+//     VM name and the provider-id custom attribute (providerid:<original ExtId>),
+//     so list by name and disambiguate by that custom attribute.
 //
 // Returns (nil, nil) when no VM could be rediscovered so the caller can decide
 // how to proceed (the create-guard in getOrCreateVM ensures this never results

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -182,16 +182,21 @@ func GenerateProviderID(uuid string) string {
 //     CAPX.
 //   - NutanixMachine.Spec.ProviderID: set once at creation and persisted with
 //     the object, so it survives a clusterctl move where status is recreated
-//     empty on the target cluster. It encodes the VM's original ExtId.
+//     empty on the target cluster. Its value is the VM's original ExtId, which
+//     at creation is identical to the VM's biosUUID; because the CAPI contract
+//     requires providerID to be immutable, it stays pinned to that original UUID
+//     even after the live ExtId later changes.
 //
 // It intentionally does NOT consult Machine.Status.NodeInfo.SystemUUID. That
-// field is the guest-reported biosUUID, which equals the ExtId only at creation
-// time by coincidence: after an unplanned Prism Element failover the ExtId
-// changes (both versions) while the biosUUID either changes (PC 7.5) or stays
-// put (PC 7.6) - in every post-failover case it is not the current ExtId, so
-// feeding it to VMs.Get would miss. The biosUUID is still useful, but only as a
-// server-side filter during rediscovery (see findVMByStableIdentifier), never as
-// a lookup key here.
+// field is the guest-reported (current) biosUUID, which equals the ExtId only at
+// creation time by coincidence: after an unplanned Prism Element failover the
+// ExtId changes (both versions) while the biosUUID either changes (PC 7.5) or
+// stays put (PC 7.6) - in every post-failover case it is not the current ExtId,
+// so feeding it to VMs.Get would miss. The biosUUID still matters for recovery,
+// but note that providerID is itself pinned to the original biosUUID value, so
+// that value doubles as the biosUUID filter during rediscovery (see
+// findVMByStableIdentifier) - which is why SystemUUID is never needed as a direct
+// lookup key here.
 func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
 	vmUUID := nutanixMachine.Status.VmUUID
 	if vmUUID != "" {
@@ -262,9 +267,12 @@ func FindVM(ctx context.Context, client *v4Converged.Client, nutanixMachine *inf
 
 // findVMByStableIdentifier rediscovers a VM whose ExtId has changed - for
 // example after an unplanned Prism Element failover - using identifiers that
-// survive the failover. The recovery key is the VM's original ExtId, which is
-// encoded in Spec.ProviderID and is also the value CAPX stamps in the
-// provider-id custom attribute (providerid:<ExtId>).
+// survive the failover. The recovery key is Spec.ProviderID's value: the VM's
+// original ExtId, which at creation equals the VM's biosUUID and, being an
+// immutable providerID, stays pinned to that original UUID. That dual identity
+// is what makes the two strategies below work - the same key is both the biosUUID
+// (stable on PC 7.6) and the value CAPX stamps into the provider-id custom
+// attribute (providerid:<original-ExtId>).
 //
 // Two strategies are combined to cover both supported PC versions:
 //   - PC 7.6+: biosUUID is stable across unplanned failover and is server-side
@@ -290,8 +298,11 @@ func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, n
 	}
 
 	// PC 7.6+ exposes a server-side filter on biosUuid, which is stable across
-	// unplanned failovers. Prefer it when available. A failure to determine the
-	// PC version is non-fatal: fall through to the version-independent path.
+	// unplanned failovers. Since recoveryKey is the original biosUUID and the
+	// biosUUID does not change on 7.6, "biosUuid eq recoveryKey" still matches the
+	// failed-over VM under its new ExtId. Prefer it when available. A failure to
+	// determine the PC version is non-fatal: fall through to the
+	// version-independent path.
 	if pcVersion, verr := client.DomainManager.GetPrismCentralVersion(ctx); verr != nil {
 		log.Error(verr, "failed to get PC version while rediscovering VM; skipping biosUuid lookup")
 	} else if isPCVersionAtLeast76(pcVersion) {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -252,7 +252,7 @@ func FindVM(ctx context.Context, client *v4Converged.Client, machine *capiv1beta
 		// otherwise search via name
 	} else {
 		log.Info(fmt.Sprintf("Searching for VM %s using name", vmName))
-		vm, err := FindVMByName(ctx, client, vmName)
+		vm, err := FindVMByName(ctx, client, nutanixMachine, vmName)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("error occurred finding VM %s by name", vmName))
 			return nil, err
@@ -370,8 +370,13 @@ func isPCVersionAtLeast76(version string) bool {
 	return minor >= 6
 }
 
-// FindVMByName retrieves the VM with the given vm name
-func FindVMByName(ctx context.Context, client *v4Converged.Client, vmName string) (*vmmconfig.Vm, error) {
+// FindVMByName retrieves the VM with the given vm name. When more than one VM
+// shares the name - for example because a duplicate was created by an earlier
+// idempotency gap - it disambiguates instead of dead-locking: it prefers the VM
+// carrying this machine's provider-id custom attribute, and otherwise adopts the
+// oldest matching VM (the VM name is unique per CAPI Machine, so all matches
+// belong to this machine and the duplicate can then be reaped).
+func FindVMByName(ctx context.Context, client *v4Converged.Client, nutanixMachine *infrav1.NutanixMachine, vmName string) (*vmmconfig.Vm, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info(fmt.Sprintf("Checking if VM with name %s exists.", vmName))
 
@@ -380,15 +385,49 @@ func FindVMByName(ctx context.Context, client *v4Converged.Client, vmName string
 		return nil, err
 	}
 
-	if len(vms) > 1 {
-		return nil, fmt.Errorf("error: found more than one (%v) vms with name %s", len(vms), vmName)
-	}
-
 	if len(vms) == 0 {
 		return nil, nil
 	}
 
-	return FindVMByUUID(ctx, client, *vms[0].ExtId)
+	if len(vms) == 1 {
+		return FindVMByUUID(ctx, client, *vms[0].ExtId)
+	}
+
+	// More than one VM matched the name. Historically this returned an error,
+	// which permanently wedged the machine whenever a duplicate VM existed - the
+	// exact situation we want to be able to recover from.
+	log.Info(fmt.Sprintf("found %d VMs with name %s; disambiguating instead of failing", len(vms), vmName))
+
+	// Prefer the VM that carries this machine's provider-id custom attribute.
+	if nutanixMachine != nil && nutanixMachine.Spec.ProviderID != "" {
+		recoveryKey := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+		if vm := matchVMByProviderIDCustomAttribute(vms, recoveryKey); vm != nil {
+			return FindVMByUUID(ctx, client, *vm.ExtId)
+		}
+	}
+
+	// No identity to match against: adopt the oldest VM deterministically so the
+	// machine can make progress; the extra VM(s) can be cleaned up afterwards.
+	oldest := oldestVM(vms)
+	log.Info(fmt.Sprintf("adopting oldest VM (ExtId %s) among %d name matches for %s", *oldest.ExtId, len(vms), vmName))
+	return FindVMByUUID(ctx, client, *oldest.ExtId)
+}
+
+// oldestVM returns the VM with the earliest CreateTime. VMs without a CreateTime
+// are considered newest so a VM with a known creation time is always preferred.
+func oldestVM(vms []vmmconfig.Vm) *vmmconfig.Vm {
+	oldest := &vms[0]
+	for i := 1; i < len(vms); i++ {
+		switch {
+		case vms[i].CreateTime == nil:
+			continue
+		case oldest.CreateTime == nil:
+			oldest = &vms[i]
+		case vms[i].CreateTime.Before(*oldest.CreateTime):
+			oldest = &vms[i]
+		}
+	}
+	return oldest
 }
 
 // GetPEUUID returns the UUID of the Prism Element cluster with the given name or UUID.

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -174,52 +174,41 @@ func GenerateProviderID(uuid string) string {
 	return fmt.Sprintf("%s%s", providerIdPrefix, uuid)
 }
 
-// GetVMUUID returns the VM's ExtId - the identifier Prism Central assigns to the
-// VM and the only value accepted by VMs.Get. It deliberately consults only
-// ExtId-namespace sources, in order of reliability:
-//
-//   - NutanixMachine.Status.VmUUID: the VM's current ExtId as last observed by
-//     CAPX.
-//   - NutanixMachine.Spec.ProviderID: set once at creation and persisted with
-//     the object, so it survives a clusterctl move where status is recreated
-//     empty on the target cluster. Its value is the VM's original ExtId, which
-//     at creation is identical to the VM's biosUUID; because the CAPI contract
-//     requires providerID to be immutable, it stays pinned to that original UUID
-//     even after the live ExtId later changes.
-//
-// It intentionally does NOT consult Machine.Status.NodeInfo.SystemUUID. That
-// field is the guest-reported biosUUID, and its relationship to the live ExtId is
-// version-dependent, which makes it an unreliable VMs.Get key: after an unplanned
-// Prism Element failover PC 7.6 keeps the biosUUID pinned to the original value
-// (so it diverges from the new ExtId), while PC 7.5 re-syncs the biosUUID to the
-// new ExtId (so it happens to equal the current ExtId). On top of that it is only
-// populated once the node has registered, so it is absent during initial
-// provisioning. providerID is the better anchor: it is always present once set,
-// stable per the CAPI contract, and its value (the original biosUUID) doubles as
-// the biosUUID filter during rediscovery (see findVMByStableIdentifier) - so
-// SystemUUID is never needed as a direct lookup key here.
+// providerIDUUID returns the VM ExtId encoded in the machine's spec.providerID,
+// or "" if it is unset or not a real UUID. Cluster templates pre-seed
+// providerID with a non-UUID placeholder ("nutanix://${CLUSTER_NAME}-m1") before
+// the VM exists; that placeholder is treated as "no identity yet". CAPX replaces
+// it with the real "nutanix://<uuid>" once the VM is created, and the CAPI
+// contract keeps it immutable thereafter - so its value is the VM's original
+// ExtId (identical to the biosUUID at creation), which is why it also serves as
+// the rediscovery key in findVMByStableIdentifier.
+func providerIDUUID(nutanixMachine *infrav1.NutanixMachine) string {
+	if nutanixMachine == nil || nutanixMachine.Spec.ProviderID == "" {
+		return ""
+	}
+	id := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+	if _, err := uuid.Parse(id); err != nil {
+		return ""
+	}
+	return id
+}
+
+// GetVMUUID returns the VM's ExtId - the only identifier accepted by VMs.Get -
+// preferring the last-observed status.vmUUID and falling back to spec.providerID
+// (which survives a clusterctl move that recreates status empty). It intentionally
+// ignores Machine.Status.NodeInfo.SystemUUID (the guest biosUUID): that is a
+// different identifier, absent until the node registers, whose relationship to the
+// live ExtId is PC-version dependent, so it is unreliable as a GET key. The
+// biosUUID keeps its role as a rediscovery filter instead (see
+// findVMByStableIdentifier).
 func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
-	vmUUID := nutanixMachine.Status.VmUUID
-	if vmUUID != "" {
+	if vmUUID := nutanixMachine.Status.VmUUID; vmUUID != "" {
 		if _, err := uuid.Parse(vmUUID); err != nil {
 			return "", fmt.Errorf("VMUUID was set but was not a valid UUID: %s err: %w", vmUUID, err)
 		}
 		return vmUUID, nil
 	}
-	if nutanixMachine.Spec.ProviderID != "" {
-		providerUUID := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
-		// Spec.ProviderID may be pre-seeded by a cluster template with a
-		// non-UUID placeholder (the shipped templates set
-		// "nutanix://${CLUSTER_NAME}-m1") before the VM exists. Only treat it
-		// as a VM identity when it parses as a real UUID; otherwise ignore it
-		// and fall through so the machine is resolved by name / created. CAPX
-		// overwrites the placeholder with the real "nutanix://<uuid>" once the
-		// VM is created.
-		if _, err := uuid.Parse(providerUUID); err == nil {
-			return providerUUID, nil
-		}
-	}
-	return "", nil
+	return providerIDUUID(nutanixMachine), nil
 }
 
 // FindVM retrieves the VM with the given uuid or name
@@ -272,48 +261,30 @@ func FindVM(ctx context.Context, client *v4Converged.Client, nutanixMachine *inf
 	}
 }
 
-// findVMByStableIdentifier rediscovers a VM whose ExtId has changed - for
-// example after an unplanned Prism Element failover - using identifiers that
-// survive the failover. The recovery key is Spec.ProviderID's value: the VM's
-// original ExtId, which at creation equals the VM's biosUUID and, being an
-// immutable providerID, stays pinned to that original UUID. That dual identity
-// is what makes the two strategies below work - the same key is both the biosUUID
-// (stable on PC 7.6) and the value CAPX stamps into the provider-id custom
-// attribute (providerid:<original-ExtId>).
+// findVMByStableIdentifier rediscovers a VM whose ExtId changed (e.g. after an
+// unplanned Prism Element failover) using identifiers that outlive the ExtId. The
+// recovery key is the VM's original ExtId from providerID, which doubles as the
+// biosUUID and as the value in the providerid:<ExtId> custom attribute, so one key
+// drives both strategies:
 //
-// Two strategies are combined to cover both supported PC versions:
-//   - PC 7.6+: biosUUID is stable across unplanned failover and is server-side
-//     filterable, so it is used as a cheap, precise lookup. The PC version is
-//     fetched here because it is not otherwise available on this path.
-//   - PC 7.5 (and as a universal fallback): on unplanned failover the biosUUID
-//     is re-synced to the new ExtId (both change to the same new value), so the
-//     original biosUUID held in recoveryKey no longer matches the VM - a biosUuid
-//     filter would miss even if 7.5 offered one. What does survive failover is the
-//     VM name and the provider-id custom attribute (providerid:<original ExtId>),
-//     so list by name and disambiguate by that custom attribute.
+//   - PC 7.6+: the biosUUID is stable across failover and server-side filterable,
+//     so GetVMByBiosUUID resolves the VM (and its clone chain) directly.
+//   - PC 7.5 / universal fallback: the biosUUID is re-synced to the new ExtId on
+//     failover so it no longer matches, but the VM name and the provider-id custom
+//     attribute survive - so list by name and match on that attribute.
 //
-// Returns (nil, nil) when no VM could be rediscovered so the caller can decide
-// how to proceed (the create-guard in getOrCreateVM ensures this never results
-// in a duplicate VM once an identity has been established).
+// Returns (nil, nil) when nothing matches; the create-guard in getOrCreateVM
+// ensures that never yields a duplicate VM.
 func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, nutanixMachine *infrav1.NutanixMachine, vmName string) (*vmmconfig.Vm, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if nutanixMachine.Spec.ProviderID == "" {
-		return nil, nil
-	}
-	recoveryKey := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+	recoveryKey := providerIDUUID(nutanixMachine)
 	if recoveryKey == "" {
 		return nil, nil
 	}
 
-	// PC 7.6+ exposes a server-side filter on biosUuid, which is stable across
-	// unplanned failovers. Since recoveryKey is the original biosUUID and the
-	// biosUUID does not change on 7.6, a biosUuid lookup still matches the
-	// failed-over VM under its new ExtId. Prefer it when available, delegating to
-	// the converged client's GetVMByBiosUUID which also resolves clone chains to
-	// the leaf VM. A failure to determine the PC version, or an inability to
-	// resolve the VM by biosUuid, is non-fatal: fall through to the
-	// version-independent name + provider-id custom attribute lookup below.
+	// PC 7.6+ fast path. Any failure here (version lookup or biosUuid miss) is
+	// non-fatal and falls through to the version-independent lookup below.
 	if pcVersion, verr := client.DomainManager.GetPrismCentralVersion(ctx); verr != nil {
 		log.Error(verr, "failed to get PC version while rediscovering VM; skipping biosUuid lookup")
 	} else if isPCVersionHigherThan75(pcVersion) {
@@ -325,9 +296,6 @@ func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, n
 		}
 	}
 
-	// Universal fallback (and the only option on PC 7.5): the VM name does not
-	// change across failover, so list by name and disambiguate by the
-	// provider-id custom attribute which carries the original ExtId.
 	vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", vmName)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list VMs by name %s while rediscovering VM: %w", vmName, err)
@@ -448,8 +416,7 @@ func FindVMByName(ctx context.Context, client *v4Converged.Client, nutanixMachin
 	log.Info(fmt.Sprintf("found %d VMs with name %s; disambiguating instead of failing", len(vms), vmName))
 
 	// Prefer the VM that carries this machine's provider-id custom attribute.
-	if nutanixMachine != nil && nutanixMachine.Spec.ProviderID != "" {
-		recoveryKey := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+	if recoveryKey := providerIDUUID(nutanixMachine); recoveryKey != "" {
 		if vm := matchVMByProviderIDCustomAttribute(vms, recoveryKey); vm != nil {
 			return FindVMByUUID(ctx, client, *vm.ExtId)
 		}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -208,10 +208,16 @@ func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
 	}
 	if nutanixMachine.Spec.ProviderID != "" {
 		providerUUID := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
-		if _, err := uuid.Parse(providerUUID); err != nil {
-			return "", fmt.Errorf("NutanixMachine.Spec.ProviderID was set but did not contain a valid UUID: %s err: %w", nutanixMachine.Spec.ProviderID, err)
+		// Spec.ProviderID may be pre-seeded by a cluster template with a
+		// non-UUID placeholder (the shipped templates set
+		// "nutanix://${CLUSTER_NAME}-m1") before the VM exists. Only treat it
+		// as a VM identity when it parses as a real UUID; otherwise ignore it
+		// and fall through so the machine is resolved by name / created. CAPX
+		// overwrites the placeholder with the real "nutanix://<uuid>" once the
+		// VM is created.
+		if _, err := uuid.Parse(providerUUID); err == nil {
+			return providerUUID, nil
 		}
-		return providerUUID, nil
 	}
 	return "", nil
 }

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -302,24 +302,20 @@ func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, n
 
 	// PC 7.6+ exposes a server-side filter on biosUuid, which is stable across
 	// unplanned failovers. Since recoveryKey is the original biosUUID and the
-	// biosUUID does not change on 7.6, "biosUuid eq recoveryKey" still matches the
-	// failed-over VM under its new ExtId. Prefer it when available. A failure to
-	// determine the PC version is non-fatal: fall through to the
-	// version-independent path.
+	// biosUUID does not change on 7.6, a biosUuid lookup still matches the
+	// failed-over VM under its new ExtId. Prefer it when available, delegating to
+	// the converged client's GetVMByBiosUUID which also resolves clone chains to
+	// the leaf VM. A failure to determine the PC version, or an inability to
+	// resolve the VM by biosUuid, is non-fatal: fall through to the
+	// version-independent name + provider-id custom attribute lookup below.
 	if pcVersion, verr := client.DomainManager.GetPrismCentralVersion(ctx); verr != nil {
 		log.Error(verr, "failed to get PC version while rediscovering VM; skipping biosUuid lookup")
 	} else if isPCVersionHigherThan75(pcVersion) {
-		vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("biosUuid eq '%s'", recoveryKey)))
-		if err != nil {
-			return nil, fmt.Errorf("failed to list VMs by biosUuid %s while rediscovering VM %s: %w", recoveryKey, vmName, err)
-		}
-		if vm := matchVMByProviderIDCustomAttribute(vms, recoveryKey); vm != nil {
+		if vm, err := client.VMs.GetVMByBiosUUID(ctx, recoveryKey); err != nil {
+			log.Info(fmt.Sprintf("biosUuid lookup did not resolve VM %s (biosUuid %s): %v; falling back to name lookup", vmName, recoveryKey, err))
+		} else {
 			log.Info(fmt.Sprintf("Rediscovered VM %s by biosUuid %s with new ExtId %s", vmName, recoveryKey, *vm.ExtId))
 			return vm, nil
-		}
-		if len(vms) == 1 {
-			log.Info(fmt.Sprintf("Rediscovered VM %s by biosUuid %s with new ExtId %s", vmName, recoveryKey, *vms[0].ExtId))
-			return &vms[0], nil
 		}
 	}
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -308,7 +308,7 @@ func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, n
 	// version-independent path.
 	if pcVersion, verr := client.DomainManager.GetPrismCentralVersion(ctx); verr != nil {
 		log.Error(verr, "failed to get PC version while rediscovering VM; skipping biosUuid lookup")
-	} else if isPCVersionAtLeast76(pcVersion) {
+	} else if isPCVersionHigherThan75(pcVersion) {
 		vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("biosUuid eq '%s'", recoveryKey)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to list VMs by biosUuid %s while rediscovering VM %s: %w", recoveryKey, vmName, err)
@@ -350,37 +350,71 @@ func matchVMByProviderIDCustomAttribute(vms []vmmconfig.Vm, recoveryKey string) 
 	return nil
 }
 
-// isPCVersionAtLeast76 reports whether the given PC version string is 7.6 or
-// newer. PC 7.6 is the first release where biosUUID is stable across unplanned
-// failover and is server-side filterable. Calendar-style releases (202x.x)
-// predate the 7.x line, and unparseable/empty versions return false so callers
-// fall back to version-independent behaviour.
-func isPCVersionAtLeast76(version string) bool {
-	v := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(version)), "pc.")
-	if v == "" {
-		return false
+// CleanPCVersion normalizes a Prism Central version string by trimming whitespace,
+// lower-casing it, and removing the optional "pc." prefix.
+func CleanPCVersion(version string) string {
+	lowerVersion := strings.ToLower(strings.TrimSpace(version))
+	return strings.TrimPrefix(lowerVersion, "pc.")
+}
+
+func convertStringToIntList(str string) []int {
+	strList := strings.Split(str, ".")
+	var intList []int
+	for _, x := range strList {
+		if val, err := strconv.Atoi(x); err != nil {
+			return []int{9999}
+		} else {
+			intList = append(intList, val)
+		}
 	}
-	parts := strings.Split(v, ".")
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return false
+	return intList
+}
+
+// CompareVersions compares version numbers of the format '3.5.2.1'.
+// Returns 0 : if v1 == v2
+// Returns 1 : if v1 > v2
+// Returns -1: if v1 < v2
+//
+// If either version is not in the correct format, they will be the greater,
+// unless neither can be parsed in which case they are equal. The case where a
+// branch can't be parsed is if the cluster is running master, or some other
+// non-release branch, or empty string. This is only expected in a test/debug
+// situation and is the motivation for making an unparseable format greater.
+func CompareVersions(v1, v2 string) int {
+	if strings.EqualFold(v1, "master") {
+		v1 = "9999"
 	}
-	if major >= 2000 {
-		// Calendar-based release (e.g. 2024.x) - older than the 7.x line.
-		return false
+	if strings.EqualFold(v2, "master") {
+		v2 = "9999"
 	}
-	if major != 7 {
-		return major > 7
+
+	v1IntList := convertStringToIntList(v1)
+	v2IntList := convertStringToIntList(v2)
+
+	maxLen := max(len(v1IntList), len(v2IntList))
+
+	v1NormIntList := make([]int, maxLen)
+	v2NormIntList := make([]int, maxLen)
+	copy(v1NormIntList, v1IntList)
+	copy(v2NormIntList, v2IntList)
+
+	for i, e := range v1NormIntList {
+		if e > v2NormIntList[i] {
+			return 1
+		} else if e < v2NormIntList[i] {
+			return -1
+		}
 	}
-	if len(parts) < 2 {
-		// "7" with no minor is treated as < "7.6".
-		return false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return false
-	}
-	return minor >= 6
+	return 0
+}
+
+// isPCVersionHigherThan75 reports whether the given PC version is 7.6 or newer.
+// PC 7.6 is the first release where the biosUUID is stable across an unplanned
+// failover and is server-side filterable. The version may include a "pc." prefix
+// (e.g. "pc.7.6.0.5").
+func isPCVersionHigherThan75(version string) bool {
+	v := CleanPCVersion(version)
+	return CompareVersions(v, "7.6") >= 0
 }
 
 // FindVMByName retrieves the VM with the given vm name. When more than one VM

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -43,7 +43,6 @@ import (
 	v1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/utils/ptr"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint:staticcheck // suppress complaining on Deprecated package
-	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"         //nolint:staticcheck // suppress complaining on Deprecated package
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2" //nolint:staticcheck // suppress complaining on Deprecated package
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -175,16 +174,25 @@ func GenerateProviderID(uuid string) string {
 	return fmt.Sprintf("%s%s", providerIdPrefix, uuid)
 }
 
-// GetVMUUID returns the UUID of the VM.
-func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMachine) (string, error) {
-	// First, try to get the systemUUID from Machine.Status.NodeInfo
-	if machine != nil && machine.Status.NodeInfo != nil && machine.Status.NodeInfo.SystemUUID != "" {
-		systemUUID := machine.Status.NodeInfo.SystemUUID
-		if _, err := uuid.Parse(systemUUID); err != nil {
-			return "", fmt.Errorf("Machine.Status.NodeInfo.SystemUUID was set but was not a valid UUID: %s err: %w", systemUUID, err)
-		}
-		return systemUUID, nil
-	}
+// GetVMUUID returns the VM's ExtId - the identifier Prism Central assigns to the
+// VM and the only value accepted by VMs.Get. It deliberately consults only
+// ExtId-namespace sources, in order of reliability:
+//
+//   - NutanixMachine.Status.VmUUID: the VM's current ExtId as last observed by
+//     CAPX.
+//   - NutanixMachine.Spec.ProviderID: set once at creation and persisted with
+//     the object, so it survives a clusterctl move where status is recreated
+//     empty on the target cluster. It encodes the VM's original ExtId.
+//
+// It intentionally does NOT consult Machine.Status.NodeInfo.SystemUUID. That
+// field is the guest-reported biosUUID, which equals the ExtId only at creation
+// time by coincidence: after an unplanned Prism Element failover the ExtId
+// changes (both versions) while the biosUUID either changes (PC 7.5) or stays
+// put (PC 7.6) - in every post-failover case it is not the current ExtId, so
+// feeding it to VMs.Get would miss. The biosUUID is still useful, but only as a
+// server-side filter during rediscovery (see findVMByStableIdentifier), never as
+// a lookup key here.
+func GetVMUUID(nutanixMachine *infrav1.NutanixMachine) (string, error) {
 	vmUUID := nutanixMachine.Status.VmUUID
 	if vmUUID != "" {
 		if _, err := uuid.Parse(vmUUID); err != nil {
@@ -192,13 +200,6 @@ func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMach
 		}
 		return vmUUID, nil
 	}
-	// Fall back to the provider ID. Status.VmUUID is derived state that can be
-	// lost (for example, after a clusterctl move where the object is recreated
-	// on the target cluster before its status is repopulated), whereas
-	// Spec.ProviderID is set once at creation and persists with the object. It
-	// encodes the VM's original ExtId, so it is a reliable identity anchor when
-	// status is empty. Without this fallback, a status-less reconcile drops to
-	// name-based lookup, which is what allows duplicate VMs to be created.
 	if nutanixMachine.Spec.ProviderID != "" {
 		providerUUID := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
 		if _, err := uuid.Parse(providerUUID); err != nil {
@@ -210,9 +211,9 @@ func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMach
 }
 
 // FindVM retrieves the VM with the given uuid or name
-func FindVM(ctx context.Context, client *v4Converged.Client, machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMachine, vmName string) (*vmmconfig.Vm, error) {
+func FindVM(ctx context.Context, client *v4Converged.Client, nutanixMachine *infrav1.NutanixMachine, vmName string) (*vmmconfig.Vm, error) {
 	log := ctrl.LoggerFrom(ctx)
-	vmUUID, err := GetVMUUID(machine, nutanixMachine)
+	vmUUID, err := GetVMUUID(nutanixMachine)
 	if err != nil {
 		return nil, err
 	}
@@ -224,12 +225,10 @@ func FindVM(ctx context.Context, client *v4Converged.Client, machine *capiv1beta
 			return nil, err
 		}
 		if vm == nil {
-			// The last-known UUID no longer resolves. This is expected when the
+			// The last-known ExtId no longer resolves. This is expected when the
 			// VM's backing Prism Element cluster failed over and the VM was
-			// assigned a new ExtId (PC 7.5), or when we are looking up by the
-			// node's biosUUID which never equals the current ExtId post-failover.
-			// Attempt to rediscover the VM by identifiers that survive failover
-			// before concluding it is gone.
+			// assigned a new ExtId. Attempt to rediscover the VM by identifiers
+			// that survive failover before concluding it is gone.
 			log.Info(fmt.Sprintf("VM %s not found by UUID %s; attempting rediscovery by stable identifiers", vmName, vmUUID))
 			recovered, rerr := findVMByStableIdentifier(ctx, client, nutanixMachine, vmName)
 			if rerr != nil {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -223,7 +224,21 @@ func FindVM(ctx context.Context, client *v4Converged.Client, machine *capiv1beta
 			return nil, err
 		}
 		if vm == nil {
-			return nil, fmt.Errorf("no vm %s found with UUID %s but was expected to be present", vmName, vmUUID)
+			// The last-known UUID no longer resolves. This is expected when the
+			// VM's backing Prism Element cluster failed over and the VM was
+			// assigned a new ExtId (PC 7.5), or when we are looking up by the
+			// node's biosUUID which never equals the current ExtId post-failover.
+			// Attempt to rediscover the VM by identifiers that survive failover
+			// before concluding it is gone.
+			log.Info(fmt.Sprintf("VM %s not found by UUID %s; attempting rediscovery by stable identifiers", vmName, vmUUID))
+			recovered, rerr := findVMByStableIdentifier(ctx, client, nutanixMachine, vmName)
+			if rerr != nil {
+				return nil, rerr
+			}
+			if recovered == nil {
+				return nil, fmt.Errorf("no vm %s found with UUID %s but was expected to be present", vmName, vmUUID)
+			}
+			return recovered, nil
 		}
 		// Check if the VM name matches the Machine name or the NutanixMachine name.
 		// Earlier, we were creating VMs with the same name as the NutanixMachine name.
@@ -244,6 +259,115 @@ func FindVM(ctx context.Context, client *v4Converged.Client, machine *capiv1beta
 		}
 		return vm, nil
 	}
+}
+
+// findVMByStableIdentifier rediscovers a VM whose ExtId has changed - for
+// example after an unplanned Prism Element failover - using identifiers that
+// survive the failover. The recovery key is the VM's original ExtId, which is
+// encoded in Spec.ProviderID and is also the value CAPX stamps in the
+// provider-id custom attribute (providerid:<ExtId>).
+//
+// Two strategies are combined to cover both supported PC versions:
+//   - PC 7.6+: biosUUID is stable across unplanned failover and is server-side
+//     filterable, so it is used as a cheap, precise lookup. The PC version is
+//     fetched here because it is not otherwise available on this path.
+//   - PC 7.5 (and as a universal fallback): biosUUID is neither stable nor
+//     filterable, but the VM name is unchanged across failover and the
+//     provider-id custom attribute survives it. List by name and disambiguate
+//     by that custom attribute.
+//
+// Returns (nil, nil) when no VM could be rediscovered so the caller can decide
+// how to proceed (the create-guard in getOrCreateVM ensures this never results
+// in a duplicate VM once an identity has been established).
+func findVMByStableIdentifier(ctx context.Context, client *v4Converged.Client, nutanixMachine *infrav1.NutanixMachine, vmName string) (*vmmconfig.Vm, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if nutanixMachine.Spec.ProviderID == "" {
+		return nil, nil
+	}
+	recoveryKey := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+	if recoveryKey == "" {
+		return nil, nil
+	}
+
+	// PC 7.6+ exposes a server-side filter on biosUuid, which is stable across
+	// unplanned failovers. Prefer it when available. A failure to determine the
+	// PC version is non-fatal: fall through to the version-independent path.
+	if pcVersion, verr := client.DomainManager.GetPrismCentralVersion(ctx); verr != nil {
+		log.Error(verr, "failed to get PC version while rediscovering VM; skipping biosUuid lookup")
+	} else if isPCVersionAtLeast76(pcVersion) {
+		vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("biosUuid eq '%s'", recoveryKey)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMs by biosUuid %s while rediscovering VM %s: %w", recoveryKey, vmName, err)
+		}
+		if vm := matchVMByProviderIDCustomAttribute(vms, recoveryKey); vm != nil {
+			log.Info(fmt.Sprintf("Rediscovered VM %s by biosUuid %s with new ExtId %s", vmName, recoveryKey, *vm.ExtId))
+			return vm, nil
+		}
+		if len(vms) == 1 {
+			log.Info(fmt.Sprintf("Rediscovered VM %s by biosUuid %s with new ExtId %s", vmName, recoveryKey, *vms[0].ExtId))
+			return &vms[0], nil
+		}
+	}
+
+	// Universal fallback (and the only option on PC 7.5): the VM name does not
+	// change across failover, so list by name and disambiguate by the
+	// provider-id custom attribute which carries the original ExtId.
+	vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", vmName)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list VMs by name %s while rediscovering VM: %w", vmName, err)
+	}
+	if vm := matchVMByProviderIDCustomAttribute(vms, recoveryKey); vm != nil {
+		log.Info(fmt.Sprintf("Rediscovered VM %s by provider-id custom attribute %s with ExtId %s", vmName, recoveryKey, *vm.ExtId))
+		return vm, nil
+	}
+
+	return nil, nil
+}
+
+// matchVMByProviderIDCustomAttribute returns the VM carrying the
+// providerid:<recoveryKey> custom attribute, or nil if none match.
+func matchVMByProviderIDCustomAttribute(vms []vmmconfig.Vm, recoveryKey string) *vmmconfig.Vm {
+	want := vmCustomAttributePrefix4ProviderID + recoveryKey
+	for i := range vms {
+		if slices.Contains(vms[i].CustomAttributes, want) {
+			return &vms[i]
+		}
+	}
+	return nil
+}
+
+// isPCVersionAtLeast76 reports whether the given PC version string is 7.6 or
+// newer. PC 7.6 is the first release where biosUUID is stable across unplanned
+// failover and is server-side filterable. Calendar-style releases (202x.x)
+// predate the 7.x line, and unparseable/empty versions return false so callers
+// fall back to version-independent behaviour.
+func isPCVersionAtLeast76(version string) bool {
+	v := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(version)), "pc.")
+	if v == "" {
+		return false
+	}
+	parts := strings.Split(v, ".")
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	if major >= 2000 {
+		// Calendar-based release (e.g. 2024.x) - older than the 7.x line.
+		return false
+	}
+	if major != 7 {
+		return major > 7
+	}
+	if len(parts) < 2 {
+		// "7" with no minor is treated as < "7.6".
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	return minor >= 6
 }
 
 // FindVMByName retrieves the VM with the given vm name

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -191,6 +191,20 @@ func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMach
 		}
 		return vmUUID, nil
 	}
+	// Fall back to the provider ID. Status.VmUUID is derived state that can be
+	// lost (for example, after a clusterctl move where the object is recreated
+	// on the target cluster before its status is repopulated), whereas
+	// Spec.ProviderID is set once at creation and persists with the object. It
+	// encodes the VM's original ExtId, so it is a reliable identity anchor when
+	// status is empty. Without this fallback, a status-less reconcile drops to
+	// name-based lookup, which is what allows duplicate VMs to be created.
+	if nutanixMachine.Spec.ProviderID != "" {
+		providerUUID := strings.TrimPrefix(nutanixMachine.Spec.ProviderID, providerIdPrefix)
+		if _, err := uuid.Parse(providerUUID); err != nil {
+			return "", fmt.Errorf("NutanixMachine.Spec.ProviderID was set but did not contain a valid UUID: %s err: %w", nutanixMachine.Spec.ProviderID, err)
+		}
+		return providerUUID, nil
+	}
 	return "", nil
 }
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1066,6 +1066,51 @@ func TestReconcileDeleteRediscoversVMAfterFailover(t *testing.T) {
 	assert.Contains(t, err.Error(), "delete boom")
 }
 
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name   string
+		v1, v2 string
+		want   int
+	}{
+		{name: "equal", v1: "7.6", v2: "7.6", want: 0},
+		{name: "equal with trailing zero", v1: "7.6.0", v2: "7.6", want: 0},
+		{name: "greater minor", v1: "7.6", v2: "7.5", want: 1},
+		{name: "lesser minor", v1: "7.5", v2: "7.6", want: -1},
+		{name: "greater patch", v1: "7.6.1", v2: "7.6", want: 1},
+		{name: "master is greatest", v1: "master", v2: "7.6", want: 1},
+		{name: "unparseable is treated as greater", v1: "not-a-version", v2: "7.6", want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CompareVersions(tt.v1, tt.v2))
+		})
+	}
+}
+
+func TestIsPCVersionHigherThan75(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "7.6 is >= 7.6", version: "7.6", want: true},
+		{name: "pc-prefixed 7.6.0 is >= 7.6", version: "pc.7.6.0", want: true},
+		{name: "pc-prefixed 7.6.0.5 is >= 7.6", version: "pc.7.6.0.5", want: true},
+		{name: "7.7 is >= 7.6", version: "7.7", want: true},
+		{name: "8.0 is >= 7.6", version: "8.0", want: true},
+		{name: "7.5 is < 7.6", version: "7.5", want: false},
+		{name: "pc-prefixed 7.5.0.5 is < 7.6", version: "pc.7.5.0.5", want: false},
+		// Unparseable/empty versions are treated as the greater value by
+		// CompareVersions (documented "assume newest" behavior).
+		{name: "empty is treated as >= 7.6", version: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPCVersionHigherThan75(tt.version))
+		})
+	}
+}
+
 func TestGetPEUUID(t *testing.T) {
 	ctx := context.Background()
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -959,10 +959,11 @@ func TestFindVMRediscoversVMAfterFailover(t *testing.T) {
 		// Last-known UUID (the original ExtId) no longer resolves.
 		cc.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, notFound)
 		cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.6.0", nil)
-		// biosUuid filter returns the VM under its new ExtId.
-		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
-			{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
-		}, nil)
+		// biosUuid lookup returns the VM under its new ExtId.
+		cc.MockVMs.EXPECT().GetVMByBiosUUID(gomock.Any(), originalUUID).Return(
+			&vmmModels.Vm{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
+			nil,
+		)
 
 		vm, err := FindVM(ctx, cc.Client, newNutanixMachine(), vmName)
 		require.NoError(t, err)

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -3469,12 +3469,18 @@ func TestGetVMUUID(t *testing.T) {
 			errorMessage: "VMUUID was set but was not a valid UUID",
 		},
 		{
-			name: "returns error when Spec.ProviderID does not contain a valid UUID",
+			name: "ignores non-UUID Spec.ProviderID and returns empty",
 			nutanixMachine: &infrav1.NutanixMachine{
 				Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + invalidUUID},
 			},
-			wantErr:      true,
-			errorMessage: "NutanixMachine.Spec.ProviderID was set but did not contain a valid UUID",
+			want: "",
+		},
+		{
+			name: "ignores template placeholder Spec.ProviderID and returns empty",
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://my-cluster-m1"},
+			},
+			want: "",
 		},
 	}
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1029,6 +1029,43 @@ func TestGetOrCreateVMDoesNotDuplicateWhenProviderIDSet(t *testing.T) {
 	assert.Nil(t, vm)
 }
 
+func TestReconcileDeleteRediscoversVMAfterFailover(t *testing.T) {
+	ctx := context.Background()
+	vmName := "test-machine"
+	staleUUID := "550e8400-e29b-41d4-a716-446655440000"
+	newExtID := "660e8400-e29b-41d4-a716-446655440001"
+	notFound := &converged.APIError{Kind: converged.ErrNotFound, Cause: errors.New("entity not found")}
+
+	ctrl := gomock.NewController(t)
+	cc := NewMockConvergedClient(ctrl)
+	// The last-known ExtId no longer resolves (PE failover reassigned it).
+	cc.MockVMs.EXPECT().Get(gomock.Any(), staleUUID).Return(nil, notFound)
+	// Rediscovery finds the VM under a new ExtId via its provider-id attribute.
+	cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
+	cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
+		{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + staleUUID}},
+	}, nil)
+	// No task in progress for the (correct) new ExtId.
+	cc.MockTasks.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil)
+	// Delete must target the rediscovered ExtId, not the stale one. Returning an
+	// error here short-circuits the reconcile without needing a k8s client for
+	// the finalizer/patch path; the assertion is that DeleteAsync is invoked with
+	// newExtID (gomock fails if it is called with staleUUID or not at all).
+	cc.MockVMs.EXPECT().DeleteAsync(gomock.Any(), newExtID).Return(nil, errors.New("delete boom"))
+
+	r := &NutanixMachineReconciler{}
+	rctx := &nctx.MachineContext{
+		Context:         ctx,
+		Machine:         &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}},
+		NutanixMachine:  &infrav1.NutanixMachine{ObjectMeta: metav1.ObjectMeta{Name: vmName}, Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + staleUUID}},
+		ConvergedClient: cc.Client,
+	}
+
+	_, err := r.reconcileDelete(rctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete boom")
+}
+
 func TestGetPEUUID(t *testing.T) {
 	ctx := context.Background()
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -964,7 +964,7 @@ func TestFindVMRediscoversVMAfterFailover(t *testing.T) {
 			{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
 		}, nil)
 
-		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		vm, err := FindVM(ctx, cc.Client, newNutanixMachine(), vmName)
 		require.NoError(t, err)
 		require.NotNil(t, vm)
 		assert.Equal(t, newExtID, *vm.ExtId)
@@ -980,7 +980,7 @@ func TestFindVMRediscoversVMAfterFailover(t *testing.T) {
 			{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
 		}, nil)
 
-		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		vm, err := FindVM(ctx, cc.Client, newNutanixMachine(), vmName)
 		require.NoError(t, err)
 		require.NotNil(t, vm)
 		assert.Equal(t, newExtID, *vm.ExtId)
@@ -993,7 +993,7 @@ func TestFindVMRediscoversVMAfterFailover(t *testing.T) {
 		cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
 		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil)
 
-		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		vm, err := FindVM(ctx, cc.Client, newNutanixMachine(), vmName)
 		require.Error(t, err)
 		assert.Nil(t, vm)
 		assert.Contains(t, err.Error(), "expected to be present")
@@ -3345,202 +3345,51 @@ func TestGetVMUUID(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		machine        *capiv1beta2.Machine
 		nutanixMachine *infrav1.NutanixMachine
 		want           string
 		wantErr        bool
 		errorMessage   string
 	}{
 		{
-			name: "should return systemUUID from Machine.Status.NodeInfo when available",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: &corev1.NodeSystemInfo{
-						SystemUUID: validUUID,
-					},
-				},
-			},
+			name: "returns status VmUUID when set",
 			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: anotherValidUUID,
-				},
+				Status: infrav1.NutanixMachineStatus{VmUUID: validUUID},
 			},
-			want:    validUUID,
-			wantErr: false,
+			want: validUUID,
 		},
 		{
-			name: "should fall back to VmUUID when Machine.Status.NodeInfo is nil",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: nil,
-				},
-			},
+			name: "falls back to Spec.ProviderID when status UUID is empty",
 			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
+				Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + validUUID},
 			},
-			want:    validUUID,
-			wantErr: false,
+			want: validUUID,
 		},
 		{
-			name: "should fall back to VmUUID when Machine.Status.NodeInfo.SystemUUID is empty",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: &corev1.NodeSystemInfo{
-						SystemUUID: "",
-					},
-				},
-			},
+			name: "prioritizes status VmUUID over Spec.ProviderID",
 			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
+				Spec:   infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + anotherValidUUID},
+				Status: infrav1.NutanixMachineStatus{VmUUID: validUUID},
 			},
-			want:    validUUID,
-			wantErr: false,
+			want: validUUID,
 		},
 		{
-			name:    "should fall back to VmUUID when machine is nil",
-			machine: nil,
-			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
-			},
-			want:    validUUID,
-			wantErr: false,
+			name:           "returns empty string when neither status UUID nor ProviderID is set",
+			nutanixMachine: &infrav1.NutanixMachine{},
+			want:           "",
 		},
 		{
-			name: "should return empty string when both systemUUID and VmUUID are not available",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: nil,
-				},
-			},
+			name: "returns error when status VmUUID is not a valid UUID",
 			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: "",
-				},
+				Status: infrav1.NutanixMachineStatus{VmUUID: invalidUUID},
 			},
-			want:    "",
-			wantErr: false,
-		},
-		{
-			name: "should return error when systemUUID is not a valid UUID",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: &corev1.NodeSystemInfo{
-						SystemUUID: invalidUUID,
-					},
-				},
-			},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: "",
-				},
-			},
-			want:         "",
-			wantErr:      true,
-			errorMessage: "Machine.Status.NodeInfo.SystemUUID was set but was not a valid UUID",
-		},
-		{
-			name: "should return error when VmUUID is not a valid UUID",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: nil,
-				},
-			},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: invalidUUID,
-				},
-			},
-			want:         "",
 			wantErr:      true,
 			errorMessage: "VMUUID was set but was not a valid UUID",
 		},
 		{
-			name: "should prioritize systemUUID even when VmUUID has different UUID",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: &corev1.NodeSystemInfo{
-						SystemUUID: validUUID,
-					},
-				},
-			},
+			name: "returns error when Spec.ProviderID does not contain a valid UUID",
 			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: anotherValidUUID,
-				},
+				Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + invalidUUID},
 			},
-			want:    validUUID,
-			wantErr: false,
-		},
-		{
-			name: "should use VmUUID when SystemUUID is empty",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{
-					NodeInfo: &corev1.NodeSystemInfo{
-						SystemUUID: "",
-					},
-				},
-			},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
-			},
-			want:    validUUID,
-			wantErr: false,
-		},
-		{
-			name: "should handle Machine with empty Status",
-			machine: &capiv1beta2.Machine{
-				Status: capiv1beta2.MachineStatus{},
-			},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
-			},
-			want:    validUUID,
-			wantErr: false,
-		},
-		{
-			name:    "should fall back to Spec.ProviderID when status UUIDs are empty",
-			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Spec: infrav1.NutanixMachineSpec{
-					ProviderID: "nutanix://" + validUUID,
-				},
-			},
-			want:    validUUID,
-			wantErr: false,
-		},
-		{
-			name:    "should prioritize status VmUUID over Spec.ProviderID",
-			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Spec: infrav1.NutanixMachineSpec{
-					ProviderID: "nutanix://" + anotherValidUUID,
-				},
-				Status: infrav1.NutanixMachineStatus{
-					VmUUID: validUUID,
-				},
-			},
-			want:    validUUID,
-			wantErr: false,
-		},
-		{
-			name:    "should return error when Spec.ProviderID does not contain a valid UUID",
-			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
-			nutanixMachine: &infrav1.NutanixMachine{
-				Spec: infrav1.NutanixMachineSpec{
-					ProviderID: "nutanix://" + invalidUUID,
-				},
-			},
-			want:         "",
 			wantErr:      true,
 			errorMessage: "NutanixMachine.Spec.ProviderID was set but did not contain a valid UUID",
 		},
@@ -3549,7 +3398,7 @@ func TestGetVMUUID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Log("Running test case ", tt.name)
-			got, err := GetVMUUID(tt.machine, tt.nutanixMachine)
+			got, err := GetVMUUID(tt.nutanixMachine)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetVMUUID() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	nctx "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/context"
 	mockconverged "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/converged"
 	mockk8sclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/k8sclient"
 	mocknutanixv3 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/nutanix"
@@ -866,6 +867,166 @@ func TestFindVMByUUID(t *testing.T) {
 		require.Nil(t, vm)
 		assert.ErrorIs(t, err, apiErr)
 	})
+}
+
+func TestFindVMByName(t *testing.T) {
+	ctx := context.Background()
+	vmName := "test-machine"
+
+	t.Run("returns nil when no VM matches the name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil)
+
+		vm, err := FindVMByName(ctx, cc.Client, &infrav1.NutanixMachine{}, vmName)
+		require.NoError(t, err)
+		assert.Nil(t, vm)
+	})
+
+	t.Run("returns the VM when exactly one matches", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		ext := "550e8400-e29b-41d4-a716-446655440000"
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).
+			Return([]vmmModels.Vm{{ExtId: ptr.To(ext), Name: ptr.To(vmName)}}, nil)
+		cc.MockVMs.EXPECT().Get(gomock.Any(), ext).
+			Return(&vmmModels.Vm{ExtId: ptr.To(ext), Name: ptr.To(vmName)}, nil)
+
+		vm, err := FindVMByName(ctx, cc.Client, &infrav1.NutanixMachine{}, vmName)
+		require.NoError(t, err)
+		require.NotNil(t, vm)
+		assert.Equal(t, ext, *vm.ExtId)
+	})
+
+	t.Run("on duplicates, prefers the VM carrying this machine's provider-id attribute", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		key := "550e8400-e29b-41d4-a716-446655440000"
+		otherExt := "111e8400-e29b-41d4-a716-446655440111"
+		mineExt := "222e8400-e29b-41d4-a716-446655440222"
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
+			{ExtId: ptr.To(otherExt), Name: ptr.To(vmName)},
+			{ExtId: ptr.To(mineExt), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + key}},
+		}, nil)
+		cc.MockVMs.EXPECT().Get(gomock.Any(), mineExt).
+			Return(&vmmModels.Vm{ExtId: ptr.To(mineExt), Name: ptr.To(vmName)}, nil)
+
+		nm := &infrav1.NutanixMachine{Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + key}}
+		vm, err := FindVMByName(ctx, cc.Client, nm, vmName)
+		require.NoError(t, err)
+		require.NotNil(t, vm)
+		assert.Equal(t, mineExt, *vm.ExtId)
+	})
+
+	t.Run("on duplicates without an identity, adopts the oldest VM", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		newExt := "111e8400-e29b-41d4-a716-446655440111"
+		oldExt := "222e8400-e29b-41d4-a716-446655440222"
+		older := time.Now().Add(-2 * time.Hour)
+		newer := time.Now()
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
+			{ExtId: ptr.To(newExt), Name: ptr.To(vmName), CreateTime: ptr.To(newer)},
+			{ExtId: ptr.To(oldExt), Name: ptr.To(vmName), CreateTime: ptr.To(older)},
+		}, nil)
+		cc.MockVMs.EXPECT().Get(gomock.Any(), oldExt).
+			Return(&vmmModels.Vm{ExtId: ptr.To(oldExt), Name: ptr.To(vmName)}, nil)
+
+		vm, err := FindVMByName(ctx, cc.Client, &infrav1.NutanixMachine{}, vmName)
+		require.NoError(t, err)
+		require.NotNil(t, vm)
+		assert.Equal(t, oldExt, *vm.ExtId)
+	})
+}
+
+func TestFindVMRediscoversVMAfterFailover(t *testing.T) {
+	ctx := context.Background()
+	vmName := "test-machine"
+	originalUUID := "550e8400-e29b-41d4-a716-446655440000"
+	newExtID := "660e8400-e29b-41d4-a716-446655440001"
+	notFound := &converged.APIError{Kind: converged.ErrNotFound, Cause: errors.New("entity not found")}
+
+	newNutanixMachine := func() *infrav1.NutanixMachine {
+		return &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName},
+			Spec:       infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + originalUUID},
+		}
+	}
+
+	t.Run("PC 7.6+ rediscovers by biosUUID after ExtId changed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		// Last-known UUID (the original ExtId) no longer resolves.
+		cc.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, notFound)
+		cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.6.0", nil)
+		// biosUuid filter returns the VM under its new ExtId.
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
+			{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
+		}, nil)
+
+		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		require.NoError(t, err)
+		require.NotNil(t, vm)
+		assert.Equal(t, newExtID, *vm.ExtId)
+	})
+
+	t.Run("PC 7.5 rediscovers by provider-id custom attribute via name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		cc.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, notFound)
+		cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
+		// biosUuid path is skipped on 7.5; recovery lists by name and matches attr.
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{
+			{ExtId: ptr.To(newExtID), Name: ptr.To(vmName), CustomAttributes: []string{"providerid:" + originalUUID}},
+		}, nil)
+
+		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		require.NoError(t, err)
+		require.NotNil(t, vm)
+		assert.Equal(t, newExtID, *vm.ExtId)
+	})
+
+	t.Run("returns an error when the VM cannot be rediscovered", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := NewMockConvergedClient(ctrl)
+		cc.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, notFound)
+		cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
+		cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil)
+
+		vm, err := FindVM(ctx, cc.Client, &capiv1beta2.Machine{}, newNutanixMachine(), vmName)
+		require.Error(t, err)
+		assert.Nil(t, vm)
+		assert.Contains(t, err.Error(), "expected to be present")
+	})
+}
+
+func TestGetOrCreateVMDoesNotDuplicateWhenProviderIDSet(t *testing.T) {
+	ctx := context.Background()
+	vmName := "test-machine"
+	originalUUID := "550e8400-e29b-41d4-a716-446655440000"
+	notFound := &converged.APIError{Kind: converged.ErrNotFound, Cause: errors.New("entity not found")}
+
+	ctrl := gomock.NewController(t)
+	cc := NewMockConvergedClient(ctrl)
+	// The VM is unresolvable: the last-known ExtId misses and no stable
+	// identifier rediscovers it. With an identity already established, the
+	// reconciler must NOT create a second VM. gomock fails the test if
+	// VMs.Create is ever called (no expectation is registered for it).
+	cc.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, notFound)
+	cc.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
+	cc.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil)
+
+	r := &NutanixMachineReconciler{}
+	rctx := &nctx.MachineContext{
+		Context:         ctx,
+		Machine:         &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}},
+		NutanixMachine:  &infrav1.NutanixMachine{ObjectMeta: metav1.ObjectMeta{Name: vmName}, Spec: infrav1.NutanixMachineSpec{ProviderID: "nutanix://" + originalUUID}},
+		ConvergedClient: cc.Client,
+	}
+
+	vm, err := r.getOrCreateVM(rctx)
+	require.Error(t, err)
+	assert.Nil(t, vm)
 }
 
 func TestGetPEUUID(t *testing.T) {
@@ -3345,6 +3506,43 @@ func TestGetVMUUID(t *testing.T) {
 			},
 			want:    validUUID,
 			wantErr: false,
+		},
+		{
+			name:    "should fall back to Spec.ProviderID when status UUIDs are empty",
+			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: "nutanix://" + validUUID,
+				},
+			},
+			want:    validUUID,
+			wantErr: false,
+		},
+		{
+			name:    "should prioritize status VmUUID over Spec.ProviderID",
+			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: "nutanix://" + anotherValidUUID,
+				},
+				Status: infrav1.NutanixMachineStatus{
+					VmUUID: validUUID,
+				},
+			},
+			want:    validUUID,
+			wantErr: false,
+		},
+		{
+			name:    "should return error when Spec.ProviderID does not contain a valid UUID",
+			machine: &capiv1beta2.Machine{Status: capiv1beta2.MachineStatus{}},
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: "nutanix://" + invalidUUID,
+				},
+			},
+			want:         "",
+			wantErr:      true,
+			errorMessage: "NutanixMachine.Spec.ProviderID was set but did not contain a valid UUID",
 		},
 	}
 

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -360,12 +360,42 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	}
 
 	if vm == nil {
+		// The last-known ExtId no longer resolves. Before concluding the VM is
+		// gone and dropping the finalizer - which would orphan a still-running
+		// VM - attempt the same failover rediscovery used on the create path.
+		// This matters when the VM's backing Prism Element cluster failed over
+		// and the VM was reassigned a new ExtId: status.vmUUID/providerID still
+		// hold the stale ExtId while the VM is present under a new one.
+		log.Info(fmt.Sprintf("VM %s not found by UUID %s during delete; attempting rediscovery by stable identifiers", vmName, vmUUID))
+		recovered, rerr := findVMByStableIdentifier(ctx, convergedClient, rctx.NutanixMachine, vmName)
+		if rerr != nil {
+			errorMsg := fmt.Errorf("error rediscovering VM %s after UUID %s did not resolve: %w", vmName, vmUUID, rerr)
+			log.Error(errorMsg, "error finding VM")
+			v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1beta1.ConditionSeverityWarning, "%s", errorMsg.Error())
+			v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
+				Type:    string(infrav1.VMProvisionedCondition),
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.DeletionFailed,
+				Message: errorMsg.Error(),
+			})
+			return reconcile.Result{}, errorMsg
+		}
+		vm = recovered
+	}
+
+	if vm == nil {
 		log.Info(fmt.Sprintf("no VM found with UUID %s: assuming it is already deleted; skipping delete", vmUUID))
 		log.Info(fmt.Sprintf("removing finalizers for VM %s during delete reconciliation", vmName))
 		ctrlutil.RemoveFinalizer(rctx.NutanixMachine, infrav1.NutanixMachineFinalizer)
 		ctrlutil.RemoveFinalizer(rctx.NutanixMachine, infrav1.DeprecatedNutanixMachineFinalizer)
 		return reconcile.Result{}, nil
 	}
+
+	// Normalize to the VM's authoritative ExtId. After a failover the value
+	// resolved from status/providerID can be stale, so every downstream
+	// operation (task check, volume-group detach, delete) must target the ExtId
+	// the VM actually carries now.
+	vmUUID = *vm.ExtId
 
 	// Check if the VM name matches the Machine name or the NutanixMachine name.
 	// Earlier, we were creating VMs with the same name as the NutanixMachine name.

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -329,7 +329,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		Status: metav1.ConditionFalse,
 		Reason: capiv1beta1.DeletingReason,
 	})
-	vmUUID, err := GetVMUUID(rctx.Machine, rctx.NutanixMachine)
+	vmUUID, err := GetVMUUID(rctx.NutanixMachine)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to get VM UUID during delete: %w", err)
 		log.Error(errorMsg, "failed to delete VM")
@@ -1352,7 +1352,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	convergedClient := rctx.ConvergedClient
 
 	// Check if the VM already exists
-	vmFound, err := FindVM(ctx, convergedClient, rctx.Machine, rctx.NutanixMachine, vmName)
+	vmFound, err := FindVM(ctx, convergedClient, rctx.NutanixMachine, vmName)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error occurred finding VM %s by name or uuid", vmName))
 		return nil, err

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -1371,6 +1371,19 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 		return vmFound, nil
 	}
 
+	// Create-guard: never create a VM for a NutanixMachine that already carries an
+	// identity. Spec.ProviderID is set exactly once, right after the VM is created
+	// (see below), and is persisted on the NutanixMachine object. If it is already
+	// set but FindVM could not locate the VM, the VM is temporarily unresolvable
+	// (for example: status lost after a clusterctl pivot, the backing PE cluster
+	// failed over and the VM was assigned a new ExtId, or the caller's List was
+	// transiently filtered by ABAC and returned zero rows). In all of these cases
+	// the correct action is to requeue and retry the lookup, not to create a second
+	// VM. Returning a plain (retryable) error triggers a backoff requeue.
+	if rctx.NutanixMachine.Spec.ProviderID != "" {
+		return nil, fmt.Errorf("VM for machine %s has providerID %s but could not be found; requeueing instead of creating a duplicate VM", vmName, rctx.NutanixMachine.Spec.ProviderID)
+	}
+
 	log.Info(fmt.Sprintf("No existing VM found. Starting creation process of VM %s.", vmName))
 	err = r.validateMachineConfig(rctx)
 	if err != nil {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -1401,17 +1401,27 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 		return vmFound, nil
 	}
 
-	// Create-guard: never create a VM for a NutanixMachine that already carries an
-	// identity. Spec.ProviderID is set exactly once, right after the VM is created
-	// (see below), and is persisted on the NutanixMachine object. If it is already
-	// set but FindVM could not locate the VM, the VM is temporarily unresolvable
-	// (for example: status lost after a clusterctl pivot, the backing PE cluster
+	// Create-guard: never create a VM for a NutanixMachine that already carries a
+	// real VM identity (a valid UUID in Status.VmUUID or Spec.ProviderID). CAPX
+	// records that identity once the VM is created and persists it on the object,
+	// so it survives a clusterctl pivot where status is recreated empty. If an
+	// identity is present but FindVM could not locate the VM, the VM is
+	// temporarily unresolvable (status lost after a pivot, the backing PE cluster
 	// failed over and the VM was assigned a new ExtId, or the caller's List was
 	// transiently filtered by ABAC and returned zero rows). In all of these cases
 	// the correct action is to requeue and retry the lookup, not to create a second
 	// VM. Returning a plain (retryable) error triggers a backoff requeue.
-	if rctx.NutanixMachine.Spec.ProviderID != "" {
-		return nil, fmt.Errorf("VM for machine %s has providerID %s but could not be found; requeueing instead of creating a duplicate VM", vmName, rctx.NutanixMachine.Spec.ProviderID)
+	//
+	// NOTE: this deliberately checks for a valid UUID via GetVMUUID rather than a
+	// non-empty Spec.ProviderID. Cluster templates pre-seed Spec.ProviderID with a
+	// non-UUID placeholder ("nutanix://${CLUSTER_NAME}-m1") before the VM exists;
+	// that placeholder must NOT block the initial creation.
+	existingVMUUID, err := GetVMUUID(rctx.NutanixMachine)
+	if err != nil {
+		return nil, err
+	}
+	if existingVMUUID != "" {
+		return nil, fmt.Errorf("VM for machine %s has UUID %s but could not be found; requeueing instead of creating a duplicate VM", vmName, existingVMUUID)
 	}
 
 	log.Info(fmt.Sprintf("No existing VM found. Starting creation process of VM %s.", vmName))

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -1401,21 +1401,12 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 		return vmFound, nil
 	}
 
-	// Create-guard: never create a VM for a NutanixMachine that already carries a
-	// real VM identity (a valid UUID in Status.VmUUID or Spec.ProviderID). CAPX
-	// records that identity once the VM is created and persists it on the object,
-	// so it survives a clusterctl pivot where status is recreated empty. If an
-	// identity is present but FindVM could not locate the VM, the VM is
-	// temporarily unresolvable (status lost after a pivot, the backing PE cluster
-	// failed over and the VM was assigned a new ExtId, or the caller's List was
-	// transiently filtered by ABAC and returned zero rows). In all of these cases
-	// the correct action is to requeue and retry the lookup, not to create a second
-	// VM. Returning a plain (retryable) error triggers a backoff requeue.
-	//
-	// NOTE: this deliberately checks for a valid UUID via GetVMUUID rather than a
-	// non-empty Spec.ProviderID. Cluster templates pre-seed Spec.ProviderID with a
-	// non-UUID placeholder ("nutanix://${CLUSTER_NAME}-m1") before the VM exists;
-	// that placeholder must NOT block the initial creation.
+	// Create-guard: if the machine already has a real VM identity but FindVM
+	// could not locate the VM, the VM is only temporarily unresolvable (status
+	// lost after a clusterctl pivot, a PE failover reassigned its ExtId, or an
+	// ABAC-filtered List returned zero rows) - requeue and retry rather than
+	// create a duplicate. GetVMUUID keys on a valid UUID, so the non-UUID
+	// providerID placeholder that templates pre-seed does not block first create.
 	existingVMUUID, err := GetVMUUID(rctx.NutanixMachine)
 	if err != nil {
 		return nil, err

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2092,6 +2092,11 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 
 		mockConvergedClient := NewMockConvergedClient(ctrl)
 		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), vmUUID).Return(nil, nil)
+		// The last-known ExtId misses, so delete attempts failover rediscovery
+		// before dropping finalizers. Rediscovery finds nothing here, so the VM
+		// is genuinely gone and finalizers are removed.
+		mockConvergedClient.MockDomainManager.EXPECT().GetPrismCentralVersion(gomock.Any()).Return("pc.7.5.0", nil)
+		mockConvergedClient.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil)
 
 		// Create machine context
 		rctx := &nctx.MachineContext{
@@ -3602,14 +3607,14 @@ func TestNutanixMachineReconciler_assignAddressesToMachine(t *testing.T) {
 }
 
 func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
-	t.Run("should prioritize Machine.Status.NodeInfo.SystemUUID over VmUUID during VM deletion", func(t *testing.T) {
+	t.Run("should ignore Machine.Status.NodeInfo.SystemUUID and use VmUUID during VM deletion", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		ctx := context.Background()
 		vmName := "test-vm"
 		systemUUID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-		vmUUID := "different-uuid-1111-2222-3333-444444444444"
+		vmUUID := "11111111-2222-3333-4444-555555555555"
 
 		// Create NutanixMachine with VmUUID in Status
 		ntnxMachine := &infrav1.NutanixMachine{
@@ -3646,18 +3651,18 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 			},
 		}
 
-		// Create mock VM matching the systemUUID (not VmUUID)
+		// Create mock VM matching the VmUUID (SystemUUID must be ignored now)
 		vm := vmmModels.NewVm()
 		vm.Name = ptr.To(vmName)
-		vm.ExtId = ptr.To(systemUUID)
+		vm.ExtId = ptr.To(vmUUID)
 
 		mockConvergedClient := NewMockConvergedClient(ctrl)
-		// Should get VM by systemUUID, NOT VmUUID
-		mockConvergedClient.MockVMs.EXPECT().Get(ctx, systemUUID).Return(vm, nil)
+		// Should get VM by VmUUID, NOT SystemUUID
+		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(vm, nil)
 		mockConvergedClient.MockTasks.EXPECT().List(ctx, gomock.Any()).Return([]prismModels.Task{}, nil)
 
 		mockOperation := mockconverged.NewMockOperation[converged.NoEntity](ctrl)
-		mockConvergedClient.MockVMs.EXPECT().DeleteAsync(ctx, systemUUID).Return(mockOperation, nil)
+		mockConvergedClient.MockVMs.EXPECT().DeleteAsync(ctx, vmUUID).Return(mockOperation, nil)
 		mockOperation.EXPECT().UUID().Return("task-uuid-123").AnyTimes()
 
 		// Create machine context
@@ -3680,14 +3685,14 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
 	})
 
-	t.Run("should prioritize Machine.Status.NodeInfo.SystemUUID when finding VM", func(t *testing.T) {
+	t.Run("should ignore Machine.Status.NodeInfo.SystemUUID and use VmUUID when finding VM", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		ctx := context.Background()
 		vmName := "test-vm"
 		systemUUID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
-		vmUUID := "different-uuid-1111-2222-3333-444444444444"
+		vmUUID := "11111111-2222-3333-4444-555555555555"
 
 		// Create NutanixMachine with VmUUID in Status
 		ntnxMachine := &infrav1.NutanixMachine{
@@ -3725,10 +3730,10 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		// Mock FindVM to return VM matching systemUUID (already powered on)
 		expectedVm := vmmModels.NewVm()
 		expectedVm.Name = ptr.To(vmName)
-		expectedVm.ExtId = ptr.To(systemUUID)
+		expectedVm.ExtId = ptr.To(vmUUID)
 		expectedVm.PowerState = vmmModels.POWERSTATE_ON.Ref()
-		// Should get VM by systemUUID, NOT VmUUID
-		mockConvergedClient.MockVMs.EXPECT().Get(ctx, systemUUID).Return(expectedVm, nil)
+		// Should get VM by VmUUID, NOT SystemUUID
+		mockConvergedClient.MockVMs.EXPECT().Get(ctx, vmUUID).Return(expectedVm, nil)
 
 		// Create machine context
 		rctx := &nctx.MachineContext{
@@ -3749,7 +3754,7 @@ func TestNutanixMachineReconciler_VMUUIDPrioritization(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, vm)
 		assert.Equal(t, vmName, *vm.Name)
-		assert.Equal(t, systemUUID, *vm.ExtId)
+		assert.Equal(t, vmUUID, *vm.ExtId)
 	})
 
 	t.Run("should fall back to VmUUID when Machine.Status.NodeInfo is nil", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/nutanix-cloud-native/prism-go-client v0.8.0
+	github.com/nutanix-cloud-native/prism-go-client v0.8.1-0.20260713151526-8bc03703d391
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.2.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nutanix-cloud-native/prism-go-client v0.8.0 h1:CYOxciuvis1xq++eQcyMZrDxVO/LQgPpyvUKzMxEO9A=
-github.com/nutanix-cloud-native/prism-go-client v0.8.0/go.mod h1:S5nV4cEuQSGOAv+C+svUuuwAOYX3U/Q/lVwtAIy7tGw=
+github.com/nutanix-cloud-native/prism-go-client v0.8.1-0.20260713151526-8bc03703d391 h1:oyKPZ3WogOIeSQi3H4g5vEdDm2lwBmKVUEsGNjQ1xuM=
+github.com/nutanix-cloud-native/prism-go-client v0.8.1-0.20260713151526-8bc03703d391/go.mod h1:yF7i8BuiQZSa9yyu9l7Wqpa3gpvUHk+M71gTjz4I31o=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2 h1:IctWgmfEJEKX5UL8NOLylPQwM5quK8tbbZF4BuSuSwE=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2/go.mod h1:c52CmT116rC0iLmS11iiTy2cg+j+ifP0X8ZIHwNVefI=
 github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1 h1:gWgUofXXGdXHCBgz3fG7WeQ6dDp4RFUG3kRY8/X0DHY=

--- a/mocks/converged/vms.go
+++ b/mocks/converged/vms.go
@@ -204,6 +204,21 @@ func (mr *MockVMsMockRecorder[VM]) Get(ctx, uuid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVMs[VM])(nil).Get), ctx, uuid)
 }
 
+// GetVMByBiosUUID mocks base method.
+func (m *MockVMs[VM]) GetVMByBiosUUID(ctx context.Context, biosUUID string) (*VM, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMByBiosUUID", ctx, biosUUID)
+	ret0, _ := ret[0].(*VM)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMByBiosUUID indicates an expected call of GetVMByBiosUUID.
+func (mr *MockVMsMockRecorder[VM]) GetVMByBiosUUID(ctx, biosUUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMByBiosUUID", reflect.TypeOf((*MockVMs[VM])(nil).GetVMByBiosUUID), ctx, biosUUID)
+}
+
 // List mocks base method.
 func (m *MockVMs[VM]) List(ctx context.Context, opts ...converged.ODataOption) ([]VM, error) {
 	m.ctrl.T.Helper()

--- a/mocks/nutanix/v3.go
+++ b/mocks/nutanix/v3.go
@@ -876,6 +876,21 @@ func (mr *MockServiceMockRecorder) GetSubnet(ctx, uuid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockService)(nil).GetSubnet), ctx, uuid)
 }
 
+// GetSyncReplicationCapableClusters mocks base method.
+func (m *MockService) GetSyncReplicationCapableClusters(ctx context.Context, request *v3.ClusterSyncReplicationCapableInput) (*v3.ClusterSyncReplicationCapableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSyncReplicationCapableClusters", ctx, request)
+	ret0, _ := ret[0].(*v3.ClusterSyncReplicationCapableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSyncReplicationCapableClusters indicates an expected call of GetSyncReplicationCapableClusters.
+func (mr *MockServiceMockRecorder) GetSyncReplicationCapableClusters(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncReplicationCapableClusters", reflect.TypeOf((*MockService)(nil).GetSyncReplicationCapableClusters), ctx, request)
+}
+
 // GetTask mocks base method.
 func (m *MockService) GetTask(ctx context.Context, taskUUID string) (*v3.TasksResponse, error) {
 	m.ctrl.T.Helper()
@@ -1024,6 +1039,21 @@ func (m *MockService) ListAllAddressGroups(ctx context.Context, filter string) (
 func (mr *MockServiceMockRecorder) ListAllAddressGroups(ctx, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAddressGroups", reflect.TypeOf((*MockService)(nil).ListAllAddressGroups), ctx, filter)
+}
+
+// ListAllAvailabilityZones mocks base method.
+func (m *MockService) ListAllAvailabilityZones(ctx context.Context, filter string) (*v3.AvailabilityZoneListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllAvailabilityZones", ctx, filter)
+	ret0, _ := ret[0].(*v3.AvailabilityZoneListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllAvailabilityZones indicates an expected call of ListAllAvailabilityZones.
+func (mr *MockServiceMockRecorder) ListAllAvailabilityZones(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAvailabilityZones", reflect.TypeOf((*MockService)(nil).ListAllAvailabilityZones), ctx, filter)
 }
 
 // ListAllCategoryValues mocks base method.
@@ -1249,6 +1279,21 @@ func (m *MockService) ListAllVM(ctx context.Context, filter string) (*v3.VMListI
 func (mr *MockServiceMockRecorder) ListAllVM(ctx, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllVM", reflect.TypeOf((*MockService)(nil).ListAllVM), ctx, filter)
+}
+
+// ListAvailabilityZones mocks base method.
+func (m *MockService) ListAvailabilityZones(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.AvailabilityZoneListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAvailabilityZones", ctx, getEntitiesRequest)
+	ret0, _ := ret[0].(*v3.AvailabilityZoneListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAvailabilityZones indicates an expected call of ListAvailabilityZones.
+func (mr *MockServiceMockRecorder) ListAvailabilityZones(ctx, getEntitiesRequest any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockService)(nil).ListAvailabilityZones), ctx, getEntitiesRequest)
 }
 
 // ListCategories mocks base method.


### PR DESCRIPTION
## Summary

CAPX can create a second VM for the same CAPI `Machine`, and can orphan a
still-running VM on delete, whenever the VM's identity cannot be resolved from
its last-known ExtId — for example after a `clusterctl move` (status not yet
repopulated on the target cluster) or after an unplanned Prism Element failover
that reassigns the VM a new ExtId. This PR closes those idempotency gaps and
tightens VM identity resolution, with unit tests throughout.

Jira: [NCN-115785](https://jira.nutanix.com/browse/NCN-115785)

## Changes

- **create-guard (`getOrCreateVM`)**: never create a VM for a `NutanixMachine`
  that already carries `spec.providerID`; requeue and retry instead.
- **identity fallback (`GetVMUUID`)**: when `status.vmUUID` is empty, fall back
  to `spec.providerID` instead of dropping to name-based lookup.
- **failover rediscovery (`FindVM`)**: when the last-known ExtId no longer
  resolves, rediscover the VM via the server-side `biosUuid` filter on PC 7.6+
  and the `providerid:<ExtId>` custom attribute via name on PC 7.5 / as a
  universal fallback.
- **disambiguation (`FindVMByName`)**: when multiple VMs share a name, prefer the
  one carrying this machine's provider-id custom attribute, otherwise adopt the
  oldest deterministically instead of dead-locking.
- **ExtId-only identity resolution (`GetVMUUID`)**: stop returning the
  guest-reported biosUUID (`Machine.Status.NodeInfo.SystemUUID`) as a lookup
  key. It shares the ExtId value only at creation; after a failover it is never
  the current ExtId, so feeding it to `VMs.Get` misses. `GetVMUUID` now consults
  only ExtId-namespace sources (`status.vmUUID`, then `spec.providerID`); the
  biosUUID keeps its legitimate role as a rediscovery filter.
- **delete-path rediscovery (`reconcileDelete`)**: before concluding a VM is
  already deleted and dropping the finalizer, attempt the same failover
  rediscovery and normalize to the VM's current ExtId — otherwise a post-failover
  delete orphans a running VM.

## Tests
Dev-PC self-hosted (clusterctl move) e2e with a TAM-provisioned PC user: SelfHostedSpec passed (1/1). A VM watcher polled PC throughout creation, pivot, and cleanup: exactly one control-plane VM and one worker VM were created (peak 2), no duplicate VM names/ExtIds were observed, the pivoted CAPX controller issued no VM creates, and teardown left no test VMs.