### PR TITLE
fix: preserve kubelet eviction-hard and tls-cipher-suites args on control-plane nodes

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -54,7 +54,7 @@ releaseSeries:
     contract: v1beta1
   - major: 1
     minor: 10
-    contract: v1beta1  
+    contract: v1beta1
   - major: 0
     minor: 0
     contract: v1beta1

--- a/templates/base/ccm-patch.yaml
+++ b/templates/base/ccm-patch.yaml
@@ -1,41 +1,6 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-kind: KubeadmControlPlane
-metadata:
-  name: "${CLUSTER_NAME}-kcp"
-spec:
-  kubeadmConfigSpec:
-    clusterConfiguration:
-      controllerManager:
-        extraArgs:
-          - name: cloud-provider
-            value: external
-    initConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          - name: cloud-provider
-            value: external
-    joinConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          - name: cloud-provider
-            value: external
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
     ccm: "nutanix"
   name: "${CLUSTER_NAME}"
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-kind: KubeadmConfigTemplate
-metadata:
-  name: "${CLUSTER_NAME}-kcfg-0"
-spec:
-  template:
-    spec:
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            - name: cloud-provider
-              value: external

--- a/templates/base/kcp.yaml
+++ b/templates/base/kcp.yaml
@@ -32,6 +32,8 @@ spec:
             value: "${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}"
       controllerManager:
         extraArgs:
+          - name: cloud-provider
+            value: external
           - name: tls-cipher-suites
             value: "${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}"
       scheduler:
@@ -106,6 +108,8 @@ spec:
           # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
+          - name: cloud-provider
+            value: external
           - name: eviction-hard
             value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
           - name: tls-cipher-suites
@@ -116,6 +120,8 @@ spec:
           # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
+          - name: cloud-provider
+            value: external
           - name: eviction-hard
             value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
           - name: tls-cipher-suites

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -1696,7 +1696,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: kube-system
 stringData:
-  credentials: |
+  credentials: |-
     [
       {
         "type": "basic_auth",
@@ -1704,7 +1704,8 @@ stringData:
           "prismCentral":{
             "username": "${NUTANIX_USER}",
             "password": "${NUTANIX_PASSWORD}"
-          }
+          },
+          "prismElements": null
         }
       }
     ]
@@ -1935,8 +1936,8 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-        - name: eviction-hard
-          value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
+        - name: tls-cipher-suites
+          value: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       scheduler:
         extraArgs:
         - name: tls-cipher-suites

--- a/templates/cluster-template-failure-domains.yaml
+++ b/templates/cluster-template-failure-domains.yaml
@@ -235,7 +235,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 stringData:
-  credentials: |
+  credentials: |-
     [
       {
         "type": "basic_auth",
@@ -243,7 +243,8 @@ stringData:
           "prismCentral":{
             "username": "${NUTANIX_USER}",
             "password": "${NUTANIX_PASSWORD}"
-          }
+          },
+          "prismElements": null
         }
       }
     ]
@@ -432,8 +433,8 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-        - name: eviction-hard
-          value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
+        - name: tls-cipher-suites
+          value: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       scheduler:
         extraArgs:
         - name: tls-cipher-suites

--- a/templates/cluster-template-image-lookup.yaml
+++ b/templates/cluster-template-image-lookup.yaml
@@ -235,7 +235,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 stringData:
-  credentials: |
+  credentials: |-
     [
       {
         "type": "basic_auth",
@@ -243,7 +243,8 @@ stringData:
           "prismCentral":{
             "username": "${NUTANIX_USER}",
             "password": "${NUTANIX_PASSWORD}"
-          }
+          },
+          "prismElements": null
         }
       }
     ]
@@ -431,8 +432,8 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-        - name: eviction-hard
-          value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
+        - name: tls-cipher-suites
+          value: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       scheduler:
         extraArgs:
         - name: tls-cipher-suites

--- a/templates/cluster-template-topology.yaml
+++ b/templates/cluster-template-topology.yaml
@@ -232,7 +232,7 @@ kind: Secret
 metadata:
   name: ${CLUSTER_NAME}-pc-creds
 stringData:
-  credentials: |
+  credentials: |-
     [
       {
         "type": "basic_auth",
@@ -240,7 +240,8 @@ stringData:
           "prismCentral":{
             "username": "${NUTANIX_USER}",
             "password": "${NUTANIX_PASSWORD}"
-          }
+          },
+          "prismElements": null
         }
       }
     ]

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -235,7 +235,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 stringData:
-  credentials: |
+  credentials: |-
     [
       {
         "type": "basic_auth",
@@ -243,7 +243,8 @@ stringData:
           "prismCentral":{
             "username": "${NUTANIX_USER}",
             "password": "${NUTANIX_PASSWORD}"
-          }
+          },
+          "prismElements": null
         }
       }
     ]
@@ -431,8 +432,8 @@ spec:
         extraArgs:
         - name: cloud-provider
           value: external
-        - name: eviction-hard
-          value: nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%,memory.available<100Mi,imagefs.inodesFree<10%
+        - name: tls-cipher-suites
+          value: ${TLS_CIPHER_SUITES=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}
       scheduler:
         extraArgs:
         - name: tls-cipher-suites


### PR DESCRIPTION
## Summary

`templates/base/ccm-patch.yaml` is a strategic-merge patch that set `kubeletExtraArgs` and `controllerManager.extraArgs` on the base `KubeadmControlPlane`/`KubeadmConfigTemplate`. Since #718 migrated these fields from v1beta1 **maps** to v1beta2 **lists** of `{name, value}`, kustomize has no OpenAPI merge-key for these CRD list fields, so the patch **replaces** the list instead of merging it. `kustomize build` therefore silently dropped the base entries:

- control-plane `initConfiguration`/`joinConfiguration` `kubeletExtraArgs` lost `eviction-hard` and `tls-cipher-suites` (only `cloud-provider` survived)
- `controllerManager.extraArgs` lost `tls-cipher-suites`

The checked-in `cluster-template*.yaml` still carried the old entries because they were **never regenerated after #718**, which hid the regression from anyone not running `make cluster-templates`.

## Fix

- Inline `cloud-provider: external` directly into `templates/base/kcp.yaml` (`initConfiguration`/`joinConfiguration` `kubeletExtraArgs` and `controllerManager.extraArgs`), matching what `kct.yaml` and the `clusterclass` templates already do.
- Reduce `ccm-patch.yaml` to just the Cluster `ccm: nutanix` label. With no strategic-merge on the list fields, the base args are preserved.
- Regenerated all flavors via `make cluster-templates` (output is idempotent).

Rendered control-plane `kubeletExtraArgs` now correctly contain `cloud-provider`, `eviction-hard`, and `tls-cipher-suites`; `controllerManager.extraArgs` now correctly contains `cloud-provider` + `tls-cipher-suites`.

### Incidental
Regeneration also re-syncs a pre-existing, unrelated drift in `secret.yaml` (explicit `"prismElements": null` and block-scalar chomping `|` → `|-`) that had likewise never been regenerated. No functional change.

## Test plan
- [x] `make cluster-templates` is idempotent (re-running produces no diff)
- [x] `clusterclass` template unchanged (already inlined these args)
- [x] Cluster `ccm: nutanix` label + CCM ClusterResourceSet selector intact
- [ ] e2e green

Made with [Cursor](https://cursor.com)