### PR TITLE
feat: Garbage-collect orphaned CAPX VMs

### DIFF
--- a/controllers/nutanixcluster_controller.go
+++ b/controllers/nutanixcluster_controller.go
@@ -145,7 +145,9 @@ func (r *NutanixClusterReconciler) mapNutanixFailureDomainToNutanixCluster() han
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixmachines,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixfailuredomains,verbs=get;list;watch
@@ -373,7 +375,8 @@ func (r *NutanixClusterReconciler) reconcileNormal(rctx *nctx.ClusterContext) (r
 
 	if rctx.NutanixCluster.Status.Ready {
 		log.Info("NutanixCluster is already in ready status.")
-		return reconcile.Result{}, nil
+		r.garbageCollectOrphanedVMs(rctx)
+		return reconcile.Result{RequeueAfter: orphanedVMGCInterval}, nil
 	}
 
 	err := r.reconcileCategories(rctx)
@@ -384,7 +387,17 @@ func (r *NutanixClusterReconciler) reconcileNormal(rctx *nctx.ClusterContext) (r
 	}
 
 	rctx.NutanixCluster.Status.Ready = true
-	return reconcile.Result{}, nil
+	r.garbageCollectOrphanedVMs(rctx)
+	return reconcile.Result{RequeueAfter: orphanedVMGCInterval}, nil
+}
+
+// garbageCollectOrphanedVMs runs the orphaned-VM garbage collector for the cluster. It is
+// best-effort: failures are logged but never fail the reconcile, since the periodic resync retries.
+func (r *NutanixClusterReconciler) garbageCollectOrphanedVMs(rctx *nctx.ClusterContext) {
+	log := ctrl.LoggerFrom(rctx.Context)
+	if err := garbageCollectOrphanedVMs(rctx.Context, r.Client, rctx.ConvergedClient, rctx.Cluster.Name, rctx.Cluster.Namespace); err != nil {
+		log.Error(err, "failed to garbage-collect orphaned VMs; will retry on next resync")
+	}
 }
 
 // reconcileVHADomains ensures a NutanixVirtualHADomain CR exists for every NutanixMetro referenced

--- a/controllers/vm_garbage_collector.go
+++ b/controllers/vm_garbage_collector.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/nutanix-cloud-native/prism-go-client/converged"
+	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
+	vmmconfig "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/utils/ptr"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+)
+
+const (
+	// orphanedVMGCGracePeriod is the minimum age a candidate VM must have before the orphaned-VM
+	// garbage collector will delete it. It guards against racing with in-flight VM provisioning
+	// (a freshly created VM whose owning NutanixMachine has not yet recorded its UUID).
+	orphanedVMGCGracePeriod = 15 * time.Minute
+
+	// orphanedVMGCInterval is how often the NutanixCluster reconciler re-enqueues itself so the
+	// orphaned-VM garbage collector runs. Orphans can appear from events that do not touch the
+	// NutanixCluster object (e.g. a Prism Element rejoining Prism Central after a site failover),
+	// so a periodic resync is what drives their cleanup.
+	orphanedVMGCInterval = 10 * time.Minute
+)
+
+// garbageCollectOrphanedVMs deletes CAPX-provisioned VMs of the given cluster that are no longer
+// tracked by any NutanixMachine.
+//
+// Background (ENG-945088): in a metro/vHA site-failover, a manually powered-off worker VM is replaced
+// by Cluster API and its NutanixMachine is deleted while the peer Prism Element is disconnected. The
+// delete only reaches the reachable PE; the stale copy frozen on the disconnected PE resurfaces when
+// that PE rejoins Prism Central. Because the owning NutanixMachine (and its finalizer) is already
+// gone, nothing reconciles the resurfaced VM and it leaks. This GC reaps such orphans. The same
+// mechanism also cleans up VMs leaked by any other path that leaves a CAPX VM without an owning
+// NutanixMachine, so it is cluster-scoped rather than metro-specific.
+//
+// It is deliberately conservative: a VM is only deleted when it (1) carries this cluster's ownership
+// category, (2) carries the CAPX providerID custom attribute (i.e. CAPX created it), (3) is older
+// than the grace period, and (4) matches no live NutanixMachine/Machine by UUID or name.
+func garbageCollectOrphanedVMs(
+	ctx context.Context,
+	k8sClient client.Client,
+	convergedClient *v4Converged.Client,
+	clusterName, namespace string,
+) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Resolve the cluster-ownership category (KubernetesClusterName=<clusterName>) that CAPX stamps
+	// on every VM it creates. If it is absent, CAPX has not created any VM for this cluster yet.
+	category, err := getCategory(ctx, convergedClient, infrav1.DefaultCAPICategoryKeyForName, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve cluster category %s=%s: %w", infrav1.DefaultCAPICategoryKeyForName, clusterName, err)
+	}
+	if category == nil || category.ExtId == nil {
+		log.V(1).Info("cluster ownership category not found; skipping orphaned VM GC", "cluster", clusterName)
+		return nil
+	}
+	categoryExtId := *category.ExtId
+
+	// List all VMs requesting only the fields the GC needs and match the cluster ownership
+	// category client-side in isOrphanedCAPXVM.
+	vms, err := convergedClient.VMs.List(ctx,
+		converged.WithSelect("extId,name,customAttributes,createTime,categories/extId"))
+	if err != nil {
+		return fmt.Errorf("failed to list VMs for cluster %s: %w", clusterName, err)
+	}
+	if len(vms) == 0 {
+		return nil
+	}
+
+	// Build the set of VM UUIDs and names still owned by a live NutanixMachine/Machine in this cluster.
+	expectedUUIDs, expectedNames, err := managedVMIdentifiers(ctx, k8sClient, clusterName, namespace)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for i := range vms {
+		vm := &vms[i]
+		if !isOrphanedCAPXVM(vm, categoryExtId, expectedUUIDs, expectedNames) {
+			continue
+		}
+		vmName := ptr.Deref(vm.Name, "")
+		vmUUID := ptr.Deref(vm.ExtId, "")
+		log.Info("Deleting orphaned CAPX VM not tracked by any NutanixMachine",
+			"cluster", clusterName, "vmName", vmName, "vmUUID", vmUUID)
+		if _, delErr := DeleteVM(ctx, convergedClient, vmName, vmUUID); delErr != nil {
+			errs = append(errs, fmt.Errorf("failed to delete orphaned VM %s (%s): %w", vmName, vmUUID, delErr))
+		}
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+// managedVMIdentifiers returns the set of VM UUIDs and VM names that are still owned by a live
+// NutanixMachine/Machine of the given cluster. VM names are collected from both the NutanixMachine
+// (legacy naming) and its owning CAPI Machine (current naming), matching how VMs are located
+// elsewhere.
+func managedVMIdentifiers(
+	ctx context.Context,
+	k8sClient client.Client,
+	clusterName, namespace string,
+) (map[string]struct{}, map[string]struct{}, error) {
+	uuids := map[string]struct{}{}
+	names := map[string]struct{}{}
+
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{capiv1beta2.ClusterNameLabel: clusterName},
+	}
+
+	nmList := &infrav1.NutanixMachineList{}
+	if err := k8sClient.List(ctx, nmList, listOpts...); err != nil {
+		return nil, nil, fmt.Errorf("failed to list NutanixMachines for cluster %s: %w", clusterName, err)
+	}
+	for i := range nmList.Items {
+		nm := &nmList.Items[i]
+		if nm.Status.VmUUID != "" {
+			uuids[nm.Status.VmUUID] = struct{}{}
+		}
+		if nm.Spec.ProviderID != "" {
+			uuids[strings.TrimPrefix(nm.Spec.ProviderID, providerIdPrefix)] = struct{}{}
+		}
+		names[nm.Name] = struct{}{}
+	}
+
+	mList := &capiv1beta2.MachineList{}
+	if err := k8sClient.List(ctx, mList, listOpts...); err != nil {
+		return nil, nil, fmt.Errorf("failed to list Machines for cluster %s: %w", clusterName, err)
+	}
+	for i := range mList.Items {
+		names[mList.Items[i].Name] = struct{}{}
+	}
+
+	return uuids, names, nil
+}
+
+// isOrphanedCAPXVM reports whether vm is a CAPX-provisioned VM of this cluster that is no longer
+// tracked by any live NutanixMachine/Machine and is therefore safe to garbage-collect.
+func isOrphanedCAPXVM(vm *vmmconfig.Vm, categoryExtId string, expectedUUIDs, expectedNames map[string]struct{}) bool {
+	// The cluster ownership category is the primary ownership signal.
+	if !slices.ContainsFunc(vm.Categories, func(c vmmconfig.CategoryReference) bool {
+		return c.ExtId != nil && *c.ExtId == categoryExtId
+	}) {
+		return false
+	}
+
+	// Only reap VMs CAPX itself provisioned (they carry the providerID custom attribute).
+	if !slices.ContainsFunc(vm.CustomAttributes, func(attr string) bool {
+		return strings.HasPrefix(attr, vmCustomAttributePrefix4ProviderID)
+	}) {
+		return false
+	}
+
+	// Avoid racing with in-flight provisioning: skip VMs younger than the grace period.
+	if vm.CreateTime != nil && time.Since(*vm.CreateTime) < orphanedVMGCGracePeriod {
+		return false
+	}
+
+	// Still managed if its UUID or name maps to a live NutanixMachine/Machine.
+	if vm.ExtId != nil {
+		if _, ok := expectedUUIDs[*vm.ExtId]; ok {
+			return false
+		}
+	}
+	if vm.Name != nil {
+		if _, ok := expectedNames[*vm.Name]; ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/controllers/vm_garbage_collector_test.go
+++ b/controllers/vm_garbage_collector_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nutanix-cloud-native/prism-go-client/converged"
+	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	vmmModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	mockconverged "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/converged"
+)
+
+const (
+	gcNamespace   = "default"
+	gcClusterName = "test-cluster"
+)
+
+func newGCFakeClient(g *WithT, objs ...client.Object) client.Client {
+	scheme := newVHAScheme(g)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// gcVM builds a VM with the given identity, optionally stamped with the cluster ownership category
+// and the CAPX providerID custom attribute, and created createdAgo in the past.
+func gcVM(name, extID, categoryExtID string, withCategory, withProviderID bool, createdAgo time.Duration) *vmmModels.Vm {
+	vm := vmmModels.NewVm()
+	vm.Name = ptr.To(name)
+	vm.ExtId = ptr.To(extID)
+	if withCategory {
+		vm.Categories = []vmmModels.CategoryReference{{ExtId: ptr.To(categoryExtID)}}
+	}
+	if withProviderID {
+		vm.CustomAttributes = []string{vmCustomAttributePrefix4ProviderID + extID}
+	}
+	created := time.Now().Add(-createdAgo)
+	vm.CreateTime = &created
+	return vm
+}
+
+func TestIsOrphanedCAPXVM(t *testing.T) {
+	const catExt = "cat-ext-id"
+
+	tests := []struct {
+		name          string
+		vm            *vmmModels.Vm
+		expectedUUIDs map[string]struct{}
+		expectedNames map[string]struct{}
+		want          bool
+	}{
+		{
+			name: "orphan is reaped",
+			vm:   gcVM("node-orphan", "uuid-orphan", catExt, true, true, time.Hour),
+			want: true,
+		},
+		{
+			name: "not CAPX provisioned (no providerID attribute)",
+			vm:   gcVM("node-orphan", "uuid-orphan", catExt, true, false, time.Hour),
+			want: false,
+		},
+		{
+			name: "missing cluster category",
+			vm:   gcVM("node-orphan", "uuid-orphan", catExt, false, true, time.Hour),
+			want: false,
+		},
+		{
+			name: "within creation grace period",
+			vm:   gcVM("node-new", "uuid-new", catExt, true, true, time.Minute),
+			want: false,
+		},
+		{
+			name:          "still managed by UUID",
+			vm:            gcVM("node-live", "uuid-live", catExt, true, true, time.Hour),
+			expectedUUIDs: map[string]struct{}{"uuid-live": {}},
+			want:          false,
+		},
+		{
+			name:          "still managed by name",
+			vm:            gcVM("node-live", "uuid-live", catExt, true, true, time.Hour),
+			expectedNames: map[string]struct{}{"node-live": {}},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			uuids := tt.expectedUUIDs
+			if uuids == nil {
+				uuids = map[string]struct{}{}
+			}
+			names := tt.expectedNames
+			if names == nil {
+				names = map[string]struct{}{}
+			}
+			g.Expect(isOrphanedCAPXVM(tt.vm, catExt, uuids, names)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestGarbageCollectOrphanedVMs_DeletesOnlyOrphan(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const catExt = "cat-ext-id"
+
+	// A live worker still tracked by a NutanixMachine + Machine.
+	liveNM := &infrav1.NutanixMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-live",
+			Namespace: gcNamespace,
+			Labels:    map[string]string{capiv1beta2.ClusterNameLabel: gcClusterName},
+		},
+		Status: infrav1.NutanixMachineStatus{VmUUID: "uuid-live"},
+	}
+	liveMachine := &capiv1beta2.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-live",
+			Namespace: gcNamespace,
+			Labels:    map[string]string{capiv1beta2.ClusterNameLabel: gcClusterName},
+		},
+	}
+
+	k8sClient := newGCFakeClient(g, liveNM, liveMachine)
+
+	mockConverged := NewMockConvergedClient(ctrl)
+
+	// getCategory resolves the cluster ownership category.
+	mockConverged.MockCategories.EXPECT().List(ctx, gomock.Any()).Return([]prismModels.Category{{
+		ExtId: ptr.To(catExt),
+		Key:   ptr.To(infrav1.DefaultCAPICategoryKeyForName),
+		Value: ptr.To(gcClusterName),
+	}}, nil)
+
+	// The category-filtered VM list returns the live VM and one orphan.
+	liveVM := gcVM("node-live", "uuid-live", catExt, true, true, time.Hour)
+	orphanVM := gcVM("node-orphan", "uuid-orphan", catExt, true, true, time.Hour)
+	mockConverged.MockVMs.EXPECT().List(ctx, gomock.Any()).Return([]vmmModels.Vm{*liveVM, *orphanVM}, nil)
+
+	// Only the orphan must be deleted.
+	delOp := mockconverged.NewMockOperation[converged.NoEntity](ctrl)
+	delOp.EXPECT().UUID().Return("delete-task-uuid")
+	mockConverged.MockVMs.EXPECT().DeleteAsync(ctx, "uuid-orphan").Return(delOp, nil)
+
+	g.Expect(garbageCollectOrphanedVMs(ctx, k8sClient, mockConverged.Client, gcClusterName, gcNamespace)).To(Succeed())
+}
+
+func TestGarbageCollectOrphanedVMs_NoCategoryNoOp(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sClient := newGCFakeClient(g)
+
+	mockConverged := NewMockConvergedClient(ctrl)
+	// Category not found -> the GC must be a no-op and never list VMs.
+	mockConverged.MockCategories.EXPECT().List(ctx, gomock.Any()).Return([]prismModels.Category{}, nil)
+
+	g.Expect(garbageCollectOrphanedVMs(ctx, k8sClient, mockConverged.Client, gcClusterName, gcNamespace)).To(Succeed())
+}
+
+func TestManagedVMIdentifiers(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	nm := &infrav1.NutanixMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nm-1",
+			Namespace: gcNamespace,
+			Labels:    map[string]string{capiv1beta2.ClusterNameLabel: gcClusterName},
+		},
+		Spec:   infrav1.NutanixMachineSpec{ProviderID: "nutanix://uuid-from-providerid"},
+		Status: infrav1.NutanixMachineStatus{VmUUID: "uuid-from-status"},
+	}
+	machine := &capiv1beta2.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine-1",
+			Namespace: gcNamespace,
+			Labels:    map[string]string{capiv1beta2.ClusterNameLabel: gcClusterName},
+		},
+	}
+
+	k8sClient := newGCFakeClient(g, nm, machine)
+
+	uuids, names, err := managedVMIdentifiers(ctx, k8sClient, gcClusterName, gcNamespace)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(uuids).To(HaveKey("uuid-from-status"))
+	g.Expect(uuids).To(HaveKey("uuid-from-providerid"))
+	g.Expect(names).To(HaveKey("nm-1"))
+	g.Expect(names).To(HaveKey("machine-1"))
+}


### PR DESCRIPTION
Adds a cluster-scoped garbage collector that deletes Nutanix VMs which CAPX created but
which are no longer tracked by any `NutanixMachine`/`Machine`. This heals VM leaks such as
the metro/vHA site-failover case in ENG-945088, where a manually powered-off worker VM is
replaced by Cluster API and its `NutanixMachine` is deleted while the peer Prism Element is
disconnected — so the delete only reaches the reachable PE, and the stale copy resurfaces
on the other PE (with no owning `NutanixMachine` left to reconcile it) once it rejoins Prism
Central.

The GC lives in the `NutanixCluster` reconciler (not the vHA controller) because the
ownership signal — the `KubernetesClusterName=<clusterName>` category CAPX stamps on every
VM — is cluster-scoped, so the same leak can occur outside metro. This makes the cleanup
generic across all clusters.

## Safety / conservatism
A VM is deleted only when **all** of the following hold:
1. it carries this cluster's ownership category (`KubernetesClusterName=<clusterName>`);
2. it carries the CAPX `providerid:` custom attribute (i.e. CAPX created it);
3. it is older than `orphanedVMGCGracePeriod` (15m) — guards against racing in-flight
   provisioning where the owning `NutanixMachine` hasn't recorded the UUID yet;
4. its UUID and name match no live `NutanixMachine`/`Machine`.
Tunables: `orphanedVMGCGracePeriod = 15m`, `orphanedVMGCInterval = 10m`.

### End-to-end on a live cluster (KIND mgmt cluster + real Prism Central)
Validated against a running workload cluster (`ns-topology/mycluster-without-topology`):
1. **Build/deploy the provider with the change**: rebuilt the manager image from the working
   tree and loaded it into the KIND management cluster (`kind load`), then restarted
   `capx-controller-manager` (avoided `make deploy`, which does `clusterctl delete
   --include-crd` and would tear down existing CRs).
2. **Create a disposable worker**: scaled the worker `MachineDeployment` to 1. Confirmed via
   the Prism v4 API that the new VM carried the ownership category
   `KubernetesClusterName=mycluster-without-topology` and the custom attribute
   `providerid:<vmUUID>`.
3. **Manufacture a real orphan** (reproduces the leak without needing an actual site-down):
   - scaled `capx-controller-manager` to 0 (so the normal delete path can't remove the VM),
   - excluded node draining on the Machine, scaled the `MachineDeployment` to 0,
   - removed the `NutanixMachine` finalizer so the `NutanixMachine` and `Machine` objects were
     deleted while the VM survived in Prism → a VM with the category + `providerid:` and no
     owning k8s objects.
4. **Run the GC**: scaled `capx-controller-manager` back to 1 and forced a `NutanixCluster`
   reconcile. (For a fast loop, `orphanedVMGCGracePeriod`/`orphanedVMGCInterval` were
   temporarily shortened, then reverted to 15m/10m.)
5. **Result**:
   - Log: `Deleting orphaned CAPX VM not tracked by any NutanixMachine`
     `vmName=mycluster-without-topology-wmd-... vmUUID=86e1be62-...`
   - Orphan VM → Prism v4 GET returns **404** (deleted).
   - Live control-plane VM → Prism v4 GET returns **200** (untouched — no false positives).
   - Cluster remained healthy; no GC errors on subsequent resyncs.

## Risk / rollout notes
- Every `NutanixCluster` now resyncs every `orphanedVMGCInterval` (10m) instead of going idle
  after `Ready`. This is intentional (needed to drive drift/orphan detection) and is a mild
  load change.
- The GC is best-effort and heavily gated (category + providerID + age + no live owner), so
  the blast radius is limited to CAPX-created, untracked VMs.