### PR TITLE
feat: guard for one vha category per vm

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -1448,21 +1448,51 @@ func getVHADomainCategory(mctx *nctx.MachineContext, ctlclient client.Client) (*
 	return nil, fmt.Errorf("not found vHADomain category for NutanixMachine")
 }
 
-// countVMVHADomainCategories returns the number of categories assigned to the VM that have the
-// vHADomain key (VHADomainDefaultCategoryKey, i.e. "k8s-vha-native-site"). The VM's category
-// references only carry the category extId, so the vHADomain categories are first resolved from
-// Prism Central by key and matched against the VM's assigned category extIds.
-func countVMVHADomainCategories(ctx context.Context, client *v4Converged.Client, vm *vmmconfig.Vm) (int, error) {
-	vhaCategories, err := client.Categories.List(ctx, converged.WithFilter(fmt.Sprintf("key eq '%s'", VHADomainDefaultCategoryKey)))
+// clusterVHADomainCategoryExtIds resolves the vHADomain categories (key VHADomainDefaultCategoryKey,
+// i.e. "k8s-vha-native-site") declared in the movement groups of the NutanixCluster's owned
+// NutanixVirtualHADomain CRs to their Prism Central extIds. Only the categories referenced by this
+// cluster's vHADomain CRs are resolved (a handful of targeted lookups), so this stays cheap even when
+// Prism Central hosts hundreds of metro clusters sharing the "k8s-vha-native-site" key.
+func clusterVHADomainCategoryExtIds(mctx *nctx.MachineContext, ctlclient client.Client) (map[string]struct{}, error) {
+	vHADomains, err := getOwnedVHADomains(mctx.Context, ctlclient, mctx.NutanixCluster)
 	if err != nil {
-		return 0, fmt.Errorf("failed to list categories with key %q: %w", VHADomainDefaultCategoryKey, err)
+		return nil, err
 	}
 
-	vhaExtIds := make(map[string]struct{}, len(vhaCategories))
-	for i := range vhaCategories {
-		if vhaCategories[i].ExtId != nil {
-			vhaExtIds[*vhaCategories[i].ExtId] = struct{}{}
+	extIds := map[string]struct{}{}
+	for _, vhaDomain := range vHADomains {
+		for _, mg := range vhaDomain.Spec.MovementGroups {
+			for i := range mg.CategoryRecoveryPlans {
+				category := mg.CategoryRecoveryPlans[i].Category
+				// Defensive: the vHADomain categories are keyed by VHADomainDefaultCategoryKey; skip
+				// anything else so an unexpected mapping cannot inflate the count.
+				if category.Key != VHADomainDefaultCategoryKey {
+					continue
+				}
+				prismCategory, err := getCategory(mctx.Context, mctx.ConvergedClient, category.Key, category.Value)
+				if err != nil {
+					return nil, fmt.Errorf("vHADomain %s: failed to resolve category (key:%s, value:%s) from Prism Central: %w", vhaDomain.Name, category.Key, category.Value, err)
+				}
+				if prismCategory == nil || prismCategory.ExtId == nil {
+					continue
+				}
+				extIds[*prismCategory.ExtId] = struct{}{}
+			}
 		}
+	}
+
+	return extIds, nil
+}
+
+// countVMVHADomainCategories returns the number of categories assigned to the VM that are vHADomain
+// categories (key VHADomainDefaultCategoryKey, i.e. "k8s-vha-native-site") belonging to the
+// NutanixCluster's own vHADomain CRs. It traverses the VM's assigned category extIds and matches them
+// against the cluster's vHADomain category extIds, instead of listing every "k8s-vha-native-site"
+// category in Prism Central (which is costly when many metro clusters share the key).
+func countVMVHADomainCategories(mctx *nctx.MachineContext, ctlclient client.Client, vm *vmmconfig.Vm) (int, error) {
+	vhaExtIds, err := clusterVHADomainCategoryExtIds(mctx, ctlclient)
+	if err != nil {
+		return 0, err
 	}
 
 	count := 0

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -1447,3 +1447,34 @@ func getVHADomainCategory(mctx *nctx.MachineContext, ctlclient client.Client) (*
 
 	return nil, fmt.Errorf("not found vHADomain category for NutanixMachine")
 }
+
+// countVMVHADomainCategories returns the number of categories assigned to the VM that have the
+// vHADomain key (VHADomainDefaultCategoryKey, i.e. "k8s-vha-native-site"). The VM's category
+// references only carry the category extId, so the vHADomain categories are first resolved from
+// Prism Central by key and matched against the VM's assigned category extIds.
+func countVMVHADomainCategories(ctx context.Context, client *v4Converged.Client, vm *vmmconfig.Vm) (int, error) {
+	vhaCategories, err := client.Categories.List(ctx, converged.WithFilter(fmt.Sprintf("key eq '%s'", VHADomainDefaultCategoryKey)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to list categories with key %q: %w", VHADomainDefaultCategoryKey, err)
+	}
+
+	vhaExtIds := make(map[string]struct{}, len(vhaCategories))
+	for i := range vhaCategories {
+		if vhaCategories[i].ExtId != nil {
+			vhaExtIds[*vhaCategories[i].ExtId] = struct{}{}
+		}
+	}
+
+	count := 0
+	for i := range vm.Categories {
+		extId := vm.Categories[i].ExtId
+		if extId == nil {
+			continue
+		}
+		if _, ok := vhaExtIds[*extId]; ok {
+			count++
+		}
+	}
+
+	return count, nil
+}

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -713,14 +713,14 @@ func (r *NutanixMachineReconciler) checkVHADomainCategory(rctx *nctx.MachineCont
 		return nil
 	}
 
-	count, err := countVMVHADomainCategories(rctx.Context, rctx.ConvergedClient, vm)
+	count, err := countVMVHADomainCategories(rctx, r.Client, vm)
 	if err != nil {
 		return err
 	}
 
 	if count != 1 {
 		return fmt.Errorf(
-			"the Metro VM %s must have one and only one category with the vHADomain key %q, but found %d",
+			"the Metro VM %s must have one and only one category with the vHADomain key %q from the cluster's vHADomain, but found %d",
 			rctx.Machine.Name, VHADomainDefaultCategoryKey, count,
 		)
 	}

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -539,6 +539,13 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 		return reconcile.Result{}, err
 	}
 
+	// In case of the Metro use case, make sure the VM has one and only one category with the
+	// vHADomain key "k8s-vha-native-site".
+	if err = r.checkVHADomainCategory(rctx, vm); err != nil {
+		log.Error(err, "Failed to check the VHADomainCategory for the VM")
+		return reconcile.Result{}, err
+	}
+
 	log.V(1).Info(fmt.Sprintf("Patching machine post creation vmUUID: %s", rctx.NutanixMachine.Status.VmUUID))
 	if err := r.patchMachine(rctx); err != nil {
 		errorMsg := fmt.Errorf("failed to patch NutanixMachine %s after creation: %w", rctx.NutanixMachine.Name, err)
@@ -692,6 +699,31 @@ func (r *NutanixMachineReconciler) checkFailureDomainStatus(rctx *nctx.MachineCo
 
 	// Set the NutanixMachine.status.failureDomain
 	rctx.NutanixMachine.Status.FailureDomain = &fd
+
+	return nil
+}
+
+// checkVHADomainCategory enforces the implicit contract that a Metro VM carries one and only one
+// category with the vHADomain key "k8s-vha-native-site". This contract is relied on by CSI and NKP
+// for k8s-HA. It is a no-op when the Machine is not configured with a NutanixMetro/NutanixMetroSite
+// failureDomain.
+func (r *NutanixMachineReconciler) checkVHADomainCategory(rctx *nctx.MachineContext, vm *vmmconfig.Vm) error {
+	if !isNutanixMetroFailureDomain(rctx.Machine.Spec.FailureDomain) &&
+		!isNutanixMetroSiteFailureDomain(rctx.Machine.Spec.FailureDomain) {
+		return nil
+	}
+
+	count, err := countVMVHADomainCategories(rctx.Context, rctx.ConvergedClient, vm)
+	if err != nil {
+		return err
+	}
+
+	if count != 1 {
+		return fmt.Errorf(
+			"the Metro VM %s must have one and only one category with the vHADomain key %q, but found %d",
+			rctx.Machine.Name, VHADomainDefaultCategoryKey, count,
+		)
+	}
 
 	return nil
 }

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -4208,3 +4208,178 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		g.Expect(nutanixMachine.Status.VmUUID).To(Equal(validUUID1), "VmUUID should be set to SystemUUID (not vmExtId)")
 	})
 }
+
+// vhaVM builds a VM whose Categories reference the given category extIds.
+func vhaVM(name string, categoryExtIds ...string) *vmmModels.Vm {
+	vm := vmmModels.NewVm()
+	vm.Name = ptr.To(name)
+	vm.ExtId = ptr.To("vm-" + name)
+	refs := make([]vmmModels.CategoryReference, 0, len(categoryExtIds))
+	for _, extId := range categoryExtIds {
+		refs = append(refs, vmmModels.CategoryReference{ExtId: ptr.To(extId)})
+	}
+	vm.Categories = refs
+	return vm
+}
+
+// TestCountVMVHADomainCategories asserts that only the categories carrying the vHADomain contract key
+// ("k8s-vha-native-site") are counted, regardless of any other categories assigned to the VM. This is
+// the core of the implicit CSI/NKP k8s-HA contract: the count must be exactly 1 for a Metro VM.
+func TestCountVMVHADomainCategories(t *testing.T) {
+	const (
+		vhaExtA   = "vha-ext-a"
+		vhaExtB   = "vha-ext-b"
+		otherExt1 = "other-ext-1"
+		otherExt2 = "other-ext-2"
+	)
+
+	// The Prism Central categories that carry the vHADomain contract key.
+	vhaCategories := []prismModels.Category{
+		{ExtId: ptr.To(vhaExtA), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-0")},
+		{ExtId: ptr.To(vhaExtB), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-1")},
+	}
+
+	tests := []struct {
+		name string
+		vm   *vmmModels.Vm
+		want int
+	}{
+		{
+			name: "no categories",
+			vm:   vhaVM("n0"),
+			want: 0,
+		},
+		{
+			name: "only non-vha categories",
+			vm:   vhaVM("n1", otherExt1, otherExt2),
+			want: 0,
+		},
+		{
+			name: "exactly one vha category (contract satisfied)",
+			vm:   vhaVM("n2", otherExt1, vhaExtA),
+			want: 1,
+		},
+		{
+			name: "two vha categories (contract violated)",
+			vm:   vhaVM("n3", vhaExtA, vhaExtB, otherExt1),
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			mockClient := NewMockConvergedClient(ctrl)
+			mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(vhaCategories, nil)
+
+			got, err := countVMVHADomainCategories(ctx, mockClient.Client, tt.vm)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCountVMVHADomainCategories_ListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockClient := NewMockConvergedClient(ctrl)
+	mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(nil, errors.New("boom"))
+
+	_, err := countVMVHADomainCategories(ctx, mockClient.Client, vhaVM("n"))
+	require.Error(t, err)
+}
+
+// TestCheckVHADomainCategory enforces the implicit CSI/NKP k8s-HA contract at reconcile time: a Metro
+// VM must carry one and only one category with the vHADomain key "k8s-vha-native-site". The check is a
+// no-op for non-Metro machines.
+func TestCheckVHADomainCategory(t *testing.T) {
+	const (
+		vhaExtA   = "vha-ext-a"
+		vhaExtB   = "vha-ext-b"
+		otherExt1 = "other-ext-1"
+	)
+
+	vhaCategories := []prismModels.Category{
+		{ExtId: ptr.To(vhaExtA), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-0")},
+		{ExtId: ptr.To(vhaExtB), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-1")},
+	}
+
+	tests := []struct {
+		name          string
+		failureDomain string
+		vm            *vmmModels.Vm
+		expectList    bool
+		wantErr       bool
+	}{
+		{
+			name:          "non-metro machine is a no-op",
+			failureDomain: "some-zone",
+			vm:            vhaVM("n", vhaExtA, vhaExtB),
+			expectList:    false,
+			wantErr:       false,
+		},
+		{
+			name:          "metro VM with exactly one vha category passes",
+			failureDomain: metroFailureDomainPrefix + "metro-1",
+			vm:            vhaVM("n", otherExt1, vhaExtA),
+			expectList:    true,
+			wantErr:       false,
+		},
+		{
+			name:          "metro VM with no vha category fails",
+			failureDomain: metroFailureDomainPrefix + "metro-1",
+			vm:            vhaVM("n", otherExt1),
+			expectList:    true,
+			wantErr:       true,
+		},
+		{
+			name:          "metro VM with two vha categories fails",
+			failureDomain: metroFailureDomainPrefix + "metro-1",
+			vm:            vhaVM("n", vhaExtA, vhaExtB),
+			expectList:    true,
+			wantErr:       true,
+		},
+		{
+			name:          "metroSite VM with exactly one vha category passes",
+			failureDomain: metroSiteFailureDomainPrefix + "site-1",
+			vm:            vhaVM("n", vhaExtA),
+			expectList:    true,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			mockClient := NewMockConvergedClient(ctrl)
+			if tt.expectList {
+				mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(vhaCategories, nil)
+			}
+
+			rctx := &nctx.MachineContext{
+				Context:         ctx,
+				ConvergedClient: mockClient.Client,
+				Machine: &capiv1beta2.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: "default"},
+					Spec:       capiv1beta2.MachineSpec{FailureDomain: tt.failureDomain},
+				},
+			}
+
+			r := &NutanixMachineReconciler{}
+			err := r.checkVHADomainCategory(rctx, tt.vm)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -4222,22 +4222,93 @@ func vhaVM(name string, categoryExtIds ...string) *vmmModels.Vm {
 	return vm
 }
 
-// TestCountVMVHADomainCategories asserts that only the categories carrying the vHADomain contract key
-// ("k8s-vha-native-site") are counted, regardless of any other categories assigned to the VM. This is
-// the core of the implicit CSI/NKP k8s-HA contract: the count must be exactly 1 for a Metro VM.
-func TestCountVMVHADomainCategories(t *testing.T) {
-	const (
-		vhaExtA   = "vha-ext-a"
-		vhaExtB   = "vha-ext-b"
-		otherExt1 = "other-ext-1"
-		otherExt2 = "other-ext-2"
-	)
+const (
+	vhaTestNamespace   = "default"
+	vhaTestNtnxCluster = "test-ntnxcluster"
+	vhaCatValue0       = "k8s-vha-capx-d1-default-0"
+	vhaCatValue1       = "k8s-vha-capx-d1-default-1"
+	vhaCatExt0         = "vha-ext-a"
+	vhaCatExt1         = "vha-ext-b"
+)
 
-	// The Prism Central categories that carry the vHADomain contract key.
-	vhaCategories := []prismModels.Category{
-		{ExtId: ptr.To(vhaExtA), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-0")},
-		{ExtId: ptr.To(vhaExtB), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-1")},
+// vhaTestNutanixCluster returns a NutanixCluster used as the owner of the vHADomain CRs.
+func vhaTestNutanixCluster() *infrav1.NutanixCluster {
+	return &infrav1.NutanixCluster{
+		TypeMeta:   metav1.TypeMeta{Kind: infrav1.NutanixClusterKind, APIVersion: infrav1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: vhaTestNtnxCluster, Namespace: vhaTestNamespace, UID: "ntnx-cluster-uid"},
 	}
+}
+
+// vhaOwnedDomain returns a NutanixVirtualHADomain owned by the given NutanixCluster whose
+// cluster-scope movement group maps the two vHADomain categories (key k8s-vha-native-site).
+func vhaOwnedDomain(ncl *infrav1.NutanixCluster) *infrav1.NutanixVirtualHADomain {
+	return &infrav1.NutanixVirtualHADomain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "d1",
+			Namespace: vhaTestNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       infrav1.NutanixClusterKind,
+				Name:       ncl.Name,
+				UID:        ncl.UID,
+			}},
+		},
+		Spec: infrav1.NutanixVirtualHADomainSpec{
+			MovementGroups: []infrav1.NutanixMovementGroup{{
+				Name: clusterScopeMovementGroupName,
+				CategoryRecoveryPlans: []infrav1.NutanixCategoryRecoveryPlan{
+					{
+						Category:         infrav1.NutanixCategoryIdentifier{Key: VHADomainDefaultCategoryKey, Value: vhaCatValue0},
+						FailureDomainRef: corev1.LocalObjectReference{Name: "fd-0"},
+					},
+					{
+						Category:         infrav1.NutanixCategoryIdentifier{Key: VHADomainDefaultCategoryKey, Value: vhaCatValue1},
+						FailureDomainRef: corev1.LocalObjectReference{Name: "fd-1"},
+					},
+				},
+			}},
+		},
+	}
+}
+
+// expectVHACategoryLookups wires the per-category getCategory (Categories.List by key+value) lookups
+// for the cluster's vHADomain CR, resolving each value to its extId. This mirrors the targeted
+// lookups the check performs instead of listing every "k8s-vha-native-site" category in PC.
+func expectVHACategoryLookups(mockClient *MockConvergedClientWrapper) {
+	byValue := map[string]string{
+		vhaCatValue0: vhaCatExt0,
+		vhaCatValue1: vhaCatExt1,
+	}
+	mockClient.MockCategories.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, opts ...converged.ODataOption) ([]prismModels.Category, error) {
+			for value, extId := range byValue {
+				if filterContains(opts, "value eq '"+value+"'") {
+					return []prismModels.Category{{
+						ExtId: ptr.To(extId),
+						Key:   ptr.To(VHADomainDefaultCategoryKey),
+						Value: ptr.To(value),
+					}}, nil
+				}
+			}
+			return []prismModels.Category{}, nil
+		},
+	).AnyTimes()
+}
+
+// filterContains reports whether the OData filter built from opts contains sub.
+func filterContains(opts []converged.ODataOption, sub string) bool {
+	params, err := v4Converged.OptsToV4ODataParams(opts...)
+	if err != nil || params.Filter == nil {
+		return false
+	}
+	return strings.Contains(*params.Filter, sub)
+}
+
+// TestCountVMVHADomainCategories asserts that only the categories belonging to the cluster's vHADomain
+// CR (key "k8s-vha-native-site") are counted, regardless of any other categories assigned to the VM.
+// This is the core of the implicit CSI/NKP k8s-HA contract: the count must be exactly 1 for a Metro VM.
+func TestCountVMVHADomainCategories(t *testing.T) {
+	const otherExt = "other-ext-1"
 
 	tests := []struct {
 		name string
@@ -4251,17 +4322,17 @@ func TestCountVMVHADomainCategories(t *testing.T) {
 		},
 		{
 			name: "only non-vha categories",
-			vm:   vhaVM("n1", otherExt1, otherExt2),
+			vm:   vhaVM("n1", otherExt, "other-ext-2"),
 			want: 0,
 		},
 		{
 			name: "exactly one vha category (contract satisfied)",
-			vm:   vhaVM("n2", otherExt1, vhaExtA),
+			vm:   vhaVM("n2", otherExt, vhaCatExt0),
 			want: 1,
 		},
 		{
 			name: "two vha categories (contract violated)",
-			vm:   vhaVM("n3", vhaExtA, vhaExtB, otherExt1),
+			vm:   vhaVM("n3", vhaCatExt0, vhaCatExt1, otherExt),
 			want: 2,
 		},
 	}
@@ -4273,82 +4344,100 @@ func TestCountVMVHADomainCategories(t *testing.T) {
 
 			ctx := context.Background()
 			mockClient := NewMockConvergedClient(ctrl)
-			mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(vhaCategories, nil)
+			expectVHACategoryLookups(mockClient)
 
-			got, err := countVMVHADomainCategories(ctx, mockClient.Client, tt.vm)
+			ncl := vhaTestNutanixCluster()
+			ctlClient := newVHACtlClient(t, ncl, vhaOwnedDomain(ncl))
+
+			rctx := &nctx.MachineContext{
+				Context:         ctx,
+				ConvergedClient: mockClient.Client,
+				NutanixCluster:  ncl,
+			}
+
+			got, err := countVMVHADomainCategories(rctx, ctlClient, tt.vm)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestCountVMVHADomainCategories_ListError(t *testing.T) {
+func TestCountVMVHADomainCategories_CategoryLookupError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	ctx := context.Background()
 	mockClient := NewMockConvergedClient(ctrl)
-	mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(nil, errors.New("boom"))
+	mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(nil, errors.New("boom")).AnyTimes()
 
-	_, err := countVMVHADomainCategories(ctx, mockClient.Client, vhaVM("n"))
+	ncl := vhaTestNutanixCluster()
+	ctlClient := newVHACtlClient(t, ncl, vhaOwnedDomain(ncl))
+
+	rctx := &nctx.MachineContext{
+		Context:         ctx,
+		ConvergedClient: mockClient.Client,
+		NutanixCluster:  ncl,
+	}
+
+	_, err := countVMVHADomainCategories(rctx, ctlClient, vhaVM("n", vhaCatExt0))
 	require.Error(t, err)
 }
 
-// TestCheckVHADomainCategory enforces the implicit CSI/NKP k8s-HA contract at reconcile time: a Metro
-// VM must carry one and only one category with the vHADomain key "k8s-vha-native-site". The check is a
-// no-op for non-Metro machines.
-func TestCheckVHADomainCategory(t *testing.T) {
-	const (
-		vhaExtA   = "vha-ext-a"
-		vhaExtB   = "vha-ext-b"
-		otherExt1 = "other-ext-1"
-	)
+// newVHACtlClient builds a fake controller-runtime client seeded with the given objects.
+func newVHACtlClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, infrav1.AddToScheme(scheme))
+	require.NoError(t, capiv1beta2.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
 
-	vhaCategories := []prismModels.Category{
-		{ExtId: ptr.To(vhaExtA), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-0")},
-		{ExtId: ptr.To(vhaExtB), Key: ptr.To(VHADomainDefaultCategoryKey), Value: ptr.To("k8s-vha-capx-d1-default-1")},
-	}
+// TestCheckVHADomainCategory enforces the implicit CSI/NKP k8s-HA contract at reconcile time: a Metro
+// VM must carry one and only one category with the vHADomain key "k8s-vha-native-site" belonging to
+// the cluster's vHADomain CR. The check is a no-op for non-Metro machines.
+func TestCheckVHADomainCategory(t *testing.T) {
+	const otherExt = "other-ext-1"
 
 	tests := []struct {
 		name          string
 		failureDomain string
 		vm            *vmmModels.Vm
-		expectList    bool
+		expectLookups bool
 		wantErr       bool
 	}{
 		{
 			name:          "non-metro machine is a no-op",
 			failureDomain: "some-zone",
-			vm:            vhaVM("n", vhaExtA, vhaExtB),
-			expectList:    false,
+			vm:            vhaVM("n", vhaCatExt0, vhaCatExt1),
+			expectLookups: false,
 			wantErr:       false,
 		},
 		{
 			name:          "metro VM with exactly one vha category passes",
 			failureDomain: metroFailureDomainPrefix + "metro-1",
-			vm:            vhaVM("n", otherExt1, vhaExtA),
-			expectList:    true,
+			vm:            vhaVM("n", otherExt, vhaCatExt0),
+			expectLookups: true,
 			wantErr:       false,
 		},
 		{
 			name:          "metro VM with no vha category fails",
 			failureDomain: metroFailureDomainPrefix + "metro-1",
-			vm:            vhaVM("n", otherExt1),
-			expectList:    true,
+			vm:            vhaVM("n", otherExt),
+			expectLookups: true,
 			wantErr:       true,
 		},
 		{
 			name:          "metro VM with two vha categories fails",
 			failureDomain: metroFailureDomainPrefix + "metro-1",
-			vm:            vhaVM("n", vhaExtA, vhaExtB),
-			expectList:    true,
+			vm:            vhaVM("n", vhaCatExt0, vhaCatExt1),
+			expectLookups: true,
 			wantErr:       true,
 		},
 		{
 			name:          "metroSite VM with exactly one vha category passes",
 			failureDomain: metroSiteFailureDomainPrefix + "site-1",
-			vm:            vhaVM("n", vhaExtA),
-			expectList:    true,
+			vm:            vhaVM("n", vhaCatExt0),
+			expectLookups: true,
 			wantErr:       false,
 		},
 	}
@@ -4360,20 +4449,24 @@ func TestCheckVHADomainCategory(t *testing.T) {
 
 			ctx := context.Background()
 			mockClient := NewMockConvergedClient(ctrl)
-			if tt.expectList {
-				mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return(vhaCategories, nil)
+			if tt.expectLookups {
+				expectVHACategoryLookups(mockClient)
 			}
+
+			ncl := vhaTestNutanixCluster()
+			ctlClient := newVHACtlClient(t, ncl, vhaOwnedDomain(ncl))
 
 			rctx := &nctx.MachineContext{
 				Context:         ctx,
 				ConvergedClient: mockClient.Client,
+				NutanixCluster:  ncl,
 				Machine: &capiv1beta2.Machine{
-					ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{Name: "n", Namespace: vhaTestNamespace},
 					Spec:       capiv1beta2.MachineSpec{FailureDomain: tt.failureDomain},
 				},
 			}
 
-			r := &NutanixMachineReconciler{}
+			r := &NutanixMachineReconciler{Client: ctlClient}
 			err := r.checkVHADomainCategory(rctx, tt.vm)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/controllers/nutanixvirtualhadomain_controller_test.go
+++ b/controllers/nutanixvirtualhadomain_controller_test.go
@@ -20,10 +20,15 @@ import (
 	"context"
 	"testing"
 
+	prismModels "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,6 +84,65 @@ func TestVHADomainNameHelpers(t *testing.T) {
 	g.Expect(vhaCategoryValue("d1", "default", 1)).To(Equal("k8s-vha-capx-d1-default-1"))
 	g.Expect(vhaRecoveryPlanName("d1", "default", 0)).To(Equal("k8s-vha-capx-d1-default-0"))
 	g.Expect(vhaProtectionPolicyName("d1")).To(Equal("k8s-vha-capx-d1"))
+}
+
+// TestVHADomainDefaultCategoryKey_Contract guards the implicit contract shared with CSI and NKP for
+// k8s-HA: the vHADomain category key MUST be exactly "k8s-vha-native-site". CSI/NKP rely on this
+// literal, so changing the constant silently would break k8s-HA in the field. This test fails loudly
+// so whoever changes the constant is alerted to the downstream contract.
+func TestVHADomainDefaultCategoryKey_Contract(t *testing.T) {
+	assert.Equal(t, "k8s-vha-native-site", VHADomainDefaultCategoryKey,
+		"the vHADomain category key is an implicit contract with CSI/NKP for k8s-HA and must not change")
+}
+
+// TestGetOrCreateVHADomainGroupCategories_UsesContractKey ensures every category generated for a
+// vHADomain is created with the contract key "k8s-vha-native-site". This upholds the CSI/NKP k8s-HA
+// contract at category-creation time (part of the "category is always created with the key
+// k8s-vha-native-site" requirement).
+func TestGetOrCreateVHADomainGroupCategories_UsesContractKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockClient := NewMockConvergedClient(ctrl)
+
+	// Two failure domains -> two categories are generated, each with a distinct value but the same
+	// contract key. Every category is looked up (List) and, when missing, created (Create).
+	mockClient.MockCategories.EXPECT().List(ctx, gomock.Any()).Return([]prismModels.Category{}, nil).Times(2)
+	mockClient.MockCategories.EXPECT().Create(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, in *prismModels.Category) (*prismModels.Category, error) {
+			// The core contract assertion: the key is always "k8s-vha-native-site".
+			assert.Equal(t, "k8s-vha-native-site", *in.Key)
+			in.ExtId = ptr.To("ext-" + *in.Value)
+			return in, nil
+		},
+	).Times(2)
+
+	r := &NutanixVirtualHADomainReconciler{}
+	rctx := &nctx.VHADomainContext{
+		Context:         ctx,
+		ConvergedClient: mockClient.Client,
+		VHADomain:       vhaDomainObj("d1", vhaClusterName),
+	}
+
+	failureDomains := []*infrav1.NutanixFailureDomain{
+		{ObjectMeta: metav1.ObjectMeta{Name: "fd-0", Namespace: vhaNamespace}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "fd-1", Namespace: vhaNamespace}},
+	}
+
+	categories, err := r.getOrCreateVHADomainGroupCategories(rctx, vhaDefaultMovementGroup, failureDomains)
+	require.NoError(t, err)
+	require.Len(t, categories, len(failureDomains))
+
+	// One and only one value is generated per failure domain, and the key is the contract key for all.
+	seenValues := map[string]struct{}{}
+	for _, c := range categories {
+		assert.Equal(t, VHADomainDefaultCategoryKey, c.Key)
+		_, dup := seenValues[c.Value]
+		assert.False(t, dup, "each failure domain must map to a distinct category value")
+		seenValues[c.Value] = struct{}{}
+	}
+	assert.Len(t, seenValues, len(failureDomains))
 }
 
 func TestVHADomainReconcileDelete_BlockedWhenOwnerNotInDeletion(t *testing.T) {


### PR DESCRIPTION
CSI and NKP rely on an **implicit contract** for k8s-HA: a VM's vHADomain category uses the key
`k8s-vha-native-site`, and each VM must have **exactly one** value under that key. Because this
contract is implicit, it is easy to break unknowingly over time.

This PR hardens that contract in the CAPX machine controller and adds unit tests that fail loudly if
the contract is ever changed:

- **Reconcile-time validation** — every `NutanixMachine` reconcile of a Metro/MetroSite machine now
  verifies the VM has one and only one category with the vHADomain key `k8s-vha-native-site`.
- **Contract-guard unit tests** — new UTs assert the category is always created with the
  `k8s-vha-native-site` key, and that a node is only ever assigned a single value for that key. Any
  change to the constant or the creation/assignment logic breaks these tests so the author is alerted
  to the downstream CSI/NKP dependency.

## Motivation

The vHADomain category (key `k8s-vha-native-site`) is applied to a VM only at VM-creation time and is
never re-synced. If a VM ends up with zero or more than one such category, CSI/NKP k8s-HA behavior
breaks silently. This adds an explicit safety check on every reconcile plus regression tests around
the implicit contract.
