### PR TITLE
feat: controller for metro scale-in

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,8 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusters
+  - machines
+  - machines/status
   verbs:
   - get
   - list
@@ -49,8 +51,8 @@ rules:
   resources:
   - clusters/status
   - machinedeployments
-  - machines
-  - machines/status
+  - machinesets
+  - machinesets/status
   verbs:
   - get
   - list

--- a/controllers/nutanixmetro_scaledown_controller.go
+++ b/controllers/nutanixmetro_scaledown_controller.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// managedDeleteMachineAnnotation marks the cluster.x-k8s.io/delete-machine annotations that this
+// controller owns. It lets the balancer add/remove the CAPI delete annotation only on machines it
+// manages, so an operator's manually-set delete-machine annotation is respected (counted, never
+// cleared).
+const managedDeleteMachineAnnotation = "metro.nutanix.com/managed-delete-machine"
+
+// MetroScaleDownBalancerReconciler keeps a stretched-NutanixMetro worker MachineSet balanced across
+// its two Prism Element sites during scale-down.
+//
+// A worker pool placed on a stretched NutanixMetro failure domain exposes a single
+// spec.failureDomain to CAPI, so CAPI's MachineSet delete policy is site-blind and can delete the
+// machines of one site preferentially, starving that Prism Element (and, for Rook-Ceph clusters,
+// wedging OSD scheduling). This controller biases deletion by maintaining the
+// cluster.x-k8s.io/delete-machine annotation (documented by CAPI as top priority on every delete
+// policy) on the machines of the over-represented site, so scale-down drains the fuller site first
+// and the two sites stay balanced.
+//
+// Known limitation: marking guarantees the imbalance is corrected first. A single scale-down larger
+// than needed to reach balance will, past the balance point, fall back to CAPI's site-blind policy
+// for the extra victims; the controller re-reconciles and re-marks after each batch. This is a
+// strict improvement and cannot re-create the one-sided collapse for normal scale-downs.
+type MetroScaleDownBalancerReconciler struct {
+	client.Client
+	Scheme           *runtime.Scheme
+	controllerConfig *ControllerConfig
+}
+
+// NewMetroScaleDownBalancerReconciler creates a MetroScaleDownBalancerReconciler.
+func NewMetroScaleDownBalancerReconciler(client client.Client, scheme *runtime.Scheme, copts ...ControllerConfigOpts) (*MetroScaleDownBalancerReconciler, error) {
+	controllerConf := &ControllerConfig{}
+	for _, opt := range copts {
+		if err := opt(controllerConf); err != nil {
+			return nil, err
+		}
+	}
+
+	return &MetroScaleDownBalancerReconciler{
+		Client:           client,
+		Scheme:           scheme,
+		controllerConfig: controllerConf,
+	}, nil
+}
+
+// SetupWithManager sets up the MetroScaleDownBalancer controller with the Manager.
+func (r *MetroScaleDownBalancerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	copts := controller.Options{
+		MaxConcurrentReconciles: r.controllerConfig.MaxConcurrentReconciles,
+		RateLimiter:             r.controllerConfig.RateLimiter,
+		SkipNameValidation:      ptr.To(r.controllerConfig.SkipNameValidation),
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("MetroScaleDownBalancer-controller").
+		For(&capiv1beta2.MachineSet{}).
+		Watches(
+			&capiv1beta2.Machine{},
+			handler.EnqueueRequestsFromMapFunc(
+				r.mapMachineToMachineSet(),
+			),
+		).
+		WithOptions(copts).
+		Complete(r)
+}
+
+// mapMachineToMachineSet enqueues the MachineSet that owns a Machine so a per-machine change (create,
+// placement label update, deletion) re-evaluates the whole balancing group.
+func (r *MetroScaleDownBalancerReconciler) mapMachineToMachineSet() handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []ctrl.Request {
+		log := ctrl.LoggerFrom(ctx)
+		machine, ok := o.(*capiv1beta2.Machine)
+		if !ok {
+			log.Error(fmt.Errorf("expected a Machine object but was %T", o), "unexpected type")
+			return nil
+		}
+
+		msName := machine.Labels[capiv1beta2.MachineSetNameLabel]
+		if msName == "" {
+			return nil
+		}
+
+		return []ctrl.Request{{
+			NamespacedName: client.ObjectKey{Name: msName, Namespace: machine.Namespace},
+		}}
+	}
+}
+
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets;machinesets/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=nutanixmachines,verbs=get;list;watch
+
+func (r *MetroScaleDownBalancerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	ms := &capiv1beta2.MachineSet{}
+	if err := r.Get(ctx, req.NamespacedName, ms); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		log.Error(err, "failed to fetch the MachineSet")
+		return reconcile.Result{}, err
+	}
+
+	// Only stretched NutanixMetro worker pools are site-blind on scale-down. NutanixMetroSite pools
+	// are already pinned to a single site, and non-metro pools have per-machine failure domains, so
+	// both are left untouched (guaranteeing zero behavior change for them).
+	if !isNutanixMetroFailureDomain(ms.Spec.Template.Spec.FailureDomain) {
+		return reconcile.Result{}, nil
+	}
+	if !ms.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	machines, err := r.listMachineSetMachines(ctx, ms)
+	if err != nil {
+		log.Error(err, "failed to list Machines for the MachineSet")
+		return reconcile.Result{}, err
+	}
+
+	victims, err := r.selectVictims(ctx, ms, machines)
+	if err != nil {
+		log.Error(err, "failed to select scale-down victims")
+		return reconcile.Result{}, err
+	}
+
+	if err := r.applyDeleteAnnotations(ctx, machines, victims); err != nil {
+		log.Error(err, "failed to apply delete-machine annotations")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// listMachineSetMachines returns the Machines owned by the given MachineSet.
+func (r *MetroScaleDownBalancerReconciler) listMachineSetMachines(ctx context.Context, ms *capiv1beta2.MachineSet) ([]*capiv1beta2.Machine, error) {
+	machineList := &capiv1beta2.MachineList{}
+	if err := r.List(ctx, machineList,
+		client.InNamespace(ms.Namespace),
+		client.MatchingLabels{capiv1beta2.MachineSetNameLabel: ms.Name},
+	); err != nil {
+		return nil, err
+	}
+
+	machines := make([]*capiv1beta2.Machine, 0, len(machineList.Items))
+	for i := range machineList.Items {
+		machines = append(machines, &machineList.Items[i])
+	}
+	return machines, nil
+}
+
+// selectVictims computes the set of Machine names that should carry the delete-machine annotation so
+// that scale-down keeps the metro's two sites balanced.
+//
+// It groups live (non-deleting) machines by their native site (resolved from the owning
+// NutanixMachine's metro.nutanix.com/native-failuredomain label), then greedily picks victims from
+// whichever site is currently larger. The number of victims K is:
+//   - the pending scale-down amount (spec.replicas < live machine count), when a scale-down is
+//     pending, so the exact machines CAPI is about to remove are the balanced ones; otherwise
+//   - the imbalance (excess = larger - smaller), as a steady-state bias so a future scale-down still
+//     prefers the fuller site.
+func (r *MetroScaleDownBalancerReconciler) selectVictims(ctx context.Context, ms *capiv1beta2.MachineSet, machines []*capiv1beta2.Machine) (map[string]struct{}, error) {
+	// bySite holds live machines with a known native site, keyed by site name.
+	bySite := map[string][]*capiv1beta2.Machine{}
+	liveTotal := 0
+	knownTotal := 0
+	for _, m := range machines {
+		if !m.DeletionTimestamp.IsZero() {
+			continue
+		}
+		liveTotal++
+
+		site, ok, err := r.machineSite(ctx, m)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			// The placement label is not set yet; this machine cannot be attributed to a site this
+			// pass. It will be reconsidered once CAPX records its native failure domain.
+			continue
+		}
+		bySite[site] = append(bySite[site], m)
+		knownTotal++
+	}
+
+	victims := map[string]struct{}{}
+	if knownTotal == 0 {
+		return victims, nil
+	}
+
+	// Sort sites by name for deterministic tie-breaking, and each site's machines newest-first so we
+	// prefer to remove the youngest machine of a site (matching CAPI's own default preference and
+	// minimizing disruption to long-lived workloads).
+	siteNames := make([]string, 0, len(bySite))
+	for name := range bySite {
+		siteNames = append(siteNames, name)
+	}
+	sort.Strings(siteNames)
+	for _, name := range siteNames {
+		sortMachinesNewestFirst(bySite[name])
+	}
+
+	excess := siteExcess(bySite, siteNames)
+
+	pendingDelete := 0
+	if ms.Spec.Replicas != nil && int(*ms.Spec.Replicas) < liveTotal {
+		pendingDelete = liveTotal - int(*ms.Spec.Replicas)
+	}
+
+	k := excess
+	if pendingDelete > 0 {
+		k = pendingDelete
+	}
+	if k > knownTotal {
+		k = knownTotal
+	}
+	if k <= 0 {
+		return victims, nil
+	}
+
+	// Greedy: each step remove one machine from whichever site currently has the most remaining
+	// machines (ties resolve to the lexicographically-smallest site name). This keeps the remainder
+	// as balanced as possible for any K.
+	remaining := map[string][]*capiv1beta2.Machine{}
+	for name, list := range bySite {
+		remaining[name] = append([]*capiv1beta2.Machine(nil), list...)
+	}
+	for i := 0; i < k; i++ {
+		pick := ""
+		best := -1
+		for _, name := range siteNames {
+			if n := len(remaining[name]); n > best {
+				best = n
+				pick = name
+			}
+		}
+		if best <= 0 {
+			break
+		}
+		victim := remaining[pick][0]
+		remaining[pick] = remaining[pick][1:]
+		victims[victim.Name] = struct{}{}
+	}
+
+	return victims, nil
+}
+
+// applyDeleteAnnotations reconciles the delete-machine annotation on every machine in the group to
+// match the desired victim set, respecting operator-set annotations.
+func (r *MetroScaleDownBalancerReconciler) applyDeleteAnnotations(ctx context.Context, machines []*capiv1beta2.Machine, victims map[string]struct{}) error {
+	for _, m := range machines {
+		if !m.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		_, wantVictim := victims[m.Name]
+		_, hasDelete := m.Annotations[capiv1beta2.DeleteMachineAnnotation]
+		_, isManaged := m.Annotations[managedDeleteMachineAnnotation]
+
+		switch {
+		case wantVictim:
+			// Already annotated (by us or by an operator): nothing to do; respect operator intent.
+			if hasDelete {
+				continue
+			}
+			if err := r.patchMachineAnnotations(ctx, m, true); err != nil {
+				return err
+			}
+		default:
+			// Only remove annotations that we own; never clear an operator's manual delete-machine.
+			if isManaged {
+				if err := r.patchMachineAnnotations(ctx, m, false); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// patchMachineAnnotations sets (mark=true) or clears (mark=false) the managed delete-machine
+// annotations on a Machine using a conflict-safe patch.
+func (r *MetroScaleDownBalancerReconciler) patchMachineAnnotations(ctx context.Context, m *capiv1beta2.Machine, mark bool) error {
+	helper, err := patch.NewHelper(m, r.Client)
+	if err != nil {
+		return err
+	}
+
+	if mark {
+		if m.Annotations == nil {
+			m.Annotations = map[string]string{}
+		}
+		m.Annotations[capiv1beta2.DeleteMachineAnnotation] = "true"
+		m.Annotations[managedDeleteMachineAnnotation] = "true"
+	} else {
+		delete(m.Annotations, capiv1beta2.DeleteMachineAnnotation)
+		delete(m.Annotations, managedDeleteMachineAnnotation)
+	}
+
+	return helper.Patch(ctx, m)
+}
+
+// machineSite resolves the native metro site (NutanixFailureDomain name) a Machine is placed on, read
+// from the owning NutanixMachine's metro.nutanix.com/native-failuredomain label. ok is false when the
+// placement has not been recorded yet.
+func (r *MetroScaleDownBalancerReconciler) machineSite(ctx context.Context, m *capiv1beta2.Machine) (string, bool, error) {
+	infraName := m.Spec.InfrastructureRef.Name
+	if infraName == "" {
+		return "", false, nil
+	}
+
+	nm := &infrav1.NutanixMachine{}
+	if err := r.Get(ctx, client.ObjectKey{Name: infraName, Namespace: m.Namespace}, nm); err != nil {
+		if errors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	site, ok := nm.Labels[metroNativeFailureDomainLabelKey]
+	if !ok || site == "" {
+		return "", false, nil
+	}
+	return site, true, nil
+}
+
+// siteExcess returns the difference between the largest and smallest site machine counts across the
+// given sites. It is zero when fewer than two sites are represented (no cross-site imbalance is
+// possible).
+func siteExcess(bySite map[string][]*capiv1beta2.Machine, siteNames []string) int {
+	if len(siteNames) < 2 {
+		return 0
+	}
+	minCount := -1
+	maxCount := 0
+	for _, name := range siteNames {
+		n := len(bySite[name])
+		if n > maxCount {
+			maxCount = n
+		}
+		if minCount < 0 || n < minCount {
+			minCount = n
+		}
+	}
+	return maxCount - minCount
+}
+
+// sortMachinesNewestFirst orders machines by creation time descending, breaking ties by name for
+// determinism.
+func sortMachinesNewestFirst(machines []*capiv1beta2.Machine) {
+	sort.SliceStable(machines, func(i, j int) bool {
+		ti := machines[i].CreationTimestamp
+		tj := machines[j].CreationTimestamp
+		if ti.Equal(&tj) {
+			return machines[i].Name < machines[j].Name
+		}
+		return ti.After(tj.Time)
+	})
+}

--- a/controllers/nutanixmetro_scaledown_controller_test.go
+++ b/controllers/nutanixmetro_scaledown_controller_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	capiv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	balancerMSName = "ms1"
+	balancerFDA    = "fd-dh1"
+	balancerFDB    = "fd-dh2"
+)
+
+// newBalancerReconciler wires a MetroScaleDownBalancerReconciler over a fake client preloaded with
+// objs.
+func newBalancerReconciler(g *WithT, objs ...client.Object) *MetroScaleDownBalancerReconciler {
+	scheme := newPlacementScheme(g)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &MetroScaleDownBalancerReconciler{Client: fakeClient, Scheme: scheme}
+}
+
+// balancerMS builds a MachineSet on the given failure domain with an optional replica count.
+func balancerMS(fd string, replicas *int32) *capiv1beta2.MachineSet {
+	return &capiv1beta2.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      balancerMSName,
+			Namespace: placementNamespace,
+			Labels:    map[string]string{capiv1beta2.ClusterNameLabel: placementClusterName},
+		},
+		Spec: capiv1beta2.MachineSetSpec{
+			Replicas: replicas,
+			Template: capiv1beta2.MachineTemplateSpec{
+				Spec: capiv1beta2.MachineSpec{FailureDomain: fd},
+			},
+		},
+	}
+}
+
+// balancerMachineInSet builds a Machine attributed to balancerMSName owning the same-named
+// NutanixMachine.
+func balancerMachineInSet(name string) *capiv1beta2.Machine {
+	return placementMachineInSet(name, name, "wmd", balancerMSName)
+}
+
+// balancerTerminating marks a Machine as being deleted (fake client requires a finalizer to persist
+// a deletion timestamp).
+func balancerTerminating(m *capiv1beta2.Machine) *capiv1beta2.Machine {
+	now := metav1.Now()
+	m.DeletionTimestamp = &now
+	m.Finalizers = []string{"test.nutanix.com/finalizer"}
+	return m
+}
+
+// reconcileBalancer runs a single reconcile keyed on the MachineSet.
+func reconcileBalancer(g *WithT, r *MetroScaleDownBalancerReconciler) {
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: balancerMSName, Namespace: placementNamespace},
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+// hasDeleteAnnotation returns whether the named Machine currently carries the CAPI delete annotation.
+func hasDeleteAnnotation(g *WithT, r *MetroScaleDownBalancerReconciler, name string) bool {
+	m := &capiv1beta2.Machine{}
+	g.Expect(r.Get(context.Background(), client.ObjectKey{Name: name, Namespace: placementNamespace}, m)).To(Succeed())
+	_, ok := m.Annotations[capiv1beta2.DeleteMachineAnnotation]
+	return ok
+}
+
+// hasManagedAnnotation returns whether the named Machine carries our ownership marker.
+func hasManagedAnnotation(g *WithT, r *MetroScaleDownBalancerReconciler, name string) bool {
+	m := &capiv1beta2.Machine{}
+	g.Expect(r.Get(context.Background(), client.ObjectKey{Name: name, Namespace: placementNamespace}, m)).To(Succeed())
+	_, ok := m.Annotations[managedDeleteMachineAnnotation]
+	return ok
+}
+
+func TestMetroScaleDownBalancerReconcile(t *testing.T) {
+	t.Run("balanced group is a no-op", func(t *testing.T) {
+		g := NewWithT(t)
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-a2", balancerFDA, false), balancerMachineInSet("m-a2"),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+			placementNM("m-b2", balancerFDB, false), balancerMachineInSet("m-b2"),
+		)
+
+		reconcileBalancer(g, r)
+
+		for _, name := range []string{"m-a1", "m-a2", "m-b1", "m-b2"} {
+			g.Expect(hasDeleteAnnotation(g, r, name)).To(BeFalse(), name)
+		}
+	})
+
+	t.Run("imbalanced group marks the excess on the larger site", func(t *testing.T) {
+		g := NewWithT(t)
+		// site A has 3, site B has 1 -> excess 2, both victims from A (smallest names first).
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-a2", balancerFDA, false), balancerMachineInSet("m-a2"),
+			placementNM("m-a3", balancerFDA, false), balancerMachineInSet("m-a3"),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		g.Expect(hasDeleteAnnotation(g, r, "m-a1")).To(BeTrue())
+		g.Expect(hasDeleteAnnotation(g, r, "m-a2")).To(BeTrue())
+		g.Expect(hasManagedAnnotation(g, r, "m-a1")).To(BeTrue())
+		g.Expect(hasDeleteAnnotation(g, r, "m-a3")).To(BeFalse())
+		g.Expect(hasDeleteAnnotation(g, r, "m-b1")).To(BeFalse())
+	})
+
+	t.Run("pending scale-down keeps the remainder balanced", func(t *testing.T) {
+		g := NewWithT(t)
+		// 3 per site, replicas 4 -> delete 2: one from each site keeps 2/2.
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", ptr.To(int32(4))),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-a2", balancerFDA, false), balancerMachineInSet("m-a2"),
+			placementNM("m-a3", balancerFDA, false), balancerMachineInSet("m-a3"),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+			placementNM("m-b2", balancerFDB, false), balancerMachineInSet("m-b2"),
+			placementNM("m-b3", balancerFDB, false), balancerMachineInSet("m-b3"),
+		)
+
+		reconcileBalancer(g, r)
+
+		aMarked := 0
+		for _, n := range []string{"m-a1", "m-a2", "m-a3"} {
+			if hasDeleteAnnotation(g, r, n) {
+				aMarked++
+			}
+		}
+		bMarked := 0
+		for _, n := range []string{"m-b1", "m-b2", "m-b3"} {
+			if hasDeleteAnnotation(g, r, n) {
+				bMarked++
+			}
+		}
+		g.Expect(aMarked).To(Equal(1))
+		g.Expect(bMarked).To(Equal(1))
+	})
+
+	t.Run("stale managed annotation is cleaned up when balanced", func(t *testing.T) {
+		g := NewWithT(t)
+		stale := balancerMachineInSet("m-a1")
+		stale.Annotations = map[string]string{
+			capiv1beta2.DeleteMachineAnnotation: "true",
+			managedDeleteMachineAnnotation:      "true",
+		}
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), stale,
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		g.Expect(hasDeleteAnnotation(g, r, "m-a1")).To(BeFalse())
+		g.Expect(hasManagedAnnotation(g, r, "m-a1")).To(BeFalse())
+	})
+
+	t.Run("operator-set delete annotation is respected", func(t *testing.T) {
+		g := NewWithT(t)
+		// Balanced group; a machine carries an operator delete annotation (no managed marker).
+		operatorMarked := balancerMachineInSet("m-a1")
+		operatorMarked.Annotations = map[string]string{capiv1beta2.DeleteMachineAnnotation: "yes"}
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), operatorMarked,
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		g.Expect(hasDeleteAnnotation(g, r, "m-a1")).To(BeTrue())
+		g.Expect(hasManagedAnnotation(g, r, "m-a1")).To(BeFalse())
+	})
+
+	t.Run("non-metro pool is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		// A machine carries a managed annotation that would be cleaned if the controller acted.
+		preAnnotated := balancerMachineInSet("m-a1")
+		preAnnotated.Annotations = map[string]string{
+			capiv1beta2.DeleteMachineAnnotation: "true",
+			managedDeleteMachineAnnotation:      "true",
+		}
+		r := newBalancerReconciler(g,
+			balancerMS("", nil),
+			placementNM("m-a1", balancerFDA, false), preAnnotated,
+		)
+
+		reconcileBalancer(g, r)
+
+		// Untouched because the pool is not a stretched-metro pool.
+		g.Expect(hasDeleteAnnotation(g, r, "m-a1")).To(BeTrue())
+		g.Expect(hasManagedAnnotation(g, r, "m-a1")).To(BeTrue())
+	})
+
+	t.Run("MetroSite pool is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		r := newBalancerReconciler(g,
+			balancerMS(metroSiteFailureDomainPrefix+"site-1", nil),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-a2", balancerFDA, false), balancerMachineInSet("m-a2"),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		for _, name := range []string{"m-a1", "m-a2", "m-b1"} {
+			g.Expect(hasDeleteAnnotation(g, r, name)).To(BeFalse(), name)
+		}
+	})
+
+	t.Run("terminating machines are skipped and never annotated", func(t *testing.T) {
+		g := NewWithT(t)
+		// Live: A=2, B=1 (excess 1 -> one victim from A). A also has a terminating machine that must
+		// not be counted or annotated.
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-a2", balancerFDA, false), balancerMachineInSet("m-a2"),
+			placementNM("m-a3", balancerFDA, true), balancerTerminating(balancerMachineInSet("m-a3")),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		g.Expect(hasDeleteAnnotation(g, r, "m-a1")).To(BeTrue())
+		g.Expect(hasDeleteAnnotation(g, r, "m-a2")).To(BeFalse())
+		g.Expect(hasDeleteAnnotation(g, r, "m-a3")).To(BeFalse())
+		g.Expect(hasDeleteAnnotation(g, r, "m-b1")).To(BeFalse())
+	})
+
+	t.Run("machines without a placement label yet are ignored", func(t *testing.T) {
+		g := NewWithT(t)
+		// One machine has no NutanixMachine site label; balanced otherwise -> no-op.
+		r := newBalancerReconciler(g,
+			balancerMS(metroFailureDomainPrefix+"metro0", nil),
+			placementNM("m-a1", balancerFDA, false), balancerMachineInSet("m-a1"),
+			placementNM("m-b1", balancerFDB, false), balancerMachineInSet("m-b1"),
+			placementNM("m-x1", "", false), balancerMachineInSet("m-x1"),
+		)
+
+		reconcileBalancer(g, r)
+
+		for _, name := range []string{"m-a1", "m-b1", "m-x1"} {
+			g.Expect(hasDeleteAnnotation(g, r, name)).To(BeFalse(), name)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -433,6 +433,25 @@ func setupNutanixMetroSiteController(ctx context.Context, mgr manager.Manager, s
 	return nil
 }
 
+func setupMetroScaleDownBalancerController(ctx context.Context, mgr manager.Manager,
+	opts ...controllers.ControllerConfigOpts,
+) error {
+	balancerCtrl, err := controllers.NewMetroScaleDownBalancerReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		opts...,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create MetroScaleDownBalancer controller: %w", err)
+	}
+
+	if err := balancerCtrl.SetupWithManager(ctx, mgr); err != nil {
+		return fmt.Errorf("unable to setup MetroScaleDownBalancer controller with manager: %w", err)
+	}
+
+	return nil
+}
+
 func setupNutanixVirtualHADomainController(ctx context.Context, mgr manager.Manager, secretInformer coreinformers.SecretInformer,
 	configMapInformer coreinformers.ConfigMapInformer, opts ...controllers.ControllerConfigOpts,
 ) error {
@@ -507,6 +526,10 @@ func runManager(ctx context.Context, mgr manager.Manager, config *managerConfig)
 	}
 
 	if err := setupNutanixMetroSiteController(ctx, mgr, secretInformer, configMapInformer, machineControllerOpts...); err != nil {
+		return fmt.Errorf("unable to setup controllers: %w", err)
+	}
+
+	if err := setupMetroScaleDownBalancerController(ctx, mgr, machineControllerOpts...); err != nil {
 		return fmt.Errorf("unable to setup controllers: %w", err)
 	}
 


### PR DESCRIPTION
Adds the **Metro Scale-Down Balancer** controller (`MetroScaleDownBalancerReconciler`),
which keeps a stretched `NutanixMetro` worker `MachineSet` evenly distributed
across its two Prism Element (PE) sites during scale-down. It biases Cluster
API's (CAPI) machine-deletion order by maintaining the
`cluster.x-k8s.io/delete-machine` annotation on machines of the
over-represented site, so scale-down drains the fuller site first and the two
sites converge toward balance.

The controller is intentionally narrow: it only touches stretched-metro worker
pools, never mutates replica counts, and never deletes machines itself — it only
influences *which* machine CAPI removes when a scale-down happens.

## Motivation

A stretched-metro worker pool exposes only a single `spec.failureDomain` to
CAPI, so CAPI's `MachineSet` delete policy is **site-blind**. On scale-down it
can preferentially delete one PE site's machines, which:

- **Starves that Prism Element** of worker capacity, defeating the purpose of
  stretching the pool across two sites, and
- For **Rook-Ceph** clusters, can wedge OSD scheduling when one site loses too
  many nodes.

CAPI documents `cluster.x-k8s.io/delete-machine` as the top-priority signal on
every delete policy (annotated machines are always chosen first, regardless of
`Random`/`Newest`/`Oldest`). This controller uses that lever to steer deletions
toward the fuller site.

## Behavior

- **In scope only when:** the `MachineSet` failure domain has the
  `NutanixMetro/` prefix and the set is not being deleted. `NutanixMetroSite/`
  (single-site), non-metro, and control-plane pools are untouched — zero
  behavior change for them.
- **Victim selection:** groups live machines by site (via the
  `metro.nutanix.com/native-failuredomain` label on the owning
  `NutanixMachine`), computes `K` (pending scale-down → `liveTotal − replicas`;
  otherwise steady-state excess `= larger − smaller`), then does a greedy
  balanced pick (remove from the currently-fuller site each step). Deterministic
  tie-breaking: lexicographic site order, newest-first within a site.
- **Coexists with operators:** a private
  `metro.nutanix.com/managed-delete-machine` ownership marker means the
  controller only ever clears annotations it set itself; a manually-applied
  `delete-machine` is always respected and never cleared.
- **Never** mutates replica counts and **never** deletes machines — CAPI remains
  the sole actor that removes machines.

## RBAC

New kubebuilder markers (regenerated into `config/rbac/role.yaml`):

- `machinesets`, `machinesets/status` — `get; list; watch`
- `machines`, `machines/status` — `get; list; watch; update; patch`
- `nutanixmachines` — `get; list; watch`

Write access is needed only on `machines` (to patch annotations); everything
else is read-only.

## Testing

### Manual end-to-end validation

Built the image from this branch, loaded it into a local KIND management cluster
(`capi-test`), deployed it onto `capx-controller-manager`, and exercised a live
stretched-metro worker pool (`MachineDeployment ab-ha-auto-m2-wmd2`, failure
domain `NutanixMetro/metro0`, two PE sites `fd0` / `fd1`).

After deploy, the controller registered cleanly:
`MetroScaleDownBalancer-controller` appears in the "Starting workers" list with
no RBAC errors.

Two annotations were used to verify behavior on each `Machine`:

- `cluster.x-k8s.io/delete-machine` — CAPI's delete signal.
- `metro.nutanix.com/managed-delete-machine` — the balancer's ownership marker;
  its presence proves the balancer (not CAPI's site-blind policy) chose the
  victim.

#### Test 1 — scale 6 → 2 (`K = 4`)

Start balanced `fd0=3 / fd1=3`. The balancer marked exactly 4 victims — **2 from
each site** — each with both annotations; CAPI deleted precisely those.

**Result:** `fd0=1 / fd1=1` — balanced.

#### Test 2 — scale to 2 (steady-state pre-mark consumed)

With the pool sitting at `fd0=1 / fd1=2` (one excess machine on `fd1`
pre-marked from a prior reconcile), scaling to 2 removed that pre-marked `fd1`
machine.

**Result:** `fd0=1 / fd1=1` — balanced.

#### Test 3 — full cycle scale 2 → 9 → 3 (`K = 6`)

Scale-up provisioned new VMs across both sites, landing at `fd0=5 / fd1=4` (all
9 site-labeled). Scaling to 3 marked the fuller-site machines; CAPI deleted
them.

**Result:** `fd0=1 / fd1=2` — balanced (diff 1, best possible for an odd count
of 3). The single excess machine on the fuller site retained the
`delete-machine` + `managed` markers (steady-state bias), so the next scale-down
converges to `1/1`.

| Test | Action | Expected | Observed | Pass |
|---|---|---|---|---|
| 1 | 6 → 2 (`K=4`) | 2+2 removed, remainder 1/1 | 2 from each site; `fd0=1/fd1=1` | ✅ |
| 2 | 3 → 2 | pre-marked excess removed | `fd0=1/fd1=1` | ✅ |
| 3 | 2 → 9 → 3 (`K=6`) | remainder balanced (`diff ≤ 1`) | `fd0=1/fd1=2`, excess pre-marked | ✅ |

> Note: a transient over-mark may be observed mid-flight during a large
> scale-down — the controller re-reconciles as deletions progress and converges
> to the correct set. It is not a bug.

## Non-goals / known limitation

- Does not decide *how many* machines to remove (replica counts stay owned by
  the user / autoscaler / CAPI), does not delete machines, and does not touch
  control-plane or single-site pools.
- A single scale-down *larger than the amount needed to reach balance* falls
  back to CAPI's site-blind policy for the extra victims past the balance point;
  the controller re-reconciles and re-marks after each batch, continuously
  nudging back toward balance. This is a strict improvement over the site-blind
  default and cannot re-create the one-sided collapse for normal (incremental)
  scale-downs.
