### PR TITLE
ci(NCN-116738): re-add CSI 3.0 e2e tests and bump driver to 3.7.0

### DIFF
--- a/scripts/csi3_nutanix_update.sh
+++ b/scripts/csi3_nutanix_update.sh
@@ -42,3 +42,14 @@ ex templates/csi3/nutanix-csi-storage.yaml <<EOF
 %s/--http-endpoint=:9812/--metrics-address=:9812/
 xit
 EOF
+
+# Fix 3: Raise nutanix-storage-precheck-job's backoffLimit from 0 to 10
+# This Job is a Helm pre-install hook, but we apply the chart output directly via
+# kustomize/CRS instead of `helm install`, so Kubernetes has no hook ordering and the
+# Job races the CSI controller against a freshly-provisioned node. A backoffLimit of 0
+# means a single transient failure (e.g. CoreDNS not ready yet) permanently starves the
+# CSI controller of the ConfigMap this Job creates, wedging it in CrashLoopBackOff forever.
+ex templates/csi3/nutanix-csi-storage.yaml <<EOF
+%s/backoffLimit: 0/backoffLimit: 10/
+xit
+EOF

--- a/scripts/csi3_nutanix_update.sh
+++ b/scripts/csi3_nutanix_update.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NUTANIX_CSI_SNAPSHOT_VERSION=6.3.3
-NUTANIX_CSI_STORAGE_VERSION=3.3.4
+NUTANIX_CSI_STORAGE_VERSION=3.7.0
 
 helm repo add nutanix-helm-releases https://nutanix.github.io/helm-releases/ --force-update && helm repo update
 

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -1702,7 +1702,7 @@ data:
     \             value: \"false\"\n          volumeMounts:\n            - mountPath:
     /var/run/precheck-pc-secret-dir\n              name: precheck-pc-secret\n              readOnly:
     true\n      volumes:\n        - name: precheck-pc-secret\n          secret:\n
-    \           secretName: ntnx-pc-secret\n  backoffLimit: 0\n"
+    \           secretName: ntnx-pc-secret\n  backoffLimit: 10\n"
   nutanix-csi-webhook.yaml: |
     ---
     apiVersion: v1

--- a/templates/cluster-template-csi3.yaml
+++ b/templates/cluster-template-csi3.yaml
@@ -1370,24 +1370,26 @@ data:
       timeoutSeconds: 2
   nutanix-csi-storage.yaml: "---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\napiVersion:
     v1\nkind: ServiceAccount\nmetadata:\n  name: nutanix-csi-controller\n  namespace:
-    ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name:
+    ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name:
     nutanix-csi-storage\n    app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\napiVersion:
-    v1\nkind: ServiceAccount\nmetadata:\n  name: nutanix-csi-node\n  namespace: ntnx-system\n---\n#
-    Source: nutanix-csi-storage/templates/ntnx-csi-init-configmap.yaml\napiVersion:
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\n---\n# Source:
+    nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
+    \ name: nutanix-csi-node\n  namespace: ntnx-system\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-init-configmap.yaml\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: ntnx-init-configmap\n  namespace: ntnx-system\n
-    \ labels:\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name:
+    \ labels:\n    helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name:
     nutanix-csi-storage\n    app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\ndata:\n  kubernetesClusterDeploymentType: non-bare-metal\n  usePC:
-    \"true\"\n  associateCategoriesToVolume: \"true\"\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind:
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\ndata:\n  kubernetesClusterDeploymentType:
+    non-bare-metal\n  usePC: \"true\"\n  associateCategoriesToVolume: \"true\"\n  usePEFallback:
+    \"false\"\n  usePETopology: \"false\"\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\nkind:
     ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: nutanix-csi-controller-role\n
-    \ namespace: ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n
+    \ namespace: ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.7.0\n
     \   app.kubernetes.io/name: nutanix-csi-storage\n    app.kubernetes.io/instance:
-    nutanix-storage\n    app.kubernetes.io/version: \"3.3.4\"\n    app.kubernetes.io/managed-by:
-    Helm\n    app.kubernetes.io/management-plane: \"PrismCentral\"\nrules:\n  - apiGroups:
-    [\"\"]\n    resources: [\"secrets\"]\n    verbs: [\"get\", \"list\", \"watch\"]\n
+    nutanix-storage\n    app.kubernetes.io/version: \"3.7.0\"\n    app.kubernetes.io/managed-by:
+    Helm\n    app.kubernetes.io/management-plane: \"PrismCentral\"\n    app.kubernetes.io/topology-enabled:
+    \"true\"\nrules:\n  - apiGroups: [\"\"]\n    resources: [\"secrets\"]\n    verbs:
+    [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\", \"delete\"]\n
     \ - apiGroups: [\"\"]\n    resources: [\"nodes\"]\n    verbs: [\"get\", \"list\",
     \"watch\"]\n  - apiGroups: [\"\"]\n    resources: [\"configmaps\"]\n    verbs:
     [\"get\", \"list\", \"watch\"]\n  - apiGroups: [\"\"]\n    resources: [\"namespaces\"]\n
@@ -1437,67 +1439,74 @@ data:
     nutanix-csi-storage/templates/service-prometheus-csi.yaml\n# Copyright 2021 Nutanix
     Inc\n# \n# example usage: kubectl create -f <this_file>\n#\n\napiVersion: v1\nkind:
     Service\nmetadata:\n  name: nutanix-csi-metrics\n  namespace: ntnx-system\n  labels:\n
-    \   app: nutanix-csi-metrics\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name:
+    \   app: nutanix-csi-metrics\n    helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name:
     nutanix-csi-storage\n    app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\nspec:\n  type: ClusterIP\n  selector:\n    app: nutanix-csi-controller\n
-    \ ports:\n    - name: provisioner\n      port: 9809\n      targetPort: 9809\n
-    \     protocol: TCP\n    - name: attacher\n      port: 9810\n      targetPort:
-    9810\n      protocol: TCP\n    - name: resizer\n      port: 9811\n      targetPort:
-    9811\n      protocol: TCP\n    - name: snapshotter\n      port: 9812\n      targetPort:
-    9812\n      protocol: TCP\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml\n#
-    Copyright 2021 Nutanix Inc\n#\n# example usage: kubectl create -f <this_file>\n\nkind:
-    DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: nutanix-csi-node\n  namespace:
-    ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name:
-    nutanix-csi-storage\n    app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\nspec:\n  selector:\n    matchLabels:\n      app: nutanix-csi-node\n
-    \ updateStrategy:\n    type: \"RollingUpdate\"\n    rollingUpdate:\n      maxUnavailable:
-    \"10%\"\n  template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/default-container:
-    nutanix-csi-node\n      labels:\n        app: nutanix-csi-node\n    spec:\n      serviceAccount:
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\nspec:\n  type:
+    ClusterIP\n  selector:\n    app: nutanix-csi-controller\n  ports:\n    - name:
+    provisioner\n      port: 9809\n      targetPort: 9809\n      protocol: TCP\n    -
+    name: attacher\n      port: 9810\n      targetPort: 9810\n      protocol: TCP\n
+    \   - name: resizer\n      port: 9811\n      targetPort: 9811\n      protocol:
+    TCP\n    - name: snapshotter\n      port: 9812\n      targetPort: 9812\n      protocol:
+    TCP\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-node-ds.yaml\n# Copyright
+    2021 Nutanix Inc\n#\n# example usage: kubectl create -f <this_file>\n\nkind: DaemonSet\napiVersion:
+    apps/v1\nmetadata:\n  name: nutanix-csi-node\n  namespace: ntnx-system\n  labels:\n
+    \   helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name: nutanix-csi-storage\n
+    \   app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\nspec:\n  selector:\n
+    \   matchLabels:\n      app: nutanix-csi-node\n  updateStrategy:\n    type: \"RollingUpdate\"\n
+    \   rollingUpdate:\n      maxUnavailable: \"10%\"\n  template:\n    metadata:\n
+    \     annotations:\n        kubectl.kubernetes.io/default-container: nutanix-csi-node\n
+    \     labels:\n        app: nutanix-csi-node\n    spec:\n      serviceAccount:
     nutanix-csi-node\n      hostNetwork: true\n      containers:\n        - name:
-    driver-registrar\n          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0\n
+    driver-registrar\n          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0\n
     \         imagePullPolicy: IfNotPresent\n          args:\n            - --v=2\n
     \           - --csi-address=$(ADDRESS)\n            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)\n
     \         env:\n            - name: ADDRESS\n              value: /csi/csi.sock\n
     \           - name: DRIVER_REG_SOCK_PATH\n              value: /var/lib/kubelet/plugins/csi.nutanix.com/csi.sock\n
     \           - name: KUBE_NODE_NAME\n              valueFrom:\n                fieldRef:\n
     \                 fieldPath: spec.nodeName\n          resources:\n            limits:\n
-    \             cpu: 100m\n              memory: 200Mi\n            requests:\n
-    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
-    \           - name: plugin-dir\n              mountPath: /csi/\n            -
-    name: registration-dir\n              mountPath: /registration\n        - name:
-    nutanix-csi-node\n          securityContext:\n            privileged: true\n            allowPrivilegeEscalation:
-    true\n          image: docker.io/nutanix/ntnx-csi:3.3.4\n          imagePullPolicy:
-    IfNotPresent\n          args :\n            - \"--endpoint=$(CSI_ENDPOINT)\"\n
-    \           - \"--nodeid=$(NODE_ID)\"\n            - \"--drivername=csi.nutanix.com\"\n
-    \           - \"--max-volumes-per-node=64\"\n            # - --volume-capacity-threshold=50.0\n
-    \         env:\n            - name: CSI_ENDPOINT\n              value: unix:///csi/csi.sock\n
-    \           - name: NODE_ID\n              valueFrom:\n                fieldRef:\n
-    \                 fieldPath: spec.nodeName\n            - name: NODE_IP\n              valueFrom:\n
-    \               fieldRef:\n                  fieldPath: status.hostIP\n            -
-    name: CSI_SECRET_DIR\n              value: /var/run/ntnx-secret-dir\n            -
-    name: CSI_INIT_CONFIGMAP_NAME\n              value: ntnx-init-configmap\n            -
-    name: CSI_INIT_CONFIGMAP_NAMESPACE\n              value: ntnx-system\n            -
-    name: CSI_PLUGIN_TYPE\n              value: NODE_PLUGIN\n          resources:\n
-    \           limits:\n              cpu: 200m\n              memory: 200Mi\n            requests:\n
-    \             cpu: 200m\n              memory: 200Mi\n          volumeMounts:\n
-    \           - mountPath: /var/run/ntnx-secret-dir\n              name: pc-secret\n
-    \             readOnly: true\n            - name: plugin-dir\n              mountPath:
-    /csi\n            - name: pods-mount-dir\n              mountPath: /var/lib/kubelet\n
-    \             # needed so that any mounts setup inside this container are\n              #
-    propagated back to the host machine.\n              mountPropagation: \"Bidirectional\"\n
-    \           - mountPath: /dev\n              name: device-dir\n            - mountPath:
-    /etc/iscsi\n              name: iscsi-dir\n            - mountPath: /host\n              name:
+    \             cpu: 50m\n              memory: 100Mi\n            requests:\n              cpu:
+    20m\n              memory: 40Mi\n          volumeMounts:\n            - name:
+    plugin-dir\n              mountPath: /csi/\n            - name: registration-dir\n
+    \             mountPath: /registration\n        - name: nutanix-csi-node\n          securityContext:\n
+    \           privileged: true\n            allowPrivilegeEscalation: true\n          image:
+    docker.io/nutanix/ntnx-csi:3.7.0\n          imagePullPolicy: IfNotPresent\n          args
+    :\n            - \"--endpoint=$(CSI_ENDPOINT)\"\n            - \"--nodeid=$(NODE_ID)\"\n
+    \           - \"--drivername=csi.nutanix.com\"\n            - \"--max-volumes-per-node=64\"\n
+    \           - \"--enable-rw-multi-support=false\"\n            - --force-detach-existing-client-in-pe-mode=true\n
+    \           # - --volume-capacity-threshold=50.0\n          env:\n            -
+    name: CSI_JWT_TOKEN_FILE\n              value: ntnx-jwt-secret\n            -
+    name: CSI_JWT_TOKEN_DIR\n              value: /var/run/ntnx-token-dir\n            -
+    name: CSI_ENDPOINT\n              value: unix:///csi/csi.sock\n            - name:
+    NODE_ID\n              valueFrom:\n                fieldRef:\n                  fieldPath:
+    spec.nodeName\n            - name: NODE_IP\n              valueFrom:\n                fieldRef:\n
+    \                 fieldPath: status.hostIP\n            - name: CSI_SECRET_DIR\n
+    \             value: /var/run/ntnx-secret-dir\n            - name: CSI_PE_SECRET_DIR\n
+    \             value: /var/run/ntnx-pe-secret-dir\n            - name: CSI_INIT_CONFIGMAP_NAME\n
+    \             value: ntnx-init-configmap\n            - name: CSI_INIT_CONFIGMAP_NAMESPACE\n
+    \             value: ntnx-system\n            - name: CSI_PLUGIN_TYPE\n              value:
+    NODE_PLUGIN\n          resources:\n            limits:\n              cpu: 50m\n
+    \             memory: 200Mi\n            requests:\n              cpu: 20m\n              memory:
+    200Mi\n          volumeMounts:\n            - mountPath: /var/run/ntnx-secret-dir\n
+    \             name: pc-secret\n              readOnly: true\n            - name:
+    plugin-dir\n              mountPath: /csi\n            - name: pods-mount-dir\n
+    \             mountPath: /var/lib/kubelet\n              # needed so that any
+    mounts setup inside this container are\n              # propagated back to the
+    host machine.\n              mountPropagation: \"Bidirectional\"\n            -
+    mountPath: /dev\n              name: device-dir\n            - mountPath: /etc/iscsi\n
+    \             name: iscsi-dir\n            - mountPath: /host\n              name:
     root-dir\n              # This is needed because mount is run from host using
     chroot.\n              mountPropagation: \"Bidirectional\"\n          ports:\n
     \           - containerPort: 9808\n              name: http-endpoint\n              protocol:
     TCP\n          livenessProbe:\n            httpGet:\n              path: /healthz\n
     \             port: http-endpoint\n            initialDelaySeconds: 60\n            timeoutSeconds:
     3\n            periodSeconds: 2\n            failureThreshold: 3\n        - name:
-    liveness-probe\n          resources:\n            requests:\n              cpu:
-    5m\n              memory: 20Mi\n          volumeMounts:\n            - mountPath:
-    /csi\n              name: plugin-dir\n          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0\n
+    liveness-probe\n          resources:\n            limits:\n              cpu:
+    50m\n              memory: 100Mi\n            requests:\n              cpu: 20m\n
+    \             memory: 40Mi\n          volumeMounts:\n            - mountPath:
+    /csi\n              name: plugin-dir\n          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0\n
     \         imagePullPolicy: IfNotPresent\n          args:\n            - --csi-address=/csi/csi.sock\n
     \           - --http-endpoint=:9808\n      priorityClassName: system-cluster-critical\n
     \     nodeSelector:\n        kubernetes.io/os: linux\n      volumes:\n        -
@@ -1512,68 +1521,73 @@ data:
     \         secret:\n            secretName: ntnx-pc-secret\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-controller-deployment.yaml\n#
     Copyright 2021 Nutanix Inc\n#\n# example usage: kubectl create -f <this_file>\n\nkind:
     Deployment\napiVersion: apps/v1\nmetadata:\n  name: nutanix-csi-controller\n  namespace:
-    ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name:
+    ntnx-system\n  labels:\n    helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name:
     nutanix-csi-storage\n    app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\nspec:\n  replicas: 2\n  strategy:\n     \n    type: RollingUpdate\n
-    \   rollingUpdate:\n      maxUnavailable: 1\n      maxSurge: 0\n  selector:\n
-    \   matchLabels:\n      app: nutanix-csi-controller\n  template:\n    metadata:\n
-    \     annotations:\n        kubectl.kubernetes.io/default-container: nutanix-csi-plugin\n
-    \     labels:\n        app: nutanix-csi-controller\n    spec:\n      affinity:\n
-    \       podAntiAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\nspec:\n  replicas:
+    2\n  strategy:\n     \n    type: RollingUpdate\n    rollingUpdate:\n      maxUnavailable:
+    1\n      maxSurge: 0\n  selector:\n    matchLabels:\n      app: nutanix-csi-controller\n
+    \ template:\n    metadata:\n      annotations:\n        kubectl.kubernetes.io/default-container:
+    nutanix-csi-plugin\n      labels:\n        app: nutanix-csi-controller\n    spec:\n
+    \     affinity:\n        podAntiAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n
     \           - labelSelector:\n                matchExpressions:\n                  -
     key: app\n                    operator: In\n                    values:\n                      -
     nutanix-csi-controller\n              topologyKey: kubernetes.io/hostname\n      serviceAccount:
     nutanix-csi-controller\n      hostNetwork: true\n      containers:\n        -
-    name: csi-provisioner\n          image: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0\n
+    name: csi-provisioner\n          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0\n
     \         imagePullPolicy: IfNotPresent\n          args:\n            - --csi-address=$(ADDRESS)\n
-    \           - --timeout=300s\n            - --worker-threads=16\n            #
+    \           - --timeout=300s\n            - --worker-threads=16\n            -
+    --retry-interval-start=5s\n            - --retry-interval-max=300s\n            #
     This adds PV/PVC metadata to create volume requests\n            - --extra-create-metadata=true\n
     \           - --default-fstype=ext4\n            # This is used to collect CSI
     operation metrics\n            - --http-endpoint=:9809\n            - --feature-gates=Topology=true\n
     \           - --leader-election=true\n            - --v=2\n            - --prevent-volume-mode-conversion=true\n
     \         env:\n            - name: ADDRESS\n              value: /var/lib/csi/sockets/pluginproxy/csi.sock\n
-    \         resources:\n            limits:\n              cpu: 100m\n              memory:
-    200Mi\n            requests:\n              cpu: 100m\n              memory: 200Mi\n
+    \         resources:\n            limits:\n              cpu: 50m\n              memory:
+    100Mi\n            requests:\n              cpu: 20m\n              memory: 40Mi\n
     \         volumeMounts:\n            - name: socket-dir\n              mountPath:
     /var/lib/csi/sockets/pluginproxy/\n        - name: csi-attacher\n          image:
-    registry.k8s.io/sig-storage/csi-attacher:v4.8.1\n          imagePullPolicy: IfNotPresent\n
+    registry.k8s.io/sig-storage/csi-attacher:v4.10.0\n          imagePullPolicy: IfNotPresent\n
     \         args:\n            - --csi-address=$(ADDRESS)\n            - --timeout=300s\n
-    \           - --worker-threads=16\n            - --http-endpoint=:9810\n            -
+    \           - --worker-threads=16\n            - --retry-interval-start=5s\n            -
+    --retry-interval-max=300s\n            - --http-endpoint=:9810\n            -
     --v=2\n            - --leader-election=true\n          env:\n            - name:
     ADDRESS\n              value: /var/lib/csi/sockets/pluginproxy/csi.sock\n          resources:\n
-    \           limits:\n              cpu: 100m\n              memory: 200Mi\n            requests:\n
-    \             cpu: 100m\n              memory: 200Mi\n          volumeMounts:\n
+    \           limits:\n              cpu: 50m\n              memory: 100Mi\n            requests:\n
+    \             cpu: 20m\n              memory: 40Mi\n          volumeMounts:\n
     \           - name: socket-dir\n              mountPath: /var/lib/csi/sockets/pluginproxy/\n
-    \       - name: csi-resizer\n          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.2\n
+    \       - name: csi-resizer\n          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0\n
     \         imagePullPolicy: IfNotPresent\n          args:\n            - --v=2\n
     \           - --csi-address=$(ADDRESS)\n            - --timeout=300s\n            -
     --leader-election=true\n            # NTNX CSI dirver supports online volume expansion.\n
     \           - --handle-volume-inuse-error=false\n            - --http-endpoint=:9811\n
     \         env:\n            - name: ADDRESS\n              value: /var/lib/csi/sockets/pluginproxy/csi.sock\n
-    \         resources:\n            limits:\n              cpu: 100m\n              memory:
-    200Mi\n            requests:\n              cpu: 100m\n              memory: 200Mi\n
+    \         resources:\n            limits:\n              cpu: 50m\n              memory:
+    100Mi\n            requests:\n              cpu: 20m\n              memory: 40Mi\n
     \         volumeMounts:\n            - name: socket-dir\n              mountPath:
     /var/lib/csi/sockets/pluginproxy/\n        # Checks whether to deploy snapshotter
-    sidecar.\n        - name: csi-snapshotter\n          image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3\n
+    sidecar.\n        - name: csi-snapshotter\n          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0\n
     \         imagePullPolicy: IfNotPresent\n          args:\n          - --csi-address=$(ADDRESS)\n
-    \         - --leader-election=true\n          - --logtostderr=true\n          -
-    --timeout=300s\n          - --metrics-address=:9812\n          env:\n          -
-    name: ADDRESS\n            value: /csi/csi.sock\n          resources:\n            requests:\n
-    \             cpu: 5m\n              memory: 30Mi\n          volumeMounts:\n          -
-    name: socket-dir\n            mountPath: /csi\n        - name: nutanix-csi-plugin\n
-    \         image: docker.io/nutanix/ntnx-csi:3.3.4\n          imagePullPolicy:
-    IfNotPresent\n          securityContext:\n            allowPrivilegeEscalation:
+    \         - --leader-election=true\n          - --timeout=300s\n          - --metrics-address=:9812\n
+    \         env:\n          - name: ADDRESS\n            value: /csi/csi.sock\n
+    \         resources:\n            limits:\n              cpu: 50m\n              memory:
+    100Mi\n            requests:\n              cpu: 20m\n              memory: 40Mi\n
+    \         volumeMounts:\n          - name: socket-dir\n            mountPath:
+    /csi\n        - name: nutanix-csi-plugin\n          image: docker.io/nutanix/ntnx-csi:3.7.0\n
+    \         imagePullPolicy: IfNotPresent\n          securityContext:\n            allowPrivilegeEscalation:
     true\n            privileged: true\n          args:\n            - --endpoint=$(CSI_ENDPOINT)\n
     \           - --nodeid=$(NODE_ID)\n            - --drivername=csi.nutanix.com\n
     \           - --files-ro-volumes-clone-enabled=false\n            # this flag
     is applicable for PC based CSI driver only\n            - --force-detach-existing-client-for-sync-rep-vol=false\n
+    \           - --force-detach-existing-client-in-pe-mode=true\n            - --enable-rw-multi-support=false\n
     \           # - --capacity-bytes-threshold=50.0\n          env:\n            -
     name: CSI_ENDPOINT\n              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock\n
     \           - name: NODE_ID\n              valueFrom:\n                fieldRef:\n
     \                 fieldPath: spec.nodeName\n            - name: CSI_CONTROLLER_POD_NAMESPACE\n
     \             valueFrom:\n                fieldRef:\n                  fieldPath:
     metadata.namespace\n            - name: CSI_SECRET_DIR\n              value: /var/run/ntnx-secret-dir\n
+    \           - name: CSI_JWT_TOKEN_DIR\n              value: /var/run/ntnx-token-dir\n
+    \           - name: CSI_PE_SECRET_DIR\n              value: /var/run/ntnx-pe-secret-dir\n
     \           - name: CSI_CATEGORY_CONFIGMAP_NAME\n              value: ntnx-cluster-configmap\n
     \           - name: CSI_CATEGORY_CONFIGMAP_NAMESPACE\n              value: ntnx-system\n
     \           - name: CSI_INIT_CONFIGMAP_NAME\n              value: ntnx-init-configmap\n
@@ -1581,60 +1595,75 @@ data:
     \           - name: CSI_CATEGORYID_CONFIGMAP_NAME\n              value: nutanix-storage-category-id\n
     \           - name: CSI_CATEGORYID_CONFIGMAP_NAMESPACE\n              value: ntnx-system\n
     \           - name: CSI_PLUGIN_TYPE\n              value: CONTROLLER_PLUGIN\n
-    \         resources:\n            limits:\n              cpu: 200m\n              memory:
-    200Mi\n            requests:\n              cpu: 200m\n              memory: 200Mi\n
+    \         resources:\n            limits:\n              cpu: 50m\n              memory:
+    200Mi\n            requests:\n              cpu: 20m\n              memory: 100Mi\n
     \         volumeMounts:\n            - mountPath: /var/lib/csi/sockets/pluginproxy/\n
     \             name: socket-dir\n            # This is needed for static NFS volume
-    feature.\n            - mountPath: /host\n              name: root-dir\n            -
-    mountPath: /var/run/ntnx-secret-dir\n              name: pc-secret\n              readOnly:
-    true\n          ports:\n            - containerPort: 9807\n              name:
-    http-endpoint\n              protocol: TCP\n          livenessProbe:\n            httpGet:\n
-    \             path: /healthz\n              port: http-endpoint\n            initialDelaySeconds:
-    60\n            timeoutSeconds: 3\n            periodSeconds: 2\n            failureThreshold:
-    3\n        - name: liveness-probe\n          resources:\n            requests:\n
-    \             cpu: 5m\n              memory: 20Mi\n          volumeMounts:\n            -
-    mountPath: /csi\n              name: socket-dir\n          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0\n
-    \         imagePullPolicy: IfNotPresent\n          args:\n            - --csi-address=/csi/csi.sock\n
-    \           - --http-endpoint=:9807\n        - args:\n          - \"--v=5\"\n
-    \         - \"--csi-address=$(ADDRESS)\"\n          - \"--leader-election=false\"\n
-    \         - \"--http-endpoint=:9813\"\n          - \"--monitor-interval=1m0s\"\n
-    \         env:\n            - name: ADDRESS\n              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock\n
-    \         image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0\n
-    \         imagePullPolicy: IfNotPresent\n          name: csi-external-health-monitor-controller\n
-    \         volumeMounts:\n            - mountPath: /var/lib/csi/sockets/pluginproxy/\n
-    \             name: socket-dir\n      priorityClassName: system-cluster-critical\n
-    \     volumes:\n        - emptyDir: {}\n          name: socket-dir\n        -
-    hostPath:\n            path: /\n            type: Directory\n          name: root-dir\n
-    \       - name: pc-secret\n          secret:\n            secretName: ntnx-pc-secret\n---\n#
-    Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\n# Copyright 2018 Nutanix
-    Inc\n#\n# Configuration to deploy the Nutanix CSI driver\n#\n# example usage:
-    kubectl create -f <this_file>\n---\n# Source: nutanix-csi-storage/templates/sc-check.yaml\n#
+    feature.\n            - mountPath: /host\n              name: root-dir\n              #
+    This ensures that unmount events on the host propagate to the container, preventing
+    orphan mounts under /host.\n              mountPropagation: HostToContainer\n
+    \           - mountPath: /var/run/ntnx-secret-dir\n              name: pc-secret\n
+    \             readOnly: true\n          ports:\n            - containerPort: 9807\n
+    \             name: http-endpoint\n              protocol: TCP\n          livenessProbe:\n
+    \           httpGet:\n              path: /healthz\n              port: http-endpoint\n
+    \           initialDelaySeconds: 60\n            timeoutSeconds: 3\n            periodSeconds:
+    2\n            failureThreshold: 3\n        - name: liveness-probe\n          resources:\n
+    \           limits:\n              cpu: 50m\n              memory: 100Mi\n            requests:\n
+    \             cpu: 20m\n              memory: 40Mi\n          volumeMounts:\n
+    \           - mountPath: /csi\n              name: socket-dir\n          image:
+    registry.k8s.io/sig-storage/livenessprobe:v2.17.0\n          imagePullPolicy:
+    IfNotPresent\n          args:\n            - --csi-address=/csi/csi.sock\n            -
+    --http-endpoint=:9807\n        - args:\n          - \"--v=5\"\n          - \"--csi-address=$(ADDRESS)\"\n
+    \         - \"--leader-election=false\"\n          - \"--http-endpoint=:9813\"\n
+    \         - \"--monitor-interval=1m0s\"\n          env:\n            - name: ADDRESS\n
+    \             value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock\n          image:
+    registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.16.0\n          imagePullPolicy:
+    IfNotPresent\n          name: csi-external-health-monitor-controller\n          resources:\n
+    \           limits:\n              cpu: 100m\n              memory: 100Mi\n            requests:\n
+    \             cpu: 20m\n              memory: 40Mi\n          volumeMounts:\n
+    \           - mountPath: /var/lib/csi/sockets/pluginproxy/\n              name:
+    socket-dir\n      priorityClassName: system-cluster-critical\n      volumes:\n
+    \       - emptyDir: {}\n          name: socket-dir\n        - hostPath:\n            path:
+    /\n            type: Directory\n          name: root-dir\n        - name: pc-secret\n
+    \         secret:\n            secretName: ntnx-pc-secret\n---\n# Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml\n#
+    Copyright 2018 Nutanix Inc\n#\n# Configuration to deploy the Nutanix CSI driver\n#\n#
+    example usage: kubectl create -f <this_file>\n---\n# Source: nutanix-csi-storage/templates/pe-secrets.yaml\n#
+    Validation: When usePC is false and usePETopology is enabled, peSecrets must not
+    be empty\n\n# CSI managed PE secrets\n---\n# Source: nutanix-csi-storage/templates/sc-check.yaml\n#
     defining error message for blocking upgrade from 3.0.0-beta.1912<=(CSI version)<=3.1.0
     to 3.2 PE mode\n\n# defining error message for blocking upgrade from CSI version>=
     3.2.0 PC to PE mode\n\n# This checks if the maxVolumesPerNode value exceeds the
     allowed maximum of 128.\n\n# This checks for the csidriver and checks whether
     the already existing driver is any of versions (>=3.0.0-beta.1904, <=3.1.0, 3.2.0
-    PC mode) from the labels and blocks the upgrade to >= 3.2.0 PE mode\n\n# This
-    checks for existing PVs with the volume attribute isLVMVolume=\"true\", \n# and
-    blocks the installation or upgrade if any are found.\n# Additionally, if the installation
-    is in PE mode, it verifies the presence of \n# nodePublishSecretRef in the spec.csi.
-    If not found, the installation or upgrade will also fail.\n\n\n# This function
-    checks for the secretRef in storage class parameters and fails installation if
-    any secretRef is missing# This checks for the existing storage classes which has
-    provisioner set as csiDriver \n# and throws an error if any of the secretRef is
-    missing, it skips\n# the check if annotaion meta.helm.sh/release-name set to the
-    release name,\n# and instead updates the storageclass with the ControllerPublishVolume
+    PC mode) from the labels and blocks the upgrade to 3.2.0 PE mode\n\n# This blocks
+    the upgrade from CSI with PE topology enabled to CSI with PE topology disabled\n\n#
+    This blocks the installation/upgrade when usePEFallback is enabled in PE Mode
+    (usePC=false)\n\n# This checks for existing PVs with the volume attribute isLVMVolume=\"true\",
+    \n# and blocks the installation or upgrade if any are found.\n# Additionally,
+    if the installation is in PE mode, it verifies the presence of \n# nodePublishSecretRef
+    in the spec.csi. If not found, the installation or upgrade will also fail.\n\n\n#
+    This function checks for the secretRef in storage class parameters and fails installation
+    if any secretRef is missing# This checks for the existing storage classes which
+    has provisioner set as csiDriver \n# and throws an error if any of the secretRef
+    is missing, it skips\n# the check if annotaion meta.helm.sh/release-name set to
+    the release name,\n# and instead updates the storageclass with the ControllerPublishVolume
     secretRef\n# as storageclass is deployed by previous isntallation.\n\n# Retaining
-    storage classes deployed by previous installations\n---\n# Source: nutanix-csi-storage/templates/csi-driver.yaml\napiVersion:
+    storage classes deployed by previous installations\n---\n# Source: nutanix-csi-storage/templates/secret-check.yaml\n#
+    Checks whether the PC Secret follows the new JSON format for all auth types. Currently
+    unused.# Checks whether the secret is a valid ServiceAuth secret in the new JSON
+    format introduced with CSI 3.5# Check if the Secret uses the ip:port:username:password
+    format (used in CSI < 3.5.0)\n\n# Validates the user defined PC secret\n\n# Checks
+    whether the PE Secret follows the new JSON format for all auth types. Currently
+    unused.# Validates the user defined PE secrets\n---\n# Source: nutanix-csi-storage/templates/csi-driver.yaml\napiVersion:
     storage.k8s.io/v1\nkind: CSIDriver\nmetadata:\n  name: csi.nutanix.com\n  labels:\n
-    \   helm.sh/chart: nutanix-csi-storage-3.3.4\n    app.kubernetes.io/name: nutanix-csi-storage\n
+    \   helm.sh/chart: nutanix-csi-storage-3.7.0\n    app.kubernetes.io/name: nutanix-csi-storage\n
     \   app.kubernetes.io/instance: nutanix-storage\n    app.kubernetes.io/version:
-    \"3.3.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
-    \"PrismCentral\"\nspec:\n  attachRequired: true\n  podInfoOnMount: true\n---\n#
-    Source: nutanix-csi-storage/templates/ntnx-sc.yaml\napiVersion: snapshot.storage.k8s.io/v1beta1\nkind:
-    VolumeSnapshotClass\nmetadata:\n  name: nutanix-snapshot-class\n  annotations:\n
-    \ labels:\ndriver: csi.nutanix.com\nparameters:\n  storageType: NutanixVolumes\ndeletionPolicy:
-    Retain\n---\n# Source: nutanix-csi-storage/templates/precheck.yaml\napiVersion:
+    \"3.7.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/management-plane:
+    \"PrismCentral\"\n    app.kubernetes.io/topology-enabled: \"true\"\nspec:\n  attachRequired:
+    true\n  podInfoOnMount: true\n  fsGroupPolicy: File\n---\n# Source: nutanix-csi-storage/templates/ntnx-sc.yaml\napiVersion:
+    snapshot.storage.k8s.io/v1beta1\nkind: VolumeSnapshotClass\nmetadata:\n  name:
+    nutanix-snapshot-class\n  annotations:\n  labels:\ndriver: csi.nutanix.com\nparameters:\n
+    \ storageType: NutanixVolumes\ndeletionPolicy: Retain\n---\n# Source: nutanix-csi-storage/templates/precheck.yaml\napiVersion:
     v1\nkind: ServiceAccount\nmetadata:\n  name: nutanix-storage-precheck-serviceaccount\n
     \ namespace: ntnx-system\n  annotations:\n    \"helm.sh/hook-delete-policy\":
     hook-succeeded,before-hook-creation,hook-failed\n    \"helm.sh/hook\": pre-upgrade,pre-install\n
@@ -1660,19 +1689,20 @@ data:
     \ labels:\n    app: nutanix-storage-precheck\nspec:\n  template:\n    metadata:\n
     \     name: nutanix-storage-precheck-job\n    spec:\n      restartPolicy: Never\n
     \     serviceAccountName: nutanix-storage-precheck-serviceaccount\n      containers:\n
-    \       - name: ntnx-csi-precheck\n          image: docker.io/nutanix/ntnx-csi-precheck:3.3.4\n
+    \       - name: ntnx-csi-precheck\n          image: docker.io/nutanix/ntnx-csi-precheck:3.7.0\n
     \         imagePullPolicy: IfNotPresent\n          env:\n            - name: CSI_PC_SECRET_DIR\n
-    \             value: \"/var/run/prechek-pc-secret-dir\"\n            - name: CSI_CATEGORY_CONFIGMAP_NAME\n
-    \             value: ntnx-cluster-configmap\n            - name: CSI_CATEGORY_CONFIGMAP_NAMESPACE\n
-    \             value: ntnx-system\n            - name: CSI_CATEGORYID_CONFIGMAP_NAME\n
-    \             value: nutanix-storage-category-id\n            - name: PRECHECK_CONFIGMAP_NAME\n
-    \             value: nutanix-storage-precheck-configmap\n            - name: RELEASE_NAMESPACE\n
-    \             value: ntnx-system\n            - name: MIN_SUPPORTED_PC_VERSION\n
-    \             value: pc.2024.2\n            - name: USE_PC\n              value:
-    \"true\"\n          volumeMounts:\n            - mountPath: /var/run/prechek-pc-secret-dir\n
-    \             name: precheck-pc-secret\n              readOnly: true\n      volumes:\n
-    \       - name: precheck-pc-secret\n          secret:\n            secretName:
-    ntnx-pc-secret\n  backoffLimit: 0\n"
+    \             value: \"/var/run/precheck-pc-secret-dir\"\n            - name:
+    CSI_CATEGORY_CONFIGMAP_NAME\n              value: ntnx-cluster-configmap\n            -
+    name: CSI_CATEGORY_CONFIGMAP_NAMESPACE\n              value: ntnx-system\n            -
+    name: CSI_CATEGORYID_CONFIGMAP_NAME\n              value: nutanix-storage-category-id\n
+    \           - name: PRECHECK_CONFIGMAP_NAME\n              value: nutanix-storage-precheck-configmap\n
+    \           - name: RELEASE_NAMESPACE\n              value: ntnx-system\n            -
+    name: MIN_SUPPORTED_PC_VERSION\n              value: pc.2024.2\n            -
+    name: USE_PC\n              value: \"true\"\n            - name: USE_PE_FALLBACK\n
+    \             value: \"false\"\n          volumeMounts:\n            - mountPath:
+    /var/run/precheck-pc-secret-dir\n              name: precheck-pc-secret\n              readOnly:
+    true\n      volumes:\n        - name: precheck-pc-secret\n          secret:\n
+    \           secretName: ntnx-pc-secret\n  backoffLimit: 0\n"
   nutanix-csi-webhook.yaml: |
     ---
     apiVersion: v1

--- a/templates/csi3/nutanix-csi-storage.yaml
+++ b/templates/csi3/nutanix-csi-storage.yaml
@@ -6,12 +6,13 @@ metadata:
   name: nutanix-csi-controller
   namespace: ntnx-system
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 ---
 # Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
 apiVersion: v1
@@ -27,16 +28,19 @@ metadata:
   name: ntnx-init-configmap
   namespace: ntnx-system
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 data:
   kubernetesClusterDeploymentType: non-bare-metal
   usePC: "true"
   associateCategoriesToVolume: "true"
+  usePEFallback: "false"
+  usePETopology: "false"
 ---
 # Source: nutanix-csi-storage/templates/ntnx-csi-rbac.yaml
 kind: ClusterRole
@@ -45,16 +49,17 @@ metadata:
   name: nutanix-csi-controller-role
   namespace: ntnx-system
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -182,12 +187,13 @@ metadata:
   namespace: ntnx-system
   labels:
     app: nutanix-csi-metrics
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 spec:
   type: ClusterIP
   selector:
@@ -221,12 +227,13 @@ metadata:
   name: nutanix-csi-node
   namespace: ntnx-system
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 spec:
   selector:
     matchLabels:
@@ -246,7 +253,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=2
@@ -263,11 +270,11 @@ spec:
                   fieldPath: spec.nodeName
           resources:
             limits:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi/
@@ -277,15 +284,21 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: docker.io/nutanix/ntnx-csi:3.3.4
+          image: docker.io/nutanix/ntnx-csi:3.7.0
           imagePullPolicy: IfNotPresent
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"
             - "--drivername=csi.nutanix.com"
             - "--max-volumes-per-node=64"
+            - "--enable-rw-multi-support=false"
+            - --force-detach-existing-client-in-pe-mode=true
             # - --volume-capacity-threshold=50.0
           env:
+            - name: CSI_JWT_TOKEN_FILE
+              value: ntnx-jwt-secret
+            - name: CSI_JWT_TOKEN_DIR
+              value: /var/run/ntnx-token-dir
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: NODE_ID
@@ -298,6 +311,8 @@ spec:
                   fieldPath: status.hostIP
             - name: CSI_SECRET_DIR
               value: /var/run/ntnx-secret-dir
+            - name: CSI_PE_SECRET_DIR
+              value: /var/run/ntnx-pe-secret-dir
             - name: CSI_INIT_CONFIGMAP_NAME
               value: ntnx-init-configmap
             - name: CSI_INIT_CONFIGMAP_NAMESPACE
@@ -306,10 +321,10 @@ spec:
               value: NODE_PLUGIN
           resources:
             limits:
-              cpu: 200m
+              cpu: 50m
               memory: 200Mi
             requests:
-              cpu: 200m
+              cpu: 20m
               memory: 200Mi
           volumeMounts:
             - mountPath: /var/run/ntnx-secret-dir
@@ -344,13 +359,16 @@ spec:
             failureThreshold: 3
         - name: liveness-probe
           resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 5m
-              memory: 20Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /csi
               name: plugin-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -397,12 +415,13 @@ metadata:
   name: nutanix-csi-controller
   namespace: ntnx-system
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 spec:
   replicas: 2
   strategy:
@@ -435,12 +454,14 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --timeout=300s
             - --worker-threads=16
+            - --retry-interval-start=5s
+            - --retry-interval-max=300s
             # This adds PV/PVC metadata to create volume requests
             - --extra-create-metadata=true
             - --default-fstype=ext4
@@ -455,21 +476,23 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             limits:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --timeout=300s
             - --worker-threads=16
+            - --retry-interval-start=5s
+            - --retry-interval-max=300s
             - --http-endpoint=:9810
             - --v=2
             - --leader-election=true
@@ -478,16 +501,16 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             limits:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=2
@@ -502,36 +525,38 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             limits:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         # Checks whether to deploy snapshotter sidecar.
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=$(ADDRESS)
           - --leader-election=true
-          - --logtostderr=true
           - --timeout=300s
           - --metrics-address=:9812
           env:
           - name: ADDRESS
             value: /csi/csi.sock
           resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 5m
-              memory: 30Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
           - name: socket-dir
             mountPath: /csi
         - name: nutanix-csi-plugin
-          image: docker.io/nutanix/ntnx-csi:3.3.4
+          image: docker.io/nutanix/ntnx-csi:3.7.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -543,6 +568,8 @@ spec:
             - --files-ro-volumes-clone-enabled=false
             # this flag is applicable for PC based CSI driver only
             - --force-detach-existing-client-for-sync-rep-vol=false
+            - --force-detach-existing-client-in-pe-mode=true
+            - --enable-rw-multi-support=false
             # - --capacity-bytes-threshold=50.0
           env:
             - name: CSI_ENDPOINT
@@ -557,6 +584,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: CSI_SECRET_DIR
               value: /var/run/ntnx-secret-dir
+            - name: CSI_JWT_TOKEN_DIR
+              value: /var/run/ntnx-token-dir
+            - name: CSI_PE_SECRET_DIR
+              value: /var/run/ntnx-pe-secret-dir
             - name: CSI_CATEGORY_CONFIGMAP_NAME
               value: ntnx-cluster-configmap
             - name: CSI_CATEGORY_CONFIGMAP_NAMESPACE
@@ -573,17 +604,19 @@ spec:
               value: CONTROLLER_PLUGIN
           resources:
             limits:
-              cpu: 200m
+              cpu: 50m
               memory: 200Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 20m
+              memory: 100Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
             # This is needed for static NFS volume feature.
             - mountPath: /host
               name: root-dir
+              # This ensures that unmount events on the host propagate to the container, preventing orphan mounts under /host.
+              mountPropagation: HostToContainer
             - mountPath: /var/run/ntnx-secret-dir
               name: pc-secret
               readOnly: true
@@ -601,13 +634,16 @@ spec:
             failureThreshold: 3
         - name: liveness-probe
           resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
             requests:
-              cpu: 5m
-              memory: 20Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -621,9 +657,16 @@ spec:
           env:
             - name: ADDRESS
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.16.0
           imagePullPolicy: IfNotPresent
           name: csi-external-health-monitor-controller
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -646,6 +689,11 @@ spec:
 #
 # example usage: kubectl create -f <this_file>
 ---
+# Source: nutanix-csi-storage/templates/pe-secrets.yaml
+# Validation: When usePC is false and usePETopology is enabled, peSecrets must not be empty
+
+# CSI managed PE secrets
+---
 # Source: nutanix-csi-storage/templates/sc-check.yaml
 # defining error message for blocking upgrade from 3.0.0-beta.1912<=(CSI version)<=3.1.0 to 3.2 PE mode
 
@@ -653,7 +701,11 @@ spec:
 
 # This checks if the maxVolumesPerNode value exceeds the allowed maximum of 128.
 
-# This checks for the csidriver and checks whether the already existing driver is any of versions (>=3.0.0-beta.1904, <=3.1.0, 3.2.0 PC mode) from the labels and blocks the upgrade to >= 3.2.0 PE mode
+# This checks for the csidriver and checks whether the already existing driver is any of versions (>=3.0.0-beta.1904, <=3.1.0, 3.2.0 PC mode) from the labels and blocks the upgrade to 3.2.0 PE mode
+
+# This blocks the upgrade from CSI with PE topology enabled to CSI with PE topology disabled
+
+# This blocks the installation/upgrade when usePEFallback is enabled in PE Mode (usePC=false)
 
 # This checks for existing PVs with the volume attribute isLVMVolume="true", 
 # and blocks the installation or upgrade if any are found.
@@ -669,21 +721,30 @@ spec:
 
 # Retaining storage classes deployed by previous installations
 ---
+# Source: nutanix-csi-storage/templates/secret-check.yaml
+# Checks whether the PC Secret follows the new JSON format for all auth types. Currently unused.# Checks whether the secret is a valid ServiceAuth secret in the new JSON format introduced with CSI 3.5# Check if the Secret uses the ip:port:username:password format (used in CSI < 3.5.0)
+
+# Validates the user defined PC secret
+
+# Checks whether the PE Secret follows the new JSON format for all auth types. Currently unused.# Validates the user defined PE secrets
+---
 # Source: nutanix-csi-storage/templates/csi-driver.yaml
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.nutanix.com
   labels:
-    helm.sh/chart: nutanix-csi-storage-3.3.4
+    helm.sh/chart: nutanix-csi-storage-3.7.0
     app.kubernetes.io/name: nutanix-csi-storage
     app.kubernetes.io/instance: nutanix-storage
-    app.kubernetes.io/version: "3.3.4"
+    app.kubernetes.io/version: "3.7.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/management-plane: "PrismCentral"
+    app.kubernetes.io/topology-enabled: "true"
 spec:
   attachRequired: true
   podInfoOnMount: true
+  fsGroupPolicy: File
 ---
 # Source: nutanix-csi-storage/templates/ntnx-sc.yaml
 apiVersion: snapshot.storage.k8s.io/v1beta1
@@ -772,11 +833,11 @@ spec:
       serviceAccountName: nutanix-storage-precheck-serviceaccount
       containers:
         - name: ntnx-csi-precheck
-          image: docker.io/nutanix/ntnx-csi-precheck:3.3.4
+          image: docker.io/nutanix/ntnx-csi-precheck:3.7.0
           imagePullPolicy: IfNotPresent
           env:
             - name: CSI_PC_SECRET_DIR
-              value: "/var/run/prechek-pc-secret-dir"
+              value: "/var/run/precheck-pc-secret-dir"
             - name: CSI_CATEGORY_CONFIGMAP_NAME
               value: ntnx-cluster-configmap
             - name: CSI_CATEGORY_CONFIGMAP_NAMESPACE
@@ -791,8 +852,10 @@ spec:
               value: pc.2024.2
             - name: USE_PC
               value: "true"
+            - name: USE_PE_FALLBACK
+              value: "false"
           volumeMounts:
-            - mountPath: /var/run/prechek-pc-secret-dir
+            - mountPath: /var/run/precheck-pc-secret-dir
               name: precheck-pc-secret
               readOnly: true
       volumes:

--- a/templates/csi3/nutanix-csi-storage.yaml
+++ b/templates/csi3/nutanix-csi-storage.yaml
@@ -862,4 +862,4 @@ spec:
         - name: precheck-pc-secret
           secret:
             secretName: ntnx-pc-secret
-  backoffLimit: 0
+  backoffLimit: 10

--- a/test/e2e/csi_test.go
+++ b/test/e2e/csi_test.go
@@ -1,0 +1,398 @@
+//go:build e2e
+
+/*
+Copyright 2022 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Nutanix flavor CSI", Label("nutanix-storage-test", "csi"), func() {
+	const (
+		specName = "cluster-csi"
+
+		nutanixWebhookCAKey        = "WEBHOOK_CA"
+		nutanixWebhookCertKey      = "WEBHOOK_CERT"
+		nutanixWebhookKeyKey       = "WEBHOOK_KEY"
+		nutanixStorageContainerKey = "NUTANIX_STORAGE_CONTAINER"
+
+		csiNamespaceName  = "ntnx-system"
+		csiDeploymentName = "nutanix-csi-controller"
+		csiProvisioner    = "csi.nutanix.com"
+	)
+
+	var (
+		namespace        *corev1.Namespace
+		clusterName      string
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		cancelWatches    context.CancelFunc
+		testHelper       testHelperInterface
+		workloadClient   client.Client
+
+		csiStorageClassName = util.RandomString(10)
+
+		nutanixStorageContainer string
+	)
+
+	BeforeEach(func() {
+		testHelper = newTestHelper(e2eConfig)
+		clusterName = testHelper.generateTestClusterName(specName)
+		clusterResources = &clusterctl.ApplyClusterTemplateAndWaitResult{}
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy can't be nil")
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+
+		nutanixWebhookCA := testHelper.getVariableFromE2eConfig(nutanixWebhookCAKey)
+		Expect(nutanixWebhookCA).ToNot(BeEmpty())
+		nutanixWebhookCert := testHelper.getVariableFromE2eConfig(nutanixWebhookCertKey)
+		Expect(nutanixWebhookCert).ToNot(BeEmpty())
+		nutanixWebhookKey := testHelper.getVariableFromE2eConfig(nutanixWebhookKeyKey)
+		Expect(nutanixWebhookKey).ToNot(BeEmpty())
+		nutanixStorageContainer = testHelper.getVariableFromE2eConfig(nutanixStorageContainerKey)
+		Expect(nutanixStorageContainer).ToNot(BeEmpty())
+	})
+
+	AfterEach(func() {
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+	})
+
+	It("Create a cluster with Nutanix CSI 3.0 and use Nutanix Volumes to create PV", Label("csi3"), func() {
+		const flavor = "csi3"
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		testHelper.deployClusterAndWait(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+			}, clusterResources)
+
+		By("Fetching workload client")
+		workloadProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)
+		workloadClient = workloadProxy.GetClient()
+
+		By("Checking if CSI namespace exists")
+		csiNamespace := &corev1.Namespace{}
+		csiNamespaceKey := client.ObjectKey{
+			Name: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiNamespaceKey, csiNamespace)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if CSI deployment exists")
+		csiDeployment := &appsv1.Deployment{}
+		csiDeploymentKey := client.ObjectKey{
+			Name:      csiDeploymentName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiDeploymentKey, csiDeployment)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI Storage class")
+		sc := &storagev1.StorageClass{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "storage.k8s.io/v1",
+				Kind:       "StorageClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: csiStorageClassName,
+				Annotations: map[string]string{
+					"storageclass.kubernetes.io/is-default-class": "true",
+				},
+			},
+			Provisioner:          csiProvisioner,
+			ReclaimPolicy:        ptr.To(corev1.PersistentVolumeReclaimDelete),
+			VolumeBindingMode:    ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
+			AllowVolumeExpansion: ptr.To(false),
+			Parameters: map[string]string{
+				"csi.storage.k8s.io/provisioner-secret-name":            "nutanix-csi-credentials",
+				"csi.storage.k8s.io/provisioner-secret-namespace":       csiNamespaceName,
+				"csi.storage.k8s.io/node-publish-secret-name":           "nutanix-csi-credentials",
+				"csi.storage.k8s.io/node-publish-secret-namespace":      csiNamespaceName,
+				"csi.storage.k8s.io/controller-expand-secret-name":      "nutanix-csi-credentials",
+				"csi.storage.k8s.io/controller-expand-secret-namespace": csiNamespaceName,
+				"csi.storage.k8s.io/fstype":                             "xfs",
+				"flashMode":                                             "DISABLED",
+				"hypervisorAttached":                                    "ENABLED",
+				"storageContainer":                                      nutanixStorageContainer,
+				"storageType":                                           "NutanixVolumes",
+				"description":                                           "CAPX e2e-test",
+			},
+		}
+		Eventually(func() error {
+			return workloadClient.Create(ctx, sc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI PVC")
+		pvcName := util.RandomString(10)
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: csiNamespaceName,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: ptr.To(csiStorageClassName),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			return workloadClient.Create(ctx, pvc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating a pod using the PVC to ensure VG is attached to the VM")
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "busybox-pod",
+				Namespace: csiNamespaceName,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "busybox",
+						Image:           "cgr.dev/chainguard/busybox:latest",
+						Command:         []string{"sleep", "3600"},
+						ImagePullPolicy: "IfNotPresent",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "csi-volume",
+								MountPath: "/data",
+							},
+						},
+					},
+				},
+				RestartPolicy: "Always",
+				Volumes: []corev1.Volume{
+					{
+						Name: "csi-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			return workloadClient.Create(ctx, pod)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if the pod is running")
+		podKey := client.ObjectKeyFromObject(pod)
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, podKey, pod)).To(Succeed())
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		})
+
+		By("Checking CSI PVC status is bound")
+		csiPvc := &corev1.PersistentVolumeClaim{}
+		csiPvcKey := client.ObjectKey{
+			Name:      pvcName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiPvcKey, csiPvc)).To(Succeed())
+			g.Expect(csiPvc.Status.Phase).To(Equal(corev1.ClaimBound))
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Deleting the pod")
+		Expect(workloadClient.Delete(ctx, pod)).To(Succeed())
+
+		By("Deleting CSI PVC")
+		Expect(workloadClient.Delete(ctx, csiPvc)).To(Succeed())
+	})
+
+	It("Create a cluster with Nutanix CSI 3.0 and use Nutanix Volumes to create PV and delete cluster without deleting PVC", Label("csi3"), func() {
+		const flavor = "csi3"
+
+		Expect(namespace).NotTo(BeNil())
+
+		By("Creating a workload cluster")
+		testHelper.deployClusterAndWait(
+			deployClusterParams{
+				clusterName:           clusterName,
+				namespace:             namespace,
+				flavor:                flavor,
+				clusterctlConfigPath:  clusterctlConfigPath,
+				artifactFolder:        artifactFolder,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+			}, clusterResources)
+
+		By("Fetching workload client")
+		workloadProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)
+		workloadClient = workloadProxy.GetClient()
+
+		By("Checking if CSI namespace exists")
+		csiNamespace := &corev1.Namespace{}
+		csiNamespaceKey := client.ObjectKey{
+			Name: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiNamespaceKey, csiNamespace)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if CSI deployment exists")
+		csiDeployment := &appsv1.Deployment{}
+		csiDeploymentKey := client.ObjectKey{
+			Name:      csiDeploymentName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiDeploymentKey, csiDeployment)).To(Succeed())
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI Storage class")
+		sc := &storagev1.StorageClass{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "storage.k8s.io/v1",
+				Kind:       "StorageClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: csiStorageClassName,
+				Annotations: map[string]string{
+					"storageclass.kubernetes.io/is-default-class": "true",
+				},
+			},
+			Provisioner:          csiProvisioner,
+			ReclaimPolicy:        ptr.To(corev1.PersistentVolumeReclaimDelete),
+			VolumeBindingMode:    ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
+			AllowVolumeExpansion: ptr.To(false),
+			Parameters: map[string]string{
+				"csi.storage.k8s.io/provisioner-secret-name":            "nutanix-csi-credentials",
+				"csi.storage.k8s.io/provisioner-secret-namespace":       csiNamespaceName,
+				"csi.storage.k8s.io/node-publish-secret-name":           "nutanix-csi-credentials",
+				"csi.storage.k8s.io/node-publish-secret-namespace":      csiNamespaceName,
+				"csi.storage.k8s.io/controller-expand-secret-name":      "nutanix-csi-credentials",
+				"csi.storage.k8s.io/controller-expand-secret-namespace": csiNamespaceName,
+				"csi.storage.k8s.io/fstype":                             "xfs",
+				"flashMode":                                             "DISABLED",
+				"hypervisorAttached":                                    "ENABLED",
+				"storageContainer":                                      nutanixStorageContainer,
+				"storageType":                                           "NutanixVolumes",
+				"description":                                           "CAPX e2e-test",
+			},
+		}
+		Eventually(func() error {
+			return workloadClient.Create(ctx, sc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating CSI PVC")
+		pvcName := util.RandomString(10)
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: csiNamespaceName,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: ptr.To(csiStorageClassName),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			return workloadClient.Create(ctx, pvc)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Creating a pod using the PVC to ensure VG is attached to the VM")
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "busybox-pod",
+				Namespace: csiNamespaceName,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "busybox",
+						Image:           "cgr.dev/chainguard/busybox:latest",
+						Command:         []string{"sleep", "3600"},
+						ImagePullPolicy: "IfNotPresent",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "csi-volume",
+								MountPath: "/data",
+							},
+						},
+					},
+				},
+				RestartPolicy: "Always",
+				Volumes: []corev1.Volume{
+					{
+						Name: "csi-volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			return workloadClient.Create(ctx, pod)
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+
+		By("Checking if the pod is running")
+		podKey := client.ObjectKeyFromObject(pod)
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, podKey, pod)).To(Succeed())
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+		})
+
+		By("Checking CSI PVC status is bound")
+		csiPvc := &corev1.PersistentVolumeClaim{}
+		csiPvcKey := client.ObjectKey{
+			Name:      pvcName,
+			Namespace: csiNamespaceName,
+		}
+		Eventually(func(g Gomega) {
+			g.Expect(workloadClient.Get(ctx, csiPvcKey, csiPvc)).To(Succeed())
+			g.Expect(csiPvc.Status.Phase).To(Equal(corev1.ClaimBound))
+		}, defaultTimeout, defaultInterval).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary
- #720 intended to remove only CSI 2.0 e2e coverage, but deleted `test/e2e/csi_test.go` in its entirety, which also removed the CSI 3.0 specs and silently zeroed out the `nutanix-storage-test` e2e job.
- Restore the CSI 3.0 `Describe`/`It` blocks in `test/e2e/csi_test.go` (dropping the CSI 2.0-only spec and its now-unused Prism Element secret fields, since CSI 3.0 provisions its secret via the CRS template using PC credentials, not in Go code).
- Bump the `nutanix-csi-storage` chart used to render `templates/csi3` from 3.3.4 to 3.7.0 (`scripts/csi3_nutanix_update.sh`), and regenerate `templates/csi3/nutanix-csi-storage.yaml` and `templates/cluster-template-csi3.yaml` accordingly.

## Test plan
- [x] `go build -tags e2e ./test/e2e/...`
- [x] `go vet -tags e2e ./test/e2e/...`
- [x] `golangci-lint run --build-tags e2e ./test/e2e/...`
- [x] CI: `nutanix-storage-test` e2e job runs the two CSI 3.0 specs against CSI driver 3.7.0