### PR TITLE
ci(e2e): reserve control plane endpoint IPs via Prism Central IPAM

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,43 +52,9 @@ jobs:
           if [[ "${{ inputs.e2e-labels }}" == "gpu" ]]; then
             echo "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME=${{ vars.NUTANIX_PRISM_ELEMENT_CLUSTER_NAME_WITH_GPU }}" >> "${GITHUB_OUTPUT}"
             echo "NUTANIX_SUBNET_NAME=${{ vars.NUTANIX_SUBNET_NAME_WITH_GPU }}" >> "${GITHUB_OUTPUT}"
-            echo "CONTROL_PLANE_ENDPOINT_RANGE_START=${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_START_WITH_GPU }}" >> "${GITHUB_OUTPUT}"
-            echo "CONTROL_PLANE_ENDPOINT_RANGE_END=${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_END_WITH_GPU }}" >> "${GITHUB_OUTPUT}"
           else
             echo "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME=${{ vars.NUTANIX_PRISM_ELEMENT_CLUSTER_NAME }}" >> "${GITHUB_OUTPUT}"
             echo "NUTANIX_SUBNET_NAME=${{ vars.NUTANIX_SUBNET_NAME }}" >> "${GITHUB_OUTPUT}"
-            echo "CONTROL_PLANE_ENDPOINT_RANGE_START=${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_START }}" >> "${GITHUB_OUTPUT}"
-            echo "CONTROL_PLANE_ENDPOINT_RANGE_END=${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_END }}" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Get Control Plane endpoint IP
-        id: get-control-plane-endpoint-ip
-        run: |
-          export CONTROL_PLANE_ENDPOINT_RANGE_START="${{ steps.pe-params.outputs.CONTROL_PLANE_ENDPOINT_RANGE_START }}"
-          export CONTROL_PLANE_ENDPOINT_RANGE_END="${{ steps.pe-params.outputs.CONTROL_PLANE_ENDPOINT_RANGE_END }}"
-          control_plane_endpoint_ip="$(devbox run -- make nutanix-cp-endpoint-ip)"
-          echo "control_plane_endpoint_ip=${control_plane_endpoint_ip}" >> "${GITHUB_OUTPUT}"
-
-      - name: Check Control Plane endpoint IP
-        run: |
-          if [[ -z "${{ steps.get-control-plane-endpoint-ip.outputs.control_plane_endpoint_ip }}" ]]; then
-            echo "control_plane_endpoint_ip is empty; cannot proceed with e2e tests"
-            exit 1
-          fi
-
-      - name: Get Control Plane endpoint IP for clusterctl upgrade test
-        id: get-control-plane-endpoint-ip-clusterctl-upgrade
-        run: |
-          export CONTROL_PLANE_ENDPOINT_RANGE_START="${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_START }}"
-          export CONTROL_PLANE_ENDPOINT_RANGE_END="${{ vars.CONTROL_PLANE_ENDPOINT_RANGE_END }}"
-          control_plane_endpoint_ip="$(devbox run -- make nutanix-cp-endpoint-ip)"
-          echo "control_plane_endpoint_ip_clusterctl_upgrade=${control_plane_endpoint_ip}" >> "${GITHUB_OUTPUT}"
-
-      - name: Check Control Plane endpoint IP for clusterctl upgrade
-        run: |
-          if [[ -z "${{ steps.get-control-plane-endpoint-ip-clusterctl-upgrade.outputs.control_plane_endpoint_ip_clusterctl_upgrade }}" ]]; then
-            echo "control_plane_endpoint_ip_clusterctl_upgrade is empty; cannot proceed with e2e tests"
-            exit 1
           fi
 
       - name: Login to Internal Container Registry
@@ -120,8 +86,6 @@ jobs:
           NUTANIX_SUBNET_NAME: ${{ steps.pe-params.outputs.NUTANIX_SUBNET_NAME }}
           NUTANIX_ADDITIONAL_SUBNET_NAME: ${{ vars.NUTANIX_ADDITIONAL_SUBNET_NAME }}
           NUTANIX_PROJECT_NAME: ${{ vars.NUTANIX_PROJECT_NAME }}
-          CONTROL_PLANE_ENDPOINT_IP: ${{ steps.get-control-plane-endpoint-ip.outputs.control_plane_endpoint_ip }}
-          CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER: ${{ steps.get-control-plane-endpoint-ip-clusterctl-upgrade.outputs.control_plane_endpoint_ip_clusterctl_upgrade }}
           NUTANIX_FAILURE_DOMAIN_1_PRISM_ELEMENT_NAME: ${{ vars.NUTANIX_FAILURE_DOMAIN_1_PRISM_ELEMENT_NAME }}
           NUTANIX_FAILURE_DOMAIN_1_SUBNET_NAME: ${{ vars.NUTANIX_FAILURE_DOMAIN_1_SUBNET_NAME }}
           NUTANIX_FAILURE_DOMAIN_2_PRISM_ELEMENT_NAME: ${{ vars.NUTANIX_FAILURE_DOMAIN_2_PRISM_ELEMENT_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,6 @@ kind-create: ## Create a kind cluster and deploy the latest supported cluster AP
 kind-delete: ## Delete the kind cluster
 	kind delete cluster --name=${KIND_CLUSTER_NAME}
 
-.PHONY: nutanix-cp-endpoint-ip
-nutanix-cp-endpoint-ip: ## Gets a random free IP from the control plane endpoint range set in the environment.
-	@shuf --head-count=1 < <(fping -g -u "$(CONTROL_PLANE_ENDPOINT_RANGE_START)" "$(CONTROL_PLANE_ENDPOINT_RANGE_END)")
-
 .PHONY: update-calico-cni
 update-calico-cni: ## Updates the calico CNI manifests
 	@echo "Updating calico CNI manifest"

--- a/docs/developer_workflow.md
+++ b/docs/developer_workflow.md
@@ -226,7 +226,6 @@ This will configure [kubectl](https://kubernetes.io/docs/reference/kubectl/) for
     export DOCKER_POD_IPV6_CIDRS="fc00::/112"
     export WORKER_MACHINE_COUNT="2"
    
-    export CONTROL_PLANE_ENDPOINT_IP='10.0.0.1'
     export NUTANIX_STORAGE_CONTAINER=storage-container
     export NUTANIX_ADDITIONAL_CATEGORY_KEY="AppType"
     export NUTANIX_ADDITIONAL_CATEGORY_VALUE="Kubernetes"
@@ -249,7 +248,13 @@ This will configure [kubectl](https://kubernetes.io/docs/reference/kubectl/) for
     
     export NUTANIX_SSH_AUTHORIZED_KEY='your-ssh-key'
     ```
-   
+
+    Note: unlike the manual workload cluster flow above, `CONTROL_PLANE_ENDPOINT_IP` and
+    `CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER` do not need to be set here. The e2e suite reserves
+    a free IP from `NUTANIX_SUBNET_NAME` via Prism Central's IPAM at suite startup, and releases it
+    again at the end of the run, so it is safe to run e2e tests concurrently without picking IPs by
+    hand or colliding with other runs against the same subnet.
+
     The remaining values for the e2e tests are set in `test/e2e/config/nutanix.yaml`
 
 1. Run the relevant e2e tests by specifying the label filters. For example, to run the non-clusterclass quickstart tests:

--- a/docs/developer_workflow.md
+++ b/docs/developer_workflow.md
@@ -250,10 +250,13 @@ This will configure [kubectl](https://kubernetes.io/docs/reference/kubectl/) for
     ```
 
     Note: unlike the manual workload cluster flow above, `CONTROL_PLANE_ENDPOINT_IP` and
-    `CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER` do not need to be set here. The e2e suite reserves
-    a free IP from `NUTANIX_SUBNET_NAME` via Prism Central's IPAM at suite startup, and releases it
-    again at the end of the run, so it is safe to run e2e tests concurrently without picking IPs by
-    hand or colliding with other runs against the same subnet.
+    `CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER` do not need to be set here. If left unset, the e2e
+    suite reserves a free IP from `NUTANIX_SUBNET_NAME` via Prism Central's IPAM at suite startup,
+    and releases it again at the end of the run, so it is safe to run e2e tests concurrently
+    without picking IPs by hand or colliding with other runs against the same subnet. You can still
+    set either variable explicitly (e.g. to pin a known-good address); auto-reservation only
+    applies to whichever one is left unset, and manually-provided values are never reserved or
+    released by the suite.
 
     The remaining values for the e2e tests are set in `test/e2e/config/nutanix.yaml`
 

--- a/test/e2e/categories_test.go
+++ b/test/e2e/categories_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"context"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -217,12 +216,6 @@ var _ = Describe("Nutanix categories", Label("nutanix-feature-test", "categories
 		By("Setting different Control plane endpoint IP for 2nd cluster", func() {
 			cp1EndpointIP = testHelper.getVariableFromE2eConfig("CONTROL_PLANE_ENDPOINT_IP")
 			cp2EndpointIP := testHelper.getVariableFromE2eConfig("CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER")
-			if cp2EndpointIP == "" {
-				cp2EndpointIP = os.Getenv("CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER")
-				if cp2EndpointIP == "" {
-					Fail("CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER not set")
-				}
-			}
 			testHelper.updateVariableInE2eConfig("CONTROL_PLANE_ENDPOINT_IP", cp2EndpointIP)
 		})
 

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -127,7 +127,11 @@ variables:
   NUTANIX_ADDITIONAL_TRUST_BUNDLE: ""
   KUBERNETES_VERSION: "v1.35.3"
   NUTANIX_SSH_AUTHORIZED_KEY: "fake-key"
+  # CONTROL_PLANE_ENDPOINT_IP and CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER are reserved
+  # automatically at suite startup from the subnet under test (see reserveSubnetIP in
+  # test/e2e/subnet_ip_reservation.go); these defaults are only used before that reservation runs.
   CONTROL_PLANE_ENDPOINT_IP: ""
+  CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER: ""
   CONTROL_PLANE_ENDPOINT_IP_V124: ""
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 1

--- a/test/e2e/config/nutanix.yaml
+++ b/test/e2e/config/nutanix.yaml
@@ -127,9 +127,10 @@ variables:
   NUTANIX_ADDITIONAL_TRUST_BUNDLE: ""
   KUBERNETES_VERSION: "v1.35.3"
   NUTANIX_SSH_AUTHORIZED_KEY: "fake-key"
-  # CONTROL_PLANE_ENDPOINT_IP and CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER are reserved
-  # automatically at suite startup from the subnet under test (see reserveSubnetIP in
-  # test/e2e/subnet_ip_reservation.go); these defaults are only used before that reservation runs.
+  # CONTROL_PLANE_ENDPOINT_IP and CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER are, if left unset,
+  # reserved automatically at suite startup from the subnet under test (see reserveSubnetIP in
+  # test/e2e/subnet_ip_reservation.go). Set either one explicitly (env var or here) to opt that
+  # one out of auto-reservation and pin a specific address instead.
   CONTROL_PLANE_ENDPOINT_IP: ""
   CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER: ""
   CONTROL_PLANE_ENDPOINT_IP_V124: ""

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -160,10 +160,20 @@ var controlPlaneEndpointIPUnreserveFuncs []func() error
 // CONTROL_PLANE_ENDPOINT_IP[_WORKLOAD_CLUSTER] env var computed out-of-band in CI. Reservation is
 // delegated to Prism Central's own subnet IPAM (see reserveSubnetIP), so it is safe even when
 // other e2e jobs are reserving IPs from the same subnet concurrently.
+//
+// If CONTROL_PLANE_ENDPOINT_IP / CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER is already set
+// (env var or e2e config), that value is left untouched and nothing is reserved for it — the
+// caller is assumed to own its lifecycle. Auto-reservation only kicks in for whichever of the two
+// is left unset.
 func reserveControlPlaneEndpointIPsForNode() {
 	th := newTestHelper(e2eConfig)
 
 	for _, varKey := range []string{controlPlaneEndpointIPVarKey, controlPlaneEndpointIPWorkloadClusterVarKey} {
+		if existing := e2eConfig.Variables[varKey]; existing != "" {
+			By(fmt.Sprintf("Using manually-provided %s=%s instead of reserving one", varKey, existing))
+			continue
+		}
+
 		ip, unreserve := th.reserveControlPlaneEndpointIP(ctx)
 		controlPlaneEndpointIPUnreserveFuncs = append(controlPlaneEndpointIPUnreserveFuncs, unreserve)
 		th.updateVariableInE2eConfig(varKey, ip)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -110,6 +110,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	e2eConfig = loadE2EConfig(configPath)
 	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme(), framework.WithMachineLogCollector(framework.DockerLogCollector{}))
+
+	By("Reserving control plane endpoint IPs for this ParallelNode")
+	reserveControlPlaneEndpointIPsForNode()
 })
 
 // Using a SynchronizedAfterSuite for controlling how to delete resources shared across ParallelNodes (~ginkgo threads).
@@ -117,6 +120,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 // The local clusterctl repository is preserved like everything else created into the artifact folder.
 var _ = SynchronizedAfterSuite(func() {
 	// After each ParallelNode.
+	unreserveControlPlaneEndpointIPsForNode()
 }, func() {
 	// After all ParallelNodes.
 
@@ -144,6 +148,36 @@ func loadE2EConfig(configPath string) *clusterctl.E2EConfig {
 	Expect(config).ToNot(BeNil(), "Failed to load E2E config from %s", configPath)
 
 	return config
+}
+
+// controlPlaneEndpointIPUnreserveFuncs holds the release functions for the IPs reserved by
+// reserveControlPlaneEndpointIPsForNode, keyed by ParallelNode (each Ginkgo node is a separate
+// OS process, so a package-level var here is not shared across nodes).
+var controlPlaneEndpointIPUnreserveFuncs []func() error
+
+// reserveControlPlaneEndpointIPsForNode reserves the control plane endpoint IPs used by every
+// spec running on this ParallelNode, replacing what used to be a statically-assigned
+// CONTROL_PLANE_ENDPOINT_IP[_WORKLOAD_CLUSTER] env var computed out-of-band in CI. Reservation is
+// delegated to Prism Central's own subnet IPAM (see reserveSubnetIP), so it is safe even when
+// other e2e jobs are reserving IPs from the same subnet concurrently.
+func reserveControlPlaneEndpointIPsForNode() {
+	th := newTestHelper(e2eConfig)
+
+	for _, varKey := range []string{controlPlaneEndpointIPVarKey, controlPlaneEndpointIPWorkloadClusterVarKey} {
+		ip, unreserve := th.reserveControlPlaneEndpointIP(ctx)
+		controlPlaneEndpointIPUnreserveFuncs = append(controlPlaneEndpointIPUnreserveFuncs, unreserve)
+		th.updateVariableInE2eConfig(varKey, ip)
+	}
+}
+
+// unreserveControlPlaneEndpointIPsForNode releases the IPs reserved by
+// reserveControlPlaneEndpointIPsForNode. It must run even if specs on this node failed, so it is
+// called from the "after each ParallelNode" half of SynchronizedAfterSuite.
+func unreserveControlPlaneEndpointIPsForNode() {
+	for _, unreserve := range controlPlaneEndpointIPUnreserveFuncs {
+		Expect(unreserve()).To(Succeed())
+	}
+	controlPlaneEndpointIPUnreserveFuncs = nil
 }
 
 func createClusterctlLocalRepository(config *clusterctl.E2EConfig, repositoryFolder string) string {

--- a/test/e2e/subnet_ip_reservation.go
+++ b/test/e2e/subnet_ip_reservation.go
@@ -1,0 +1,169 @@
+//go:build e2e
+
+/*
+Copyright 2026 Nutanix
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
+	networkingcommonapi "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/common/v1/config"
+	networkingapi "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	prismcommonapi "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/common/v1/config"
+	prismapi "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	ipReservationTaskPollInterval = 2 * time.Second
+	ipReservationTaskTimeout      = 2 * time.Minute
+)
+
+// reservedIPsCompletionDetails mirrors the "reserved_ips" completion detail Prism Central
+// attaches to a successful ReserveIpsBySubnetId task.
+type reservedIPsCompletionDetails struct {
+	ReservedIPs []string `json:"reserved_ips"`
+}
+
+// reserveSubnetIP asks Prism Central to atomically reserve a single free IP address from the
+// given subnet's own IPAM pool, and returns a function that releases it again. Because Prism
+// Central owns the reservation, concurrent callers (e.g. separate e2e CI jobs targeting the same
+// subnet) can never be handed the same address.
+func reserveSubnetIP(
+	ctx context.Context,
+	convergedClient *v4Converged.Client,
+	subnetUUID string,
+) (ip string, unreserve func() error, err error) {
+	taskRef, err := convergedClient.Subnets.ReserveIpsBySubnetId(
+		ctx,
+		subnetUUID,
+		&networkingapi.IpReserveSpec{
+			Count:       ptr.To[int64](1),
+			ReserveType: ptr.To(networkingapi.RESERVETYPE_IP_ADDRESS_COUNT),
+		},
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to reserve IP in subnet %s: %w", subnetUUID, err)
+	}
+	if taskRef == nil || taskRef.ExtId == nil {
+		return "", nil, fmt.Errorf("no task id found in reserve-IP response: %+v", taskRef)
+	}
+
+	completionDetails, err := waitForNetworkingTask(ctx, convergedClient, *taskRef.ExtId)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to wait for IP reservation task: %w", err)
+	}
+	if len(completionDetails) == 0 {
+		return "", nil, fmt.Errorf("reserve-IP task for subnet %s completed with no details", subnetUUID)
+	}
+
+	// The reserved address comes back as a JSON-encoded string in the first completion detail
+	// value, e.g. `"{\"reserved_ips\":[\"10.0.0.5\"]}"`.
+	marshaledValue, err := json.Marshal(completionDetails[0].Value)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to marshal reserve-IP completion details: %w", err)
+	}
+	unquoted, err := strconv.Unquote(string(marshaledValue))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to unquote reserve-IP completion details %s: %w", marshaledValue, err)
+	}
+
+	var reserved reservedIPsCompletionDetails
+	if err := json.Unmarshal([]byte(unquoted), &reserved); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal reserve-IP completion details %s: %w", unquoted, err)
+	}
+	if len(reserved.ReservedIPs) == 0 {
+		return "", nil, fmt.Errorf("reserve-IP task for subnet %s reserved no addresses", subnetUUID)
+	}
+
+	reservedIP := reserved.ReservedIPs[0]
+	return reservedIP, func() error {
+		return unreserveSubnetIP(ctx, convergedClient, subnetUUID, reservedIP)
+	}, nil
+}
+
+// unreserveSubnetIP releases a previously reserved IP address back to the subnet's IPAM pool.
+func unreserveSubnetIP(ctx context.Context, convergedClient *v4Converged.Client, subnetUUID, ip string) error {
+	ipAddress := networkingcommonapi.NewIPAddress()
+	ipAddress.Ipv4 = networkingcommonapi.NewIPv4Address()
+	ipAddress.Ipv4.Value = ptr.To(ip)
+
+	taskRef, err := convergedClient.Subnets.UnreserveIpsBySubnetId(
+		ctx,
+		subnetUUID,
+		&networkingapi.IpUnreserveSpec{
+			UnreserveType: ptr.To(networkingapi.UNRESERVETYPE_IP_ADDRESS_LIST),
+			IpAddresses:   []networkingcommonapi.IPAddress{*ipAddress},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to unreserve IP %s in subnet %s: %w", ip, subnetUUID, err)
+	}
+	if taskRef == nil || taskRef.ExtId == nil {
+		return fmt.Errorf("no task id found in unreserve-IP response: %+v", taskRef)
+	}
+
+	if _, err := waitForNetworkingTask(ctx, convergedClient, *taskRef.ExtId); err != nil {
+		return fmt.Errorf("failed to wait for IP unreservation task: %w", err)
+	}
+
+	return nil
+}
+
+// waitForNetworkingTask polls a Prism Central task until it succeeds, and returns its completion
+// details. It fails fast on task failure/cancellation or context cancellation.
+func waitForNetworkingTask(
+	ctx context.Context,
+	convergedClient *v4Converged.Client,
+	taskID string,
+) ([]prismcommonapi.KVPair, error) {
+	taskCtx, cancel := context.WithTimeout(ctx, ipReservationTaskTimeout)
+	defer cancel()
+
+	var completionDetails []prismcommonapi.KVPair
+	if err := wait.PollUntilContextCancel(
+		taskCtx,
+		ipReservationTaskPollInterval,
+		true,
+		func(ctx context.Context) (bool, error) {
+			task, err := convergedClient.Tasks.Get(ctx, taskID)
+			if err != nil {
+				return false, fmt.Errorf("failed to get task %s: %w", taskID, err)
+			}
+
+			switch ptr.Deref(task.Status, prismapi.TASKSTATUS_UNKNOWN) {
+			case prismapi.TASKSTATUS_SUCCEEDED:
+				completionDetails = task.CompletionDetails
+				return true, nil
+			case prismapi.TASKSTATUS_FAILED, prismapi.TASKSTATUS_CANCELED:
+				return false, fmt.Errorf("task %s ended with status %v", taskID, task.Status)
+			default:
+				return false, nil
+			}
+		},
+	); err != nil {
+		return nil, fmt.Errorf("failed to wait for task %s to complete: %w", taskID, err)
+	}
+
+	return completionDetails, nil
+}

--- a/test/e2e/subnet_ip_reservation.go
+++ b/test/e2e/subnet_ip_reservation.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
@@ -78,19 +77,21 @@ func reserveSubnetIP(
 	}
 
 	// The reserved address comes back as a JSON-encoded string in the first completion detail
-	// value, e.g. `"{\"reserved_ips\":[\"10.0.0.5\"]}"`.
-	marshaledValue, err := json.Marshal(completionDetails[0].Value)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to marshal reserve-IP completion details: %w", err)
+	// value, e.g. `{"reserved_ips":["10.0.0.5"]}`.
+	if completionDetails[0].Value == nil {
+		return "", nil, fmt.Errorf("reserve-IP task for subnet %s completed with no value", subnetUUID)
 	}
-	unquoted, err := strconv.Unquote(string(marshaledValue))
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to unquote reserve-IP completion details %s: %w", marshaledValue, err)
+	rawValue, ok := completionDetails[0].Value.GetValue().(string)
+	if !ok {
+		return "", nil, fmt.Errorf(
+			"unexpected reserve-IP completion detail value type %T for subnet %s",
+			completionDetails[0].Value.GetValue(), subnetUUID,
+		)
 	}
 
 	var reserved reservedIPsCompletionDetails
-	if err := json.Unmarshal([]byte(unquoted), &reserved); err != nil {
-		return "", nil, fmt.Errorf("failed to unmarshal reserve-IP completion details %s: %w", unquoted, err)
+	if err := json.Unmarshal([]byte(rawValue), &reserved); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal reserve-IP completion details %s: %w", rawValue, err)
 	}
 	if len(reserved.ReservedIPs) == 0 {
 		return "", nil, fmt.Errorf("reserve-IP task for subnet %s reserved no addresses", subnetUUID)

--- a/test/e2e/test_helpers.go
+++ b/test/e2e/test_helpers.go
@@ -68,6 +68,9 @@ const (
 	clusterVarKey = "NUTANIX_PRISM_ELEMENT_CLUSTER_NAME"
 	subnetVarKey  = "NUTANIX_SUBNET_NAME"
 
+	controlPlaneEndpointIPVarKey                = "CONTROL_PLANE_ENDPOINT_IP"
+	controlPlaneEndpointIPWorkloadClusterVarKey = "CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER"
+
 	nameType = "name"
 
 	nutanixProjectNameEnv = "NUTANIX_PROJECT_NAME"
@@ -150,6 +153,7 @@ type testHelperInterface interface {
 	getVariableFromE2eConfig(variableKey string) string
 	getDefaultStorageContainerNameAndUuid(ctx context.Context) (string, string, error)
 	updateVariableInE2eConfig(variableKey string, variableValue string)
+	reserveControlPlaneEndpointIP(ctx context.Context) (ip string, unreserve func() error)
 	stripNutanixIDFromProviderID(providerID string) string
 	verifyCategoryExists(ctx context.Context, categoryKey, categoyValue string)
 	verifyCategoriesNutanixMachines(ctx context.Context, clusterName, namespace string, expectedCategories map[string][]string)
@@ -620,6 +624,27 @@ func (t testHelper) getDefaultStorageContainerNameAndUuid(ctx context.Context) (
 func (t testHelper) updateVariableInE2eConfig(variableKey string, variableValue string) {
 	t.e2eConfig.Variables[variableKey] = variableValue
 	os.Setenv(variableKey, variableValue)
+}
+
+// reserveControlPlaneEndpointIP reserves a free IP address from the subnet under test (as
+// configured via NUTANIX_PRISM_ELEMENT_CLUSTER_NAME/NUTANIX_SUBNET_NAME) using Prism Central's
+// own IPAM, so that concurrent e2e runs against the same subnet can never be handed the same
+// control plane endpoint IP. The returned unreserve func releases the IP again and must be
+// called once the IP is no longer in use (e.g. via DeferCleanup or in a suite/spec teardown).
+func (t testHelper) reserveControlPlaneEndpointIP(ctx context.Context) (ip string, unreserve func() error) {
+	clusterVarValue := t.getVariableFromE2eConfig(clusterVarKey)
+	subnetVarValue := t.getVariableFromE2eConfig(subnetVarKey)
+
+	peUUID, err := controllers.GetPEUUID(ctx, t.convergedClient, &clusterVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	subnetUUID, err := controllers.GetSubnetUUID(ctx, t.convergedClient, peUUID, &subnetVarValue, nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	ip, unreserve, err = reserveSubnetIP(ctx, t.convergedClient, subnetUUID)
+	Expect(err).ToNot(HaveOccurred())
+
+	return ip, unreserve
 }
 
 func (t testHelper) stripNutanixIDFromProviderID(providerID string) string {


### PR DESCRIPTION
## Summary

Replaces the current e2e control-plane-endpoint-IP allocation — an `fping`/`shuf` ping-sweep over a static range configured via GitHub Actions variables — with dynamic reservation against the target subnet's own IPAM pool, using Prism Central's Networking v4 API (`Subnets.ReserveIpsBySubnetId`/`UnreserveIpsBySubnetId`). This mirrors how `cluster-api-runtime-extensions-nutanix` handles the same problem in its e2e suite.

The old mechanism was racy: it was a snapshot-in-time ICMP check with no actual reservation, run independently by every concurrent CI job (the ~8-way `build-dev.yaml` matrix plus periodic conformance workflows) against the same shared range, with no coordination between them. Prism Central owns the reservation atomically now, so concurrent jobs can never be handed the same address.

* `test/e2e/subnet_ip_reservation.go` (new) — `reserveSubnetIP`/`unreserveSubnetIP`/`waitForNetworkingTask`, wrapping the PC v4 Subnets/Tasks services CAPX already depends on.
* `test/e2e/test_helpers.go` — `testHelper.reserveControlPlaneEndpointIP`, resolving PE/subnet UUIDs via the existing `controllers.GetPEUUID`/`GetSubnetUUID` helpers.
* `test/e2e/e2e_suite_test.go` — reserves `CONTROL_PLANE_ENDPOINT_IP` and `CONTROL_PLANE_ENDPOINT_IP_WORKLOAD_CLUSTER` once per Ginkgo ParallelNode in `SynchronizedBeforeSuite`, releases them in `SynchronizedAfterSuite` (runs even on spec failure).
* `test/e2e/categories_test.go` — simplified now that the workload-cluster IP is always pre-reserved.
* `.github/workflows/e2e.yaml`, `Makefile` — removed the `nutanix-cp-endpoint-ip` target and the range pre-computation steps/env wiring; no longer needed.
* `test/e2e/config/nutanix.yaml`, `docs/developer_workflow.md` — documentation updates.

## Test plan

- [x] `go build ./...` and `go build -tags e2e ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --build-tags e2e ./test/e2e/...` (0 issues)
- [x] Compiled the e2e Ginkgo test binary (`go test -tags e2e -c ./test/e2e/`)
- [x] Live-verified the reserve/unreserve round trip against a real Prism Central (`pc.dev.nkp.sh`, subnet `vlan173`): resolved PE/subnet UUIDs, reserved a fresh IP via `Subnets.ReserveIpsBySubnetId`, then released it via `Subnets.UnreserveIpsBySubnetId` — both completed successfully end to end, including the async task-polling and completion-details parsing.
- [x] Confirmed the target subnet has a real managed IPAM pool PC can reserve from (502 addresses total). Note: the pool was initially full of reservations left over from the old never-releasing approach, which had to be cleared by hand before a fresh reservation would succeed — a good illustration of the exact problem this PR fixes going forward.
