### PR TITLE
fix(nutanixmachine): fix nil pointer dereference in getDiskList

### DIFF
--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -1640,7 +1640,7 @@ func getDiskList(rctx *nctx.MachineContext, peUUID string) ([]vmmconfig.Disk, []
 	disks = append(disks, *systemDisk)
 
 	bootstrapRef := rctx.NutanixMachine.Spec.BootstrapRef
-	if bootstrapRef.Kind == infrav1.NutanixMachineBootstrapRefKindImage {
+	if bootstrapRef != nil && bootstrapRef.Kind == infrav1.NutanixMachineBootstrapRefKindImage {
 		bootstrapDisk, err := getBootstrapDisk(rctx)
 		if err != nil {
 			return nil, nil, err

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -1186,6 +1186,26 @@ func TestNutanixClusterReconcilerGetDiskList(t *testing.T) {
 				return defaultNtnxMachine, defaultMachine, defaultNtnxCluster, convergedClientMock.Client
 			},
 		},
+		{
+			// Regression test: BootstrapRef is nil for part of the reconcile window (it's
+			// populated later in Reconcile, not guaranteed set by the time getOrCreateVM's
+			// disk-building runs), and getDiskList used to dereference it unconditionally,
+			// panicking with a nil pointer dereference instead of just skipping the
+			// image-bootstrap cdrom branch.
+			name:         "does not panic when BootstrapRef is nil",
+			wantDisksLen: 1,
+			fixtures: func(mockCtrl *gomock.Controller) (*infrav1.NutanixMachine, *capiv1beta2.Machine, *infrav1.NutanixCluster, *v4Converged.Client) {
+				ntnxMachine := defaultNtnxMachine.DeepCopy()
+				ntnxMachine.Spec.BootstrapRef = nil
+				ntnxMachine.Spec.DataDisks = nil
+
+				convergedClientMock := NewMockConvergedClient(mockCtrl)
+				convergedClientMock.MockImages.EXPECT().Get(gomock.Any(), *defaultSystemImage.ExtId).Return(defaultSystemImage, nil).MinTimes(1)
+				convergedClientMock.MockTasks.EXPECT().List(gomock.Any(), gomock.Any()).Return([]prismModels.Task{}, nil).MinTimes(1)
+
+				return ntnxMachine, defaultMachine, defaultNtnxCluster, convergedClientMock.Client
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
## Summary
- `getDiskList` dereferenced `Spec.BootstrapRef.Kind` without checking for nil. `BootstrapRef` is legitimately nil for part of the reconcile window (it's set later in `Reconcile`, not guaranteed present by the time `getOrCreateVM`'s disk-building runs), so this can panic with a nil pointer dereference.
- This mirrors a fix already applied and observed live in the internal fork (nutanix-cloud-native/internal-cluster-api-provider-nutanix#109), where controller-runtime's panic recovery caught it and the retried reconcile succeeded, so it wasn't fatal in practice, but it's a real crash on a previously-untested code path.
- Fix: guard the dereference with a nil check.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./controllers/...`
- [x] `go test ./controllers/... -run TestNutanixClusterReconcilerGetDiskList` — added a regression case (`does not panic when BootstrapRef is nil`) alongside the existing table-driven tests, all passing.