### PR TITLE
fix: prevent duplicate VM creation on racing reconciles

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -191,6 +191,30 @@ func GetVMUUID(machine *capiv1beta2.Machine, nutanixMachine *infrav1.NutanixMach
 		}
 		return vmUUID, nil
 	}
+	// Spec.ProviderID is patched in the same call as Status.VmUUID, but lands on the
+	// API server first (metadata+spec patch before the status patch), so a reconcile
+	// triggered immediately behind VM creation can observe it while Status.VmUUID is
+	// still not durable. It is also the only one of the two fields that survives a
+	// clusterctl move, since status is dropped on Create for objects with the status
+	// subresource. Falling back to it here lets FindVM locate the VM by UUID instead
+	// of racing Prism's name-search index.
+	//
+	// Unlike Status.VmUUID, this field isn't exclusively controller-written: templates
+	// are free to pre-populate NutanixMachine.Spec.ProviderID with a non-UUID placeholder
+	// (the e2e NutanixMachineTemplate fixture ships "nutanix://${CLUSTER_NAME}-m1"), so a
+	// value that doesn't parse must be treated as "no usable identifier yet" rather than
+	// a hard error - an error here would permanently block reconciliation for any machine
+	// created from such a template.
+	if providerID := nutanixMachine.Spec.ProviderID; providerID != "" {
+		vmUUID, ok := strings.CutPrefix(providerID, providerIdPrefix)
+		if !ok {
+			return "", nil
+		}
+		if _, err := uuid.Parse(vmUUID); err != nil {
+			return "", nil
+		}
+		return vmUUID, nil
+	}
 	return "", nil
 }
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -69,9 +69,18 @@ const (
 	createErrorFailureReason  = "CreateError"
 	powerOnErrorFailureReason = "PowerOnError"
 
-	CAPXProjectPolicyAnnotation      = "capx.nutanix.com/project-policy"
-	CAPXProjectPolicyDefaultOnly     = "default-only"
-	CAPXProjectPolicyUnrestricted    = "unrestricted"
+	CAPXProjectPolicyAnnotation   = "capx.nutanix.com/project-policy"
+	CAPXProjectPolicyDefaultOnly  = "default-only"
+	CAPXProjectPolicyUnrestricted = "unrestricted"
+
+	// VMCreationRequestIDAnnotation holds the idempotency key (NTNX-Request-Id) used for
+	// the VM Create call. It is minted once and persisted before the first Create attempt,
+	// then reused by every later reconcile so a retried Create returns the original task's
+	// result instead of creating a second VM. It lives in an annotation, not status, because
+	// clusterctl move drops status on Create for objects with the status subresource enabled,
+	// while metadata (including annotations) passes through unchanged.
+	VMCreationRequestIDAnnotation = "capx.nutanix.com/vm-creation-request-id"
+
 	metroFailureDomainPrefix         = "NutanixMetro/"
 	metroSiteFailureDomainPrefix     = "NutanixMetroSite/"
 	metroNativeFailureDomainLabelKey = "metro.nutanix.com/native-failuredomain"

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -3346,6 +3346,57 @@ func TestGetVMUUID(t *testing.T) {
 			want:    validUUID,
 			wantErr: false,
 		},
+		{
+			name:    "should fall back to Spec.ProviderID when systemUUID and Status.VmUUID are both unavailable",
+			machine: nil,
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: providerIdPrefix + validUUID,
+				},
+			},
+			want:    validUUID,
+			wantErr: false,
+		},
+		{
+			name:    "should prioritize Status.VmUUID over Spec.ProviderID",
+			machine: nil,
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: providerIdPrefix + anotherValidUUID,
+				},
+				Status: infrav1.NutanixMachineStatus{
+					VmUUID: validUUID,
+				},
+			},
+			want:    validUUID,
+			wantErr: false,
+		},
+		{
+			// Templates can pre-populate NutanixMachineTemplate.spec.template.spec.providerID
+			// with a placeholder (the e2e fixture uses "nutanix://${CLUSTER_NAME}-m1"), so a
+			// value without the expected prefix must be silently ignored, not treated as an
+			// error - an error here would permanently block reconciliation for such machines.
+			name:    "should silently ignore Spec.ProviderID lacking the nutanix:// prefix",
+			machine: nil,
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: validUUID,
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "should silently ignore a non-UUID Spec.ProviderID (e.g. a template placeholder)",
+			machine: nil,
+			nutanixMachine: &infrav1.NutanixMachine{
+				Spec: infrav1.NutanixMachineSpec{
+					ProviderID: providerIdPrefix + invalidUUID,
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -58,6 +58,7 @@ import (
 
 	infrav1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	nctx "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/context"
+	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
 )
 
 var (
@@ -1349,6 +1350,41 @@ func setMetroCustomAttributes(rctx *nctx.MachineContext, vm *vmmconfig.Vm) {
 	}
 }
 
+// getOrMintVMCreationRequestID returns the idempotency key to use for the VM Create call.
+// If the NutanixMachine doesn't already have one recorded, a new UUID is minted and durably
+// persisted as an annotation before this returns, so every later reconcile of this object -
+// including one that races immediately behind this one, or one that resumes after a
+// controller restart - reuses the exact same key. Reusing it turns a retried Create into a
+// no-op that returns the original task's result instead of creating a second VM.
+//
+// It is stored as an annotation rather than in status because clusterctl move drops status
+// on Create for objects with the status subresource enabled, while metadata (including
+// annotations) passes through unchanged - see the Spec.ProviderID fallback in GetVMUUID for
+// the same reasoning applied to the VM's identity itself.
+func (r *NutanixMachineReconciler) getOrMintVMCreationRequestID(rctx *nctx.MachineContext) (string, error) {
+	if requestID := rctx.NutanixMachine.Annotations[VMCreationRequestIDAnnotation]; requestID != "" {
+		return requestID, nil
+	}
+
+	// Snapshot the object *before* mutating it: a patch helper built from the already-mutated
+	// object computes an empty diff, so the patch would be a silent no-op - defeating the
+	// "persist before the first Create" guarantee this function exists to provide. Same
+	// hazard as patchMachine; see its doc comment.
+	before := rctx.NutanixMachine.DeepCopy()
+
+	requestID := uuid.NewString()
+	if rctx.NutanixMachine.Annotations == nil {
+		rctx.NutanixMachine.Annotations = map[string]string{}
+	}
+	rctx.NutanixMachine.Annotations[VMCreationRequestIDAnnotation] = requestID
+
+	if err := r.Patch(rctx.Context, rctx.NutanixMachine, client.MergeFrom(before)); err != nil {
+		return "", fmt.Errorf("failed to persist vm creation request id: %w", err)
+	}
+
+	return requestID, nil
+}
+
 func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vmmconfig.Vm, error) {
 	var err error
 	ctx := rctx.Context
@@ -1377,6 +1413,14 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	}
 
 	log.Info(fmt.Sprintf("No existing VM found. Starting creation process of VM %s.", vmName))
+
+	// Mint (or recall) the idempotency key before doing anything else, so it is durably
+	// persisted ahead of the actual Create call below. See getOrMintVMCreationRequestID.
+	requestID, err := r.getOrMintVMCreationRequestID(rctx)
+	if err != nil {
+		return nil, err
+	}
+
 	err = r.validateMachineConfig(rctx)
 	if err != nil {
 		rctx.SetFailureStatus(createErrorFailureReason, err)
@@ -1484,7 +1528,7 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 
 	// Create the actual VM/Machine
 	log.Info(fmt.Sprintf("Creating VM with name %s for cluster %s", vmName, rctx.NutanixCluster.Name))
-	vm, err = convergedClient.VMs.Create(ctx, vm)
+	vm, err = convergedClient.VMs.Create(v4Converged.WithRequestID(ctx, requestID), vm)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to create VM %s: %w", vmName, err)
 		if !isRetryableAPIError(err) {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -533,6 +533,10 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 		return reconcile.Result{}, err
 	}
 
+	// Snapshot before checkFailureDomainStatus/checkVHADomainCategory mutate the object, so the
+	// patchMachine call below has a valid pre-mutation baseline to diff against - see patchMachine.
+	beforeFailureDomainAndVHACheck := rctx.NutanixMachine.DeepCopy()
+
 	// Set the NutanixMachine.status.failureDomain if the Machine is created with failureDomain
 	if err = r.checkFailureDomainStatus(rctx); err != nil {
 		log.Error(err, "Failed to check/set status.failureDomain")
@@ -547,7 +551,7 @@ func (r *NutanixMachineReconciler) reconcileNormal(rctx *nctx.MachineContext) (r
 	}
 
 	log.V(1).Info(fmt.Sprintf("Patching machine post creation vmUUID: %s", rctx.NutanixMachine.Status.VmUUID))
-	if err := r.patchMachine(rctx); err != nil {
+	if err := r.patchMachine(rctx, beforeFailureDomainAndVHACheck); err != nil {
 		errorMsg := fmt.Errorf("failed to patch NutanixMachine %s after creation: %w", rctx.NutanixMachine.Name, err)
 		log.Error(errorMsg, "failed to patch")
 		return reconcile.Result{}, errorMsg
@@ -641,10 +645,11 @@ func (r *NutanixMachineReconciler) syncVmUUID(rctx *nctx.MachineContext, vmExtId
 
 	// Update and patch if needed
 	if rctx.NutanixMachine.Status.VmUUID != targetUUID {
+		before := rctx.NutanixMachine.DeepCopy()
 		rctx.NutanixMachine.Status.VmUUID = targetUUID
 		log.Info("Updated NutanixMachine VmUUID status", "vmUUID", targetUUID)
 
-		if err := r.patchMachine(rctx); err != nil {
+		if err := r.patchMachine(rctx, before); err != nil {
 			return fmt.Errorf("failed to patch NutanixMachine %s after setting VmUUID from %s: %w", rctx.NutanixMachine.Name, targetUUID, err)
 		}
 	}
@@ -1496,10 +1501,11 @@ func (r *NutanixMachineReconciler) getOrCreateVM(rctx *nctx.MachineContext) (*vm
 	log.V(1).Info(fmt.Sprintf("Created VM %s. Got the vm UUID: %s, power state: %s", vmName, vmUuid, powerState))
 
 	// set the VM UUID on the nutanix machine as soon as it is available. VM UUID can be used for cleanup in case of failure
+	before := rctx.NutanixMachine.DeepCopy()
 	rctx.NutanixMachine.Spec.ProviderID = GenerateProviderID(vmUuid)
 	rctx.NutanixMachine.Status.VmUUID = vmUuid
 
-	err = r.patchMachine(rctx)
+	err = r.patchMachine(rctx, before)
 	if err != nil {
 		log.Error(err, "failed to patch NutanixMachine after setting VmUUID")
 		return nil, err
@@ -1782,9 +1788,14 @@ func (r *NutanixMachineReconciler) getBootstrapData(rctx *nctx.MachineContext) (
 	return value, nil
 }
 
-func (r *NutanixMachineReconciler) patchMachine(rctx *nctx.MachineContext) error {
+// patchMachine persists rctx.NutanixMachine's current state, diffing it against before - a
+// snapshot the caller must take with DeepCopy() *before* mutating the object. v1beta1patch.Helper
+// computes its diff from whatever object it was constructed with, so building the helper from the
+// already-mutated object (as opposed to a pre-mutation snapshot) makes the diff empty and the
+// resulting patch a silent no-op.
+func (r *NutanixMachineReconciler) patchMachine(rctx *nctx.MachineContext, before *infrav1.NutanixMachine) error {
 	log := ctrl.LoggerFrom(rctx.Context)
-	patchHelper, err := v1beta1patch.NewHelper(rctx.NutanixMachine, r.Client)
+	patchHelper, err := v1beta1patch.NewHelper(before, r.Client)
 	if err != nil {
 		errorMsg := fmt.Errorf("failed to create patch helper to patch machine %s: %w", rctx.NutanixMachine.Name, err)
 		return errorMsg

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2662,6 +2662,78 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 	})
 }
 
+func TestNutanixMachineReconciler_getOrMintVMCreationRequestID(t *testing.T) {
+	t.Run("mints and durably persists a new request ID via a patch that captures the annotation diff", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+		}
+
+		mockK8sClient := mockctlclient.NewMockClient(ctrl)
+
+		var appliedPatch []byte
+		mockK8sClient.EXPECT().Patch(ctx, ntnxMachine, gomock.Any()).DoAndReturn(
+			func(_ context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
+				data, err := patch.Data(obj)
+				require.NoError(t, err)
+				appliedPatch = data
+				return nil
+			},
+		)
+
+		reconciler := &NutanixMachineReconciler{Client: mockK8sClient}
+		rctx := &nctx.MachineContext{Context: ctx, NutanixMachine: ntnxMachine}
+
+		requestID, err := reconciler.getOrMintVMCreationRequestID(rctx)
+		require.NoError(t, err)
+
+		_, err = uuid.Parse(requestID)
+		require.NoError(t, err, "minted request ID should be a valid UUID")
+
+		// The patch sent to the API server must actually contain the new annotation - if the
+		// diff were computed against a baseline captured after the mutation, this would be
+		// empty and the annotation would never become durable.
+		assert.Contains(t, string(appliedPatch), VMCreationRequestIDAnnotation)
+		assert.Contains(t, string(appliedPatch), requestID)
+		assert.Equal(t, requestID, ntnxMachine.Annotations[VMCreationRequestIDAnnotation])
+	})
+
+	t.Run("reuses a previously persisted request ID instead of minting or patching again", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		existingRequestID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+				Annotations: map[string]string{
+					VMCreationRequestIDAnnotation: existingRequestID,
+				},
+			},
+		}
+
+		// No Patch expectation is set: a second reconcile that finds the annotation already
+		// persisted (e.g. after the first Create failed/timed out) must reuse it as-is rather
+		// than minting a new one, so the retried Create stays idempotent against the same task.
+		mockK8sClient := mockctlclient.NewMockClient(ctrl)
+
+		reconciler := &NutanixMachineReconciler{Client: mockK8sClient}
+		rctx := &nctx.MachineContext{Context: ctx, NutanixMachine: ntnxMachine}
+
+		requestID, err := reconciler.getOrMintVMCreationRequestID(rctx)
+		require.NoError(t, err)
+		assert.Equal(t, existingRequestID, requestID)
+	})
+}
+
 func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 	t.Run("should return existing VM when found by UUID", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -3043,7 +3115,9 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		createdVM := vmmModels.NewVm()
 		createdVM.Name = ptr.To(vmName)
 		createdVM.ExtId = ptr.To(vmUUID)
-		mockConvergedClient.MockVMs.EXPECT().Create(ctx, gomock.Any()).Return(createdVM, nil)
+		// Context is gomock.Any() here, not ctx, because getOrCreateVM wraps it with
+		// v4Converged.WithRequestID for the vm-creation-request-id idempotency key.
+		mockConvergedClient.MockVMs.EXPECT().Create(gomock.Any(), gomock.Any()).Return(createdVM, nil)
 
 		// Create machine context
 		rctx := &nctx.MachineContext{
@@ -3110,6 +3184,7 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(ntnxMachine), persisted))
 		assert.Equal(t, vmUUID, persisted.Status.VmUUID)
 		assert.Equal(t, fmt.Sprintf("nutanix://%s", vmUUID), persisted.Spec.ProviderID)
+		assert.NotEmpty(t, persisted.Annotations[VMCreationRequestIDAnnotation])
 	})
 
 	t.Run("should set failure status when category lookup returns not found", func(t *testing.T) {
@@ -3207,7 +3282,16 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 			ConvergedClient: mockConvergedClient.Client,
 		}
 
-		reconciler := &NutanixMachineReconciler{}
+		// Mock Kubernetes client for the vm-creation-request-id annotation patch
+		// getOrMintVMCreationRequestID issues before the create flow proceeds.
+		mockK8sClient := mockctlclient.NewMockClient(ctrl)
+		scheme := runtime.NewScheme()
+		_ = infrav1.AddToScheme(scheme)
+		_ = capiv1beta2.AddToScheme(scheme)
+		mockK8sClient.EXPECT().Scheme().Return(scheme).AnyTimes()
+		mockK8sClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		reconciler := &NutanixMachineReconciler{Client: mockK8sClient}
 		vm, err := reconciler.getOrCreateVM(rctx)
 
 		require.Error(t, err)
@@ -3313,7 +3397,16 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 			ConvergedClient: mockConvergedClient.Client,
 		}
 
-		reconciler := &NutanixMachineReconciler{}
+		// Mock Kubernetes client for the vm-creation-request-id annotation patch
+		// getOrMintVMCreationRequestID issues before the create flow proceeds.
+		mockK8sClient := mockctlclient.NewMockClient(ctrl)
+		scheme := runtime.NewScheme()
+		_ = infrav1.AddToScheme(scheme)
+		_ = capiv1beta2.AddToScheme(scheme)
+		mockK8sClient.EXPECT().Scheme().Return(scheme).AnyTimes()
+		mockK8sClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		reconciler := &NutanixMachineReconciler{Client: mockK8sClient}
 		vm, err := reconciler.getOrCreateVM(rctx)
 
 		require.Error(t, err)

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -3056,36 +3056,36 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 			ConvergedClient: mockConvergedClient.Client,
 		}
 
-		// Create mock Kubernetes client for getBootstrapData
-		mockK8sClient := mockctlclient.NewMockClient(ctrl)
-
-		// Mock Get call for bootstrap secret
+		// Use a real fake client (not a gomock) so getOrCreateVM's patchMachine call
+		// exercises the actual v1beta1patch.Helper diffing/patching logic, including the
+		// status subresource - a hand-rolled Status()/Patch() mock would need to
+		// reimplement that logic to be trustworthy, and would silently stop testing
+		// anything the moment it diverged.
 		bootstrapSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrap-secret",
+				Namespace: "default",
+			},
 			Data: map[string][]byte{
 				"value": []byte("#!/bin/bash\necho 'bootstrap'"),
 			},
 		}
-		mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, key client.ObjectKey, obj *corev1.Secret, opts ...interface{}) error {
-				*obj = *bootstrapSecret
-				return nil
-			},
-		)
 
 		// Create a scheme with the necessary types registered
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
 
-		// Mock Scheme.Convert for patchMachine
-		mockK8sClient.EXPECT().Scheme().Return(scheme).AnyTimes()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ntnxMachine, bootstrapSecret).
+			WithStatusSubresource(ntnxMachine).
+			Build()
 
-		// Mock Patch call for patchMachine (called by syncVmUUID)
-		mockK8sClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-
-		// Create reconciler with mock client
+		// Create reconciler with fake client
 		reconciler := &NutanixMachineReconciler{
-			Client: mockK8sClient,
+			Client: fakeClient,
 		}
 
 		// Test getOrCreateVM
@@ -3101,6 +3101,15 @@ func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {
 		assert.Equal(t, vmUUID, ntnxMachine.Status.VmUUID)
 		// The providerID should be set using the actual VM UUID
 		assert.Equal(t, fmt.Sprintf("nutanix://%s", vmUUID), ntnxMachine.Spec.ProviderID)
+
+		// Re-fetch independently to confirm the VmUUID and providerID were actually durably
+		// persisted via patchMachine, not just mutated on the in-memory object (which would
+		// still show these values even if the underlying patch call silently computed an
+		// empty diff and never reached the server).
+		persisted := &infrav1.NutanixMachine{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(ntnxMachine), persisted))
+		assert.Equal(t, vmUUID, persisted.Status.VmUUID)
+		assert.Equal(t, fmt.Sprintf("nutanix://%s", vmUUID), persisted.Spec.ProviderID)
 	})
 
 	t.Run("should set failure status when category lookup returns not found", func(t *testing.T) {
@@ -3930,7 +3939,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,
@@ -3948,6 +3957,14 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		// Verify results
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(nutanixMachine.Status.VmUUID).To(Equal(validUUID1), "VmUUID should be synced to SystemUUID (prioritized over vmExtId)")
+
+		// Mutating the in-memory object proves nothing about durability - patchMachine could
+		// compute an empty diff and skip the API call entirely while the local pointer still
+		// shows the new value. Re-fetch independently from the fake client's store to confirm
+		// the patch actually reached the server.
+		persisted := &infrav1.NutanixMachine{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(nutanixMachine), persisted)).To(Succeed())
+		g.Expect(persisted.Status.VmUUID).To(Equal(validUUID1), "VmUUID update must be durably persisted, not just mutated in memory")
 	})
 
 	t.Run("should not update VmUUID when SystemUUID matches", func(t *testing.T) {
@@ -3982,7 +3999,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,
@@ -4032,7 +4049,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,
@@ -4084,7 +4101,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,
@@ -4136,7 +4153,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,
@@ -4188,7 +4205,7 @@ func TestNutanixMachineReconciler_syncVmUUID(t *testing.T) {
 		scheme := runtime.NewScheme()
 		_ = infrav1.AddToScheme(scheme)
 		_ = capiv1beta2.AddToScheme(scheme)
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nutanixMachine).WithStatusSubresource(nutanixMachine).Build()
 
 		rctx := &nctx.MachineContext{
 			Context:        ctx,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/nutanix-cloud-native/prism-go-client v0.8.0
+	github.com/nutanix-cloud-native/prism-go-client v0.8.2-0.20260809222332-d015b296f1bd
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.2.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nutanix-cloud-native/prism-go-client v0.8.0 h1:CYOxciuvis1xq++eQcyMZrDxVO/LQgPpyvUKzMxEO9A=
 github.com/nutanix-cloud-native/prism-go-client v0.8.0/go.mod h1:S5nV4cEuQSGOAv+C+svUuuwAOYX3U/Q/lVwtAIy7tGw=
+github.com/nutanix-cloud-native/prism-go-client v0.8.2-0.20260809222332-d015b296f1bd h1:FmdYf0rlv9E8+OQpeUhNju4XDhfORbmnvBZ4N+/5Z4Q=
+github.com/nutanix-cloud-native/prism-go-client v0.8.2-0.20260809222332-d015b296f1bd/go.mod h1:yF7i8BuiQZSa9yyu9l7Wqpa3gpvUHk+M71gTjz4I31o=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2 h1:IctWgmfEJEKX5UL8NOLylPQwM5quK8tbbZF4BuSuSwE=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2/go.mod h1:c52CmT116rC0iLmS11iiTy2cg+j+ifP0X8ZIHwNVefI=
 github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1 h1:gWgUofXXGdXHCBgz3fG7WeQ6dDp4RFUG3kRY8/X0DHY=

--- a/mocks/converged/users.go
+++ b/mocks/converged/users.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	converged "github.com/nutanix-cloud-native/prism-go-client/converged"
+	authn "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authn"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,6 +42,50 @@ func (m *MockUsers[User]) EXPECT() *MockUsersMockRecorder[User] {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockUsers[User]) Create(ctx context.Context, entity *User) (*User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, entity)
+	ret0, _ := ret[0].(*User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockUsersMockRecorder[User]) Create(ctx, entity any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUsers[User])(nil).Create), ctx, entity)
+}
+
+// CreateUserKey mocks base method.
+func (m *MockUsers[User]) CreateUserKey(ctx context.Context, userExtId string, key *authn.Key) (*authn.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserKey", ctx, userExtId, key)
+	ret0, _ := ret[0].(*authn.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserKey indicates an expected call of CreateUserKey.
+func (mr *MockUsersMockRecorder[User]) CreateUserKey(ctx, userExtId, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserKey", reflect.TypeOf((*MockUsers[User])(nil).CreateUserKey), ctx, userExtId, key)
+}
+
+// DeleteUserKeyById mocks base method.
+func (m *MockUsers[User]) DeleteUserKeyById(ctx context.Context, userExtId, keyID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserKeyById", ctx, userExtId, keyID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUserKeyById indicates an expected call of DeleteUserKeyById.
+func (mr *MockUsersMockRecorder[User]) DeleteUserKeyById(ctx, userExtId, keyID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserKeyById", reflect.TypeOf((*MockUsers[User])(nil).DeleteUserKeyById), ctx, userExtId, keyID)
+}
+
 // Get mocks base method.
 func (m *MockUsers[User]) Get(ctx context.Context, uuid string) (*User, error) {
 	m.ctrl.T.Helper()
@@ -54,6 +99,21 @@ func (m *MockUsers[User]) Get(ctx context.Context, uuid string) (*User, error) {
 func (mr *MockUsersMockRecorder[User]) Get(ctx, uuid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockUsers[User])(nil).Get), ctx, uuid)
+}
+
+// GetUserKeyById mocks base method.
+func (m *MockUsers[User]) GetUserKeyById(ctx context.Context, userExtId, keyID string) (*authn.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserKeyById", ctx, userExtId, keyID)
+	ret0, _ := ret[0].(*authn.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserKeyById indicates an expected call of GetUserKeyById.
+func (mr *MockUsersMockRecorder[User]) GetUserKeyById(ctx, userExtId, keyID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserKeyById", reflect.TypeOf((*MockUsers[User])(nil).GetUserKeyById), ctx, userExtId, keyID)
 }
 
 // List mocks base method.
@@ -76,6 +136,26 @@ func (mr *MockUsersMockRecorder[User]) List(ctx any, opts ...any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockUsers[User])(nil).List), varargs...)
 }
 
+// ListUserKeys mocks base method.
+func (m *MockUsers[User]) ListUserKeys(ctx context.Context, userExtId string, opts ...converged.ODataOption) ([]authn.Key, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, userExtId}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListUserKeys", varargs...)
+	ret0, _ := ret[0].([]authn.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserKeys indicates an expected call of ListUserKeys.
+func (mr *MockUsersMockRecorder[User]) ListUserKeys(ctx, userExtId any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, userExtId}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserKeys", reflect.TypeOf((*MockUsers[User])(nil).ListUserKeys), varargs...)
+}
+
 // NewIterator mocks base method.
 func (m *MockUsers[User]) NewIterator(ctx context.Context, opts ...converged.ODataOption) converged.Iterator[User] {
 	m.ctrl.T.Helper()
@@ -93,4 +173,33 @@ func (mr *MockUsersMockRecorder[User]) NewIterator(ctx any, opts ...any) *gomock
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIterator", reflect.TypeOf((*MockUsers[User])(nil).NewIterator), varargs...)
+}
+
+// RevokeUserKey mocks base method.
+func (m *MockUsers[User]) RevokeUserKey(ctx context.Context, userExtId, keyID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeUserKey", ctx, userExtId, keyID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeUserKey indicates an expected call of RevokeUserKey.
+func (mr *MockUsersMockRecorder[User]) RevokeUserKey(ctx, userExtId, keyID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeUserKey", reflect.TypeOf((*MockUsers[User])(nil).RevokeUserKey), ctx, userExtId, keyID)
+}
+
+// UpdateUserState mocks base method.
+func (m *MockUsers[User]) UpdateUserState(uuid string, status *authn.UserStateUpdate) (*authn.UserStateUpdateResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserState", uuid, status)
+	ret0, _ := ret[0].(*authn.UserStateUpdateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserState indicates an expected call of UpdateUserState.
+func (mr *MockUsersMockRecorder[User]) UpdateUserState(uuid, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserState", reflect.TypeOf((*MockUsers[User])(nil).UpdateUserState), uuid, status)
 }

--- a/mocks/converged/vms.go
+++ b/mocks/converged/vms.go
@@ -204,6 +204,21 @@ func (mr *MockVMsMockRecorder[VM]) Get(ctx, uuid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVMs[VM])(nil).Get), ctx, uuid)
 }
 
+// GetVMByBiosUUID mocks base method.
+func (m *MockVMs[VM]) GetVMByBiosUUID(ctx context.Context, biosUUID string) (*VM, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMByBiosUUID", ctx, biosUUID)
+	ret0, _ := ret[0].(*VM)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMByBiosUUID indicates an expected call of GetVMByBiosUUID.
+func (mr *MockVMsMockRecorder[VM]) GetVMByBiosUUID(ctx, biosUUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMByBiosUUID", reflect.TypeOf((*MockVMs[VM])(nil).GetVMByBiosUUID), ctx, biosUUID)
+}
+
 // List mocks base method.
 func (m *MockVMs[VM]) List(ctx context.Context, opts ...converged.ODataOption) ([]VM, error) {
 	m.ctrl.T.Helper()

--- a/mocks/nutanix/v3.go
+++ b/mocks/nutanix/v3.go
@@ -876,6 +876,21 @@ func (mr *MockServiceMockRecorder) GetSubnet(ctx, uuid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockService)(nil).GetSubnet), ctx, uuid)
 }
 
+// GetSyncReplicationCapableClusters mocks base method.
+func (m *MockService) GetSyncReplicationCapableClusters(ctx context.Context, request *v3.ClusterSyncReplicationCapableInput) (*v3.ClusterSyncReplicationCapableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSyncReplicationCapableClusters", ctx, request)
+	ret0, _ := ret[0].(*v3.ClusterSyncReplicationCapableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSyncReplicationCapableClusters indicates an expected call of GetSyncReplicationCapableClusters.
+func (mr *MockServiceMockRecorder) GetSyncReplicationCapableClusters(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncReplicationCapableClusters", reflect.TypeOf((*MockService)(nil).GetSyncReplicationCapableClusters), ctx, request)
+}
+
 // GetTask mocks base method.
 func (m *MockService) GetTask(ctx context.Context, taskUUID string) (*v3.TasksResponse, error) {
 	m.ctrl.T.Helper()
@@ -1024,6 +1039,21 @@ func (m *MockService) ListAllAddressGroups(ctx context.Context, filter string) (
 func (mr *MockServiceMockRecorder) ListAllAddressGroups(ctx, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAddressGroups", reflect.TypeOf((*MockService)(nil).ListAllAddressGroups), ctx, filter)
+}
+
+// ListAllAvailabilityZones mocks base method.
+func (m *MockService) ListAllAvailabilityZones(ctx context.Context, filter string) (*v3.AvailabilityZoneListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllAvailabilityZones", ctx, filter)
+	ret0, _ := ret[0].(*v3.AvailabilityZoneListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllAvailabilityZones indicates an expected call of ListAllAvailabilityZones.
+func (mr *MockServiceMockRecorder) ListAllAvailabilityZones(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAvailabilityZones", reflect.TypeOf((*MockService)(nil).ListAllAvailabilityZones), ctx, filter)
 }
 
 // ListAllCategoryValues mocks base method.
@@ -1249,6 +1279,21 @@ func (m *MockService) ListAllVM(ctx context.Context, filter string) (*v3.VMListI
 func (mr *MockServiceMockRecorder) ListAllVM(ctx, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllVM", reflect.TypeOf((*MockService)(nil).ListAllVM), ctx, filter)
+}
+
+// ListAvailabilityZones mocks base method.
+func (m *MockService) ListAvailabilityZones(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.AvailabilityZoneListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAvailabilityZones", ctx, getEntitiesRequest)
+	ret0, _ := ret[0].(*v3.AvailabilityZoneListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAvailabilityZones indicates an expected call of ListAvailabilityZones.
+func (mr *MockServiceMockRecorder) ListAvailabilityZones(ctx, getEntitiesRequest any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailabilityZones", reflect.TypeOf((*MockService)(nil).ListAvailabilityZones), ctx, getEntitiesRequest)
 }
 
 // ListCategories mocks base method.


### PR DESCRIPTION
Ports [internal-cluster-api-provider-nutanix#107](https://github.com/nutanix-cloud-native/internal-cluster-api-provider-nutanix/pull/107). This provider is affected by the same bug.

> [!IMPORTANT]
> **Merge order**: depends on nutanix-cloud-native/prism-go-client#374. `go.mod` currently points at a pseudo-version of that PR's branch head (`v0.8.2-0.20260809222332-d015b296f1bd`). Once #374 merges, this needs a re-bump to a commit on `prism-go-client` `main` (or a tagged release) before it can land.

## Summary
- **Root cause**: a reconcile triggered immediately behind a VM-creation reconcile could observe `Spec.ProviderID` before `Status.VmUUID` was durable (or neither), falling back to a Prism name search that is vulnerable to read-after-write lag — causing CAPX to create a second VM for the same `NutanixMachine`.
- `GetVMUUID` now falls back to `Spec.ProviderID` (silently ignoring malformed/placeholder values, e.g. those set by `NutanixMachineTemplate` defaults) so a racing or post-`clusterctl move` reconcile can resolve the VM by UUID instead of by name. Treating an unparseable value as an error would permanently block reconciliation for any machine created from a template that ships a placeholder providerID, so it is treated as "no usable identifier yet".
- `patchMachine` now diffs against a caller-supplied pre-mutation baseline instead of the already-mutated object. `v1beta1patch.Helper` computes its diff from whatever object it was constructed with, so building the helper from the mutated object made every one of these patches a silent no-op: the VM UUID and providerID only ever reached the API server via the deferred patch at the end of a *successful* reconcile — precisely the window this race lives in. Fixed at all three call sites that share the helper.
- A per-machine idempotency key is minted and durably persisted (`capx.nutanix.com/vm-creation-request-id` annotation) before the first `Create` call, and reused via the `NTNX-Request-Id` header on every later attempt, so a retried `Create` returns the original task's result instead of creating a second VM. It lives in an annotation, not status, because `clusterctl move` drops status on Create for objects with the status subresource enabled.
- Bumps `prism-go-client` to the commit introducing `converged/v4.WithRequestID` and regenerates the mocks affected by interface changes picked up in the same bump (`v3.Service` gained `GetSyncReplicationCapableClusters`, `converged.VMs` gained `GetVMByBiosUUID`, `converged.Users` gained its write methods).

## Test plan
- [x] `make unit-test` — full suite green.
- [x] `TestGetVMUUID` — new cases for the `Spec.ProviderID` fallback: precedence of `Status.VmUUID`, missing `nutanix://` prefix, and non-UUID placeholder values.
- [x] `TestNutanixMachineReconciler_getOrMintVMCreationRequestID` — asserts the patch actually sent to the API server contains the annotation (a diff computed against a post-mutation baseline would be empty and silently non-durable), and that an already-persisted key is reused without a second patch.
- [x] The `syncVmUUID` and `getOrCreateVM` tests now assert durability by re-fetching the object from the fake client rather than reading the in-memory pointer, so a patch regressing to a no-op fails the test. This required `WithStatusSubresource` on those fake clients, and the `getOrCreateVM` create-path subtest now uses a real fake client instead of a hand-rolled `Status()`/`Patch()` gomock that would have to reimplement the helper's diffing logic to stay trustworthy.

## Notes for reviewers
- `make mocks` does not cover `mocks/nutanix/v3.go`; it was regenerated with the `mockgen` command recorded in that file's header. Worth adding to the Makefile target separately so the next dependency bump doesn't hit the same trap.
- `mocks/converged/users.go` in this diff includes regeneration drift that predates this change — `make mocks` on `main` produces it too.