### PR TITLE
ci: correct check_approvals output reference in security workflows

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       # For pull_request_target: pass through the actual approval result (empty string if the step was skipped, i.e. no label or not external).
       # For all other events: default to 'true' so non-PR triggers are not blocked.
-      check_approvals: ${{ github.event_name == 'pull_request_target' && steps.check_approvals.outputs.check_approvals || (github.event_name != 'pull_request_target' && 'true') || '' }}
+      check_approvals: ${{ github.event_name == 'pull_request_target' && steps.check_approvals.outputs.status || (github.event_name != 'pull_request_target' && 'true') || '' }}
       # Output whether the PR is external
       external_pr: ${{ ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url) || 'false' }}
     steps:

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -26,7 +26,7 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url )) }}
     outputs:
       # Output the approval status for pull_request_target events, otherwise default to 'true'
-      check_approvals: ${{ github.event_name == 'pull_request_target' && steps.check_approvals.outputs.check_approvals || 'true' }}
+      check_approvals: ${{ github.event_name == 'pull_request_target' && steps.check_approvals.outputs.status || 'true' }}
       # Output whether the PR is external
       external_pr: ${{ github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url }}
     steps:


### PR DESCRIPTION
## Summary

The `check_approvals` gate references `steps.check_approvals.outputs.check_approvals`, but the `action-check-approvals` action exposes its result as `status`. Because of the mismatched key, the gate did not evaluate as intended for external pull requests.

## Fix

Point the expression at the action's `status` output. One-token change per file; the existing gate structure is unchanged.