### PR TITLE
fix: formatting spec for kubectl display

### DIFF
--- a/api/v1beta1/nutanixmetrosite_types.go
+++ b/api/v1beta1/nutanixmetrosite_types.go
@@ -61,8 +61,9 @@ type NutanixMetroSiteStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
-// +kubebuilder:printcolumn:name="PreferredFailureDomain",type="string",JSONPath=".spec.preferredFailureDomain",description="Reference of the preferred NutanixFailureDomain object"
-// +kubebuilder:printcolumn:name="Metro",type="string",JSONPath=".spec.metroRef",description="Reference of NutanixMetro object this site belongs to"
+// +kubebuilder:printcolumn:name="PreferredFailureDomain",type="string",JSONPath=".spec.preferredFailureDomain.name",description="Reference of the preferred NutanixFailureDomain object"
+// +kubebuilder:printcolumn:name="Metro",type="string",JSONPath=".spec.metroRef.name",description="Reference of NutanixMetro object this site belongs to"
+// +kubebuilder:printcolumn:name="Group",type="string",JSONPath=".spec.groupNameLabel",description="Group label for nodes anchored to a topology segment"
 
 // NutanixMetroSite is the Schema for the NutanixMetroSite API.
 type NutanixMetroSite struct {

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	corev1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 )
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmetrosites.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmetrosites.yaml
@@ -20,12 +20,16 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Reference of the preferred NutanixFailureDomain object
-      jsonPath: .spec.preferredFailureDomain
+      jsonPath: .spec.preferredFailureDomain.name
       name: PreferredFailureDomain
       type: string
     - description: Reference of NutanixMetro object this site belongs to
-      jsonPath: .spec.metroRef
+      jsonPath: .spec.metroRef.name
       name: Metro
+      type: string
+    - description: Group label for nodes anchored to a topology segment
+      jsonPath: .spec.groupNameLabel
+      name: Group
       type: string
     name: v1beta1
     schema:


### PR DESCRIPTION
Properly formatting metrosite fields while getting it using kubectl.

Before:
[konvoy@localhost nkp_home]$ kubectl get nutanixmetrosite -A
NAMESPACE   NAME           PREFERREDFAILUREDOMAIN   METRO
kommander     metro0-s0   {"name":"fd0"}                            {"name":"metro0"}
kommander     metro0-s1   {"name":"fd1"}                             {"name":"metro0"}

After:
NAME           GROUP            METRO    FD
metro0-s0   metro0-site0   metro0    fd0
metro0-s1    metro0-site1   metro0    fd1


Changes Made:
```
//+kubebuilder:printcolumn:name="PreferredFailureDomain",type="string",JSONPath=".spec.preferredFailureDomain.name",description="Reference of the preferred NutanixFailureDomain object"

//+kubebuilder:printcolumn:name="Metro",type="string",JSONPath=".spec.metroRef.name",description="Reference of NutanixMetro object this site belongs to"

//+kubebuilder:printcolumn:name="Group",type="string",JSONPath=".spec.groupNameLabel",description="Group label for nodes anchored to a topology segment"

```