### PR TITLE
fix: handle get category race condition

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -771,13 +771,32 @@ func getOrCreateCategory(ctx context.Context, client *prismclientv3.Client, cate
 		return nil, errorMsg
 	}
 	if categoryValue == nil {
-		categoryValue, err = client.V3.CreateOrUpdateCategoryValue(ctx, *categoryKey.Name, &prismclientv3.CategoryValue{
+		_, err = client.V3.CreateOrUpdateCategoryValue(ctx, *categoryKey.Name, &prismclientv3.CategoryValue{
 			Description: utils.StringPtr(infrav1.DefaultCAPICategoryDescription),
 			Value:       utils.StringPtr(categoryIdentifier.Value),
 		})
 		if err != nil {
 			errorMsg := fmt.Errorf("failed to create category value %s in category key %s: %v", categoryIdentifier.Value, categoryIdentifier.Key, err)
 			log.Error(errorMsg, "failed to create category value")
+			return nil, errorMsg
+		}
+
+		// Prism Central's category-value create response is not a reliable
+		// signal that the value is readable yet: the value can be absent from
+		// a subsequent read (e.g. the GetCategoryVMSpec lookup during machine
+		// reconciliation) even though creation reported success. Verify the
+		// value can actually be read back before treating creation as done, so
+		// callers (e.g. reconcileCategories) don't mark the cluster Ready and
+		// let machine reconciliation race ahead of category propagation.
+		categoryValue, err = getCategoryValue(ctx, client, *categoryKey.Name, categoryIdentifier.Value)
+		if err != nil {
+			errorMsg := fmt.Errorf("failed to verify category value %s in category %s after creation. error: %v", categoryIdentifier.Value, categoryIdentifier.Key, err)
+			log.Error(errorMsg, "failed to verify category value")
+			return nil, errorMsg
+		}
+		if categoryValue == nil {
+			errorMsg := fmt.Errorf("category value %s in category %s was created but is not yet readable from Prism Central", categoryIdentifier.Value, categoryIdentifier.Key)
+			log.Info(errorMsg.Error())
 			return nil, errorMsg
 		}
 	}

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -921,6 +921,60 @@ func TestGetCategoryVMSpecMapping_MultiValues(t *testing.T) {
 	})
 }
 
+func TestGetOrCreateCategories_ReadBackVerification(t *testing.T) {
+	key := "KubernetesClusterName"
+	value := "e2e-nutanix-ag-test-1786608844"
+	notFoundErr := errors.New("CATEGORY_NAME_VALUE_MISMATCH")
+
+	ids := []*infrav1.NutanixCategoryIdentifier{{Key: key, Value: value}}
+
+	t.Run("creates category value and succeeds once read-back confirms it is visible", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mockv3 := mocknutanixv3.NewMockService(ctrl)
+		client := &prismclientv3.Client{V3: mockv3}
+
+		mockv3.EXPECT().GetCategoryKey(ctx, key).Return(&prismclientv3.CategoryKeyStatus{Name: &key}, nil)
+		gomock.InOrder(
+			mockv3.EXPECT().GetCategoryValue(ctx, key, value).Return(nil, notFoundErr),
+			mockv3.EXPECT().CreateOrUpdateCategoryValue(ctx, key, gomock.Any()).
+				Return(&prismclientv3.CategoryValueStatus{Value: &value}, nil),
+			mockv3.EXPECT().GetCategoryValue(ctx, key, value).Return(&prismclientv3.CategoryValueStatus{Value: &value}, nil),
+		)
+
+		got, err := GetOrCreateCategories(ctx, client, ids)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, value, *got[0].Value)
+	})
+
+	t.Run("returns an error instead of Ready-ing when the created value is not yet readable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mockv3 := mocknutanixv3.NewMockService(ctrl)
+		client := &prismclientv3.Client{V3: mockv3}
+
+		mockv3.EXPECT().GetCategoryKey(ctx, key).Return(&prismclientv3.CategoryKeyStatus{Name: &key}, nil)
+		gomock.InOrder(
+			mockv3.EXPECT().GetCategoryValue(ctx, key, value).Return(nil, notFoundErr),
+			mockv3.EXPECT().CreateOrUpdateCategoryValue(ctx, key, gomock.Any()).
+				Return(&prismclientv3.CategoryValueStatus{Value: &value}, nil),
+			// Prism Central reports the create as successful, but a subsequent
+			// read still can't see it (the eventual-consistency race this test
+			// guards against).
+			mockv3.EXPECT().GetCategoryValue(ctx, key, value).Return(nil, notFoundErr),
+		)
+
+		_, err := GetOrCreateCategories(ctx, client, ids)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet readable")
+	})
+}
+
 func TestGetStorageContainerByNtnxResourceIdentifier(t *testing.T) {
 	mockctl := gomock.NewController(t)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```