### PR TITLE
fix: formatting spec for kubectl display for metro

### DIFF
--- a/api/v1beta1/nutanixmetro_types.go
+++ b/api/v1beta1/nutanixmetro_types.go
@@ -55,7 +55,7 @@ type NutanixMetroStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:metadata:annotations="clusterctl.cluster.x-k8s.io/skip-crd-name-preflight-check=true"
 // +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
-// +kubebuilder:printcolumn:name="FailureDomains",type="string",JSONPath=".spec.failureDomains",description="References of NutanixFailureDomain objects"
+// +kubebuilder:printcolumn:name="FailureDomains",type="string",JSONPath=".spec.failureDomains[*].name",description="References of NutanixFailureDomain objects"
 
 // NutanixMetro is the Schema for the NutanixMetro API.
 type NutanixMetro struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmetros.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_nutanixmetros.yaml
@@ -21,7 +21,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: References of NutanixFailureDomain objects
-      jsonPath: .spec.failureDomains
+      jsonPath: .spec.failureDomains[*].name
       name: FailureDomains
       type: string
     name: v1beta1


### PR DESCRIPTION
What changed:
.spec.failureDomains targets the full array of objects: [{"name":"fd0"},{"name":"fd1"}]

.spec.failureDomains[*].name extracts only the name property from each item: ["fd0","fd1"]