### PR TITLE
fix: delete recovered VM after Metro UPFO instead of orphaning it

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -85,6 +85,17 @@ const (
 
 	vmCustomAttributePrefix4MetroPreferredPE        = "metro-preferred-pe:"
 	vmCustomAttributePrefix4MetroNodeGroupNameLabel = "metro-node-group-name:"
+
+	drConfigEntityType    = "entity_dr_config"
+	drRoleDecoupled       = "kDecoupled"
+	drConfigRoleAttribute = "role"
+
+	// skippedDecoupledVMUUIDAnnotation records the Machine's original VM UUID when
+	// delete skipped it because DR marked the VM decoupled (Metro UPFO).
+	skippedDecoupledVMUUIDAnnotation = "capx.nutanix.com/skipped-decoupled-vm-uuid"
+	// recoveredVMUUIDAnnotation is the non-decoupled recovered VM CAPX will delete
+	// instead of the decoupled original.
+	recoveredVMUUIDAnnotation = "capx.nutanix.com/recovered-vm-uuid"
 )
 
 type StorageContainerIntentResponse struct {
@@ -252,6 +263,148 @@ func FindVMByName(ctx context.Context, client *v4Converged.Client, vmName string
 	}
 
 	return FindVMByUUID(ctx, client, *vms[0].ExtId)
+}
+
+func nutanixV3Service(client *prismclientv3.Client) prismclientv3.Service {
+	if client == nil {
+		return nil
+	}
+	return client.V3
+}
+
+func groupsFieldValue(entity *prismclientv3.GroupsEntity, name string) string {
+	if entity == nil {
+		return ""
+	}
+	for _, data := range entity.Data {
+		if data == nil || data.Name != name {
+			continue
+		}
+		for _, pair := range data.Values {
+			if pair == nil || len(pair.Values) == 0 {
+				continue
+			}
+			return pair.Values[0]
+		}
+	}
+	return ""
+}
+
+// isVMDecoupled reports whether Prism Central DR config marks the VM as decoupled.
+// A decoupled VM must not be deleted by CAPX; Disaster Recovery owns it.
+func isVMDecoupled(ctx context.Context, v3Client prismclientv3.Service, vmUUID string) (bool, error) {
+	if v3Client == nil || vmUUID == "" {
+		return false, nil
+	}
+
+	resp, err := v3Client.GroupsGetEntities(ctx, &prismclientv3.GroupsGetEntitiesRequest{
+		EntityType:     ptr.To(drConfigEntityType),
+		FilterCriteria: fmt.Sprintf("entity_uuid=in=%s", vmUUID),
+		GroupMemberAttributes: []*prismclientv3.GroupsRequestedAttribute{
+			{Attribute: ptr.To(drConfigRoleAttribute)},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to get DR config for VM %s: %w", vmUUID, err)
+	}
+	if resp == nil {
+		return false, nil
+	}
+
+	for _, group := range resp.GroupResults {
+		if group == nil {
+			continue
+		}
+		for _, entity := range group.EntityResults {
+			if groupsFieldValue(entity, drConfigRoleAttribute) == drRoleDecoupled {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// findNonDecoupledVMByName lists VMs with the given names and returns the single
+// VM that is not DR-decoupled. Returns nil if only decoupled VMs exist (or none).
+func findNonDecoupledVMByName(ctx context.Context, client *v4Converged.Client, v3Client prismclientv3.Service, names []string) (*vmmconfig.Vm, error) {
+	log := ctrl.LoggerFrom(ctx)
+	seen := map[string]struct{}{}
+	live := make([]*vmmconfig.Vm, 0)
+
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		vms, err := client.VMs.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", name)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMs named %s: %w", name, err)
+		}
+		for i := range vms {
+			vm := vms[i]
+			if vm.ExtId == nil || *vm.ExtId == "" {
+				continue
+			}
+			uuid := *vm.ExtId
+			if _, ok := seen[uuid]; ok {
+				continue
+			}
+			seen[uuid] = struct{}{}
+
+			decoupled, err := isVMDecoupled(ctx, v3Client, uuid)
+			if err != nil {
+				return nil, err
+			}
+			if decoupled {
+				log.Info(fmt.Sprintf("skipping decoupled VM %s with UUID %s", name, uuid))
+				continue
+			}
+
+			full, err := FindVMByUUID(ctx, client, uuid)
+			if err != nil {
+				return nil, err
+			}
+			if full != nil {
+				live = append(live, full)
+			}
+		}
+	}
+
+	if len(live) == 0 {
+		return nil, nil
+	}
+	if len(live) > 1 {
+		return nil, fmt.Errorf("found more than one (%d) non-decoupled VMs with names %v", len(live), names)
+	}
+	return live[0], nil
+}
+
+func nutanixMachineAnnotation(nm *infrav1.NutanixMachine, key string) string {
+	if nm == nil || nm.Annotations == nil {
+		return ""
+	}
+	return nm.Annotations[key]
+}
+
+func setNutanixMachineAnnotation(nm *infrav1.NutanixMachine, key, value string) {
+	if nm.Annotations == nil {
+		nm.Annotations = map[string]string{}
+	}
+	nm.Annotations[key] = value
+}
+
+func deleteNutanixMachineAnnotation(nm *infrav1.NutanixMachine, key string) {
+	if nm == nil || nm.Annotations == nil {
+		return
+	}
+	delete(nm.Annotations, key)
+}
+
+func vmNamesForDelete(machineName, nutanixMachineName string) []string {
+	names := []string{machineName}
+	if nutanixMachineName != "" && nutanixMachineName != machineName {
+		names = append(names, nutanixMachineName)
+	}
+	return names
 }
 
 // GetPEUUID returns the UUID of the Prism Element cluster with the given name or UUID.

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -265,13 +265,6 @@ func FindVMByName(ctx context.Context, client *v4Converged.Client, vmName string
 	return FindVMByUUID(ctx, client, *vms[0].ExtId)
 }
 
-func nutanixV3Service(client *prismclientv3.Client) prismclientv3.Service {
-	if client == nil {
-		return nil
-	}
-	return client.V3
-}
-
 func groupsFieldValue(entity *prismclientv3.GroupsEntity, name string) string {
 	if entity == nil {
 		return ""
@@ -290,8 +283,35 @@ func groupsFieldValue(entity *prismclientv3.GroupsEntity, name string) string {
 	return ""
 }
 
+// useMetroDRDeletePath reports whether reconcileDelete may call v3 Groups
+// (entity_dr_config) to skip DR-decoupled VMs. kDecoupled is a Metro UPFO signal.
+// Groups is not project-scoped and is denied for least-privilege / Projects 2.0
+// users, so non-metro delete must stay UUID-only even when Groups is down.
+func useMetroDRDeletePath(rctx *nctx.MachineContext) bool {
+	if rctx == nil {
+		return false
+	}
+	if rctx.Machine != nil && (isNutanixMetroFailureDomain(rctx.Machine.Spec.FailureDomain) ||
+		isNutanixMetroSiteFailureDomain(rctx.Machine.Spec.FailureDomain)) {
+		return true
+	}
+	if rctx.NutanixMachine == nil {
+		return false
+	}
+	if fd := ptr.Deref(rctx.NutanixMachine.Status.FailureDomain, ""); isNutanixMetroFailureDomain(fd) ||
+		isNutanixMetroSiteFailureDomain(fd) {
+		return true
+	}
+	if nutanixMachineAnnotation(rctx.NutanixMachine, metroActivePlacementPEAnnotation) != "" {
+		return true
+	}
+	return nutanixMachineAnnotation(rctx.NutanixMachine, skippedDecoupledVMUUIDAnnotation) != "" ||
+		nutanixMachineAnnotation(rctx.NutanixMachine, recoveredVMUUIDAnnotation) != ""
+}
+
 // isVMDecoupled reports whether Prism Central DR config marks the VM as decoupled.
 // A decoupled VM must not be deleted by CAPX; Disaster Recovery owns it.
+// Callers must only use this on the Metro delete path (see useMetroDRDeletePath).
 func isVMDecoupled(ctx context.Context, v3Client prismclientv3.Service, vmUUID string) (bool, error) {
 	if v3Client == nil || vmUUID == "" {
 		return false, nil

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -2326,6 +2326,122 @@ func TestDeleteVM(t *testing.T) {
 	})
 }
 
+func drConfigGroupsResponse(role string) *prismclientv3.GroupsGetEntitiesResponse {
+	return &prismclientv3.GroupsGetEntitiesResponse{
+		GroupResults: []*prismclientv3.GroupsGroupResult{
+			{
+				EntityResults: []*prismclientv3.GroupsEntity{
+					{
+						Data: []*prismclientv3.GroupsFieldData{
+							{Name: drConfigRoleAttribute, Values: []*prismclientv3.GroupsTimevaluePair{{Values: []string{role}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestIsVMDecoupled(t *testing.T) {
+	ctx := context.Background()
+	vmUUID := "e530a7a6-3e93-4408-77af-d7ce41a3997c"
+
+	t.Run("returns false when v3 client is nil", func(t *testing.T) {
+		decoupled, err := isVMDecoupled(ctx, nil, vmUUID)
+		assert.NoError(t, err)
+		assert.False(t, decoupled)
+	})
+
+	t.Run("returns true when role is kDecoupled", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(ctx, gomock.Any()).Return(drConfigGroupsResponse(drRoleDecoupled), nil)
+
+		decoupled, err := isVMDecoupled(ctx, mockV3, vmUUID)
+		assert.NoError(t, err)
+		assert.True(t, decoupled)
+	})
+
+	t.Run("returns false when role is not decoupled", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(ctx, gomock.Any()).Return(drConfigGroupsResponse("kActive"), nil)
+
+		decoupled, err := isVMDecoupled(ctx, mockV3, vmUUID)
+		assert.NoError(t, err)
+		assert.False(t, decoupled)
+	})
+
+	t.Run("returns error when groups API fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(ctx, gomock.Any()).Return(nil, errors.New("pc unavailable"))
+
+		decoupled, err := isVMDecoupled(ctx, mockV3, vmUUID)
+		assert.Error(t, err)
+		assert.False(t, decoupled)
+		assert.Contains(t, err.Error(), "failed to get DR config")
+	})
+}
+
+func TestFindNonDecoupledVMByName(t *testing.T) {
+	ctx := context.Background()
+	vmName := "cp1"
+	decoupledUUID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	liveUUID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	t.Run("skips decoupled VM and returns recovered VM", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		decoupledVM := vmmModels.NewVm()
+		decoupledVM.Name = ptr.To(vmName)
+		decoupledVM.ExtId = ptr.To(decoupledUUID)
+		liveVM := vmmModels.NewVm()
+		liveVM.Name = ptr.To(vmName)
+		liveVM.ExtId = ptr.To(liveUUID)
+
+		mockClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockClient.MockVMs.EXPECT().List(ctx, gomock.Any()).Return([]vmmModels.Vm{*decoupledVM, *liveVM}, nil)
+		mockV3.EXPECT().GroupsGetEntities(ctx, gomock.Any()).DoAndReturn(
+			func(_ context.Context, req *prismclientv3.GroupsGetEntitiesRequest) (*prismclientv3.GroupsGetEntitiesResponse, error) {
+				if strings.Contains(req.FilterCriteria, decoupledUUID) {
+					return drConfigGroupsResponse(drRoleDecoupled), nil
+				}
+				return drConfigGroupsResponse("kActive"), nil
+			},
+		).AnyTimes()
+		mockClient.MockVMs.EXPECT().Get(ctx, liveUUID).Return(liveVM, nil)
+
+		got, err := findNonDecoupledVMByName(ctx, mockClient.Client, mockV3, []string{vmName})
+		assert.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, liveUUID, *got.ExtId)
+	})
+
+	t.Run("returns nil when only decoupled VMs exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		decoupledVM := vmmModels.NewVm()
+		decoupledVM.Name = ptr.To(vmName)
+		decoupledVM.ExtId = ptr.To(decoupledUUID)
+
+		mockClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockClient.MockVMs.EXPECT().List(ctx, gomock.Any()).Return([]vmmModels.Vm{*decoupledVM}, nil)
+		mockV3.EXPECT().GroupsGetEntities(ctx, gomock.Any()).Return(drConfigGroupsResponse(drRoleDecoupled), nil)
+
+		got, err := findNonDecoupledVMByName(ctx, mockClient.Client, mockV3, []string{vmName})
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
 func TestDeleteCategoryKeyValues(t *testing.T) {
 	ctx := context.Background()
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -31,6 +31,7 @@ import (
 	mockk8sclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/k8sclient"
 	mocknutanixv3 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/mocks/nutanix"
 	nutanixclient "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/client"
+	nctx "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pkg/context"
 	converged "github.com/nutanix-cloud-native/prism-go-client/converged"
 	v4Converged "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
 	credentialtypes "github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
@@ -2340,6 +2341,35 @@ func drConfigGroupsResponse(role string) *prismclientv3.GroupsGetEntitiesRespons
 			},
 		},
 	}
+}
+
+func TestUseMetroDRDeletePath(t *testing.T) {
+	t.Run("false when context is empty", func(t *testing.T) {
+		assert.False(t, useMetroDRDeletePath(nil))
+		assert.False(t, useMetroDRDeletePath(&nctx.MachineContext{
+			Machine:        &capiv1beta2.Machine{},
+			NutanixMachine: &infrav1.NutanixMachine{},
+		}))
+	})
+
+	t.Run("true for metro site failure domain", func(t *testing.T) {
+		assert.True(t, useMetroDRDeletePath(&nctx.MachineContext{
+			Machine: &capiv1beta2.Machine{
+				Spec: capiv1beta2.MachineSpec{FailureDomain: metroSiteFailureDomainPrefix + "metro0-s1"},
+			},
+		}))
+	})
+
+	t.Run("true when delete already recorded a recovered VM", func(t *testing.T) {
+		assert.True(t, useMetroDRDeletePath(&nctx.MachineContext{
+			Machine: &capiv1beta2.Machine{},
+			NutanixMachine: &infrav1.NutanixMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{recoveredVMUUIDAnnotation: "live-uuid"},
+				},
+			},
+		}))
+	})
 }
 
 func TestIsVMDecoupled(t *testing.T) {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -346,7 +346,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		return reconcile.Result{}, nil
 	}
 
-	vm, err := FindVMByUUID(ctx, convergedClient, vmUUID)
+	vm, waitForRecovered, err := r.vmToDelete(rctx, vmUUID, vmName)
 	if err != nil {
 		errorMsg := fmt.Errorf("error finding VM %s with UUID %s: %w", vmName, vmUUID, err)
 		log.Error(errorMsg, "error finding VM")
@@ -359,13 +359,24 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		})
 		return reconcile.Result{}, errorMsg
 	}
+	if waitForRecovered {
+		log.Info(fmt.Sprintf("recorded VM %s with UUID %s is decoupled; waiting for a recovered non-decoupled VM", vmName, vmUUID))
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 
 	if vm == nil {
-		log.Info(fmt.Sprintf("no VM found with UUID %s: assuming it is already deleted; skipping delete", vmUUID))
-		log.Info(fmt.Sprintf("removing finalizers for VM %s during delete reconciliation", vmName))
+		log.Info(fmt.Sprintf("no live VM remains for %s (recorded UUID %s); removing finalizers", vmName, vmUUID))
 		ctrlutil.RemoveFinalizer(rctx.NutanixMachine, infrav1.NutanixMachineFinalizer)
 		ctrlutil.RemoveFinalizer(rctx.NutanixMachine, infrav1.DeprecatedNutanixMachineFinalizer)
 		return reconcile.Result{}, nil
+	}
+
+	if vm.Name == nil {
+		return reconcile.Result{}, fmt.Errorf("found VM with UUID %s but name was empty", ptr.Deref(vm.ExtId, vmUUID))
+	}
+	targetUUID := ptr.Deref(vm.ExtId, vmUUID)
+	if targetUUID == "" {
+		return reconcile.Result{}, fmt.Errorf("found VM %s but UUID was empty", *vm.Name)
 	}
 
 	// Check if the VM name matches the Machine name or the NutanixMachine name.
@@ -374,12 +385,12 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 	// This check is to ensure that we are deleting the correct VM for both cases as older CAPX VMs
 	// will have the NutanixMachine name as the VM name.
 	if *vm.Name != vmName && *vm.Name != rctx.NutanixMachine.Name {
-		return reconcile.Result{}, fmt.Errorf("found VM with UUID %s but name %s did not match Machine name %s or NutanixMachineName %s", vmUUID, *vm.Name, vmName, rctx.NutanixMachine.Name)
+		return reconcile.Result{}, fmt.Errorf("found VM with UUID %s but name %s did not match Machine name %s or NutanixMachineName %s", targetUUID, *vm.Name, vmName, rctx.NutanixMachine.Name)
 	}
 
-	log.V(1).Info(fmt.Sprintf("Found VM %s with UUID %s.", *vm.Name, vmUUID))
+	log.V(1).Info(fmt.Sprintf("Found VM %s with UUID %s.", *vm.Name, targetUUID))
 
-	taskInProgress, err := VmHasTaskInProgress(ctx, convergedClient, vmUUID)
+	taskInProgress, err := VmHasTaskInProgress(ctx, convergedClient, targetUUID)
 	if err != nil {
 		errorMsg := fmt.Errorf("error occurred while fetching running task from VM: %w", err)
 		log.Error(errorMsg, "error fetching running task from VM")
@@ -396,7 +407,7 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		log.Info(fmt.Sprintf("VM %s has tasks in progress. Requeuing", vmName))
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	} else {
-		log.V(1).Info(fmt.Sprintf("no running tasks anymore... Initiating delete for VM %s with UUID %s", vmName, vmUUID))
+		log.V(1).Info(fmt.Sprintf("no running tasks anymore... Initiating delete for VM %s with UUID %s", vmName, targetUUID))
 	}
 
 	var vgDetachNeeded bool
@@ -407,8 +418,8 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 		}
 	}
 	if vgDetachNeeded {
-		if err := r.detachVolumeGroups(rctx, vmName, vmUUID, vm.Disks); err != nil {
-			err := fmt.Errorf("failed to detach volume groups from VM %s with UUID %s: %w", vmName, vmUUID, err)
+		if err := r.detachVolumeGroups(rctx, vmName, targetUUID, vm.Disks); err != nil {
+			err := fmt.Errorf("failed to detach volume groups from VM %s with UUID %s: %w", vmName, targetUUID, err)
 			log.Error(err, "failed to detach volume groups from VM")
 			v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.VolumeGroupDetachFailed, capiv1beta1.ConditionSeverityWarning, "%s", err.Error())
 			v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -423,14 +434,14 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 
 		// Requeue to wait for volume group detach tasks to complete. This is done instead of blocking on task
 		// completion to avoid long-running reconcile loops.
-		log.Info(fmt.Sprintf("detaching volume groups from VM %s with UUID %s; requeueing again after %s", vmName, vmUUID, detachVGRequeueAfter))
+		log.Info(fmt.Sprintf("detaching volume groups from VM %s with UUID %s; requeueing again after %s", vmName, targetUUID, detachVGRequeueAfter))
 		return reconcile.Result{RequeueAfter: detachVGRequeueAfter}, nil
 	}
 
 	// Delete the VM since the VM was found (err was nil)
-	deleteTaskUUID, err := DeleteVM(ctx, convergedClient, vmName, vmUUID)
+	deleteTaskUUID, err := DeleteVM(ctx, convergedClient, vmName, targetUUID)
 	if err != nil {
-		err := fmt.Errorf("failed to delete VM %s with UUID %s: %w", vmName, vmUUID, err)
+		err := fmt.Errorf("failed to delete VM %s with UUID %s: %w", vmName, targetUUID, err)
 		log.Error(err, "failed to delete VM")
 		v1beta1conditions.MarkFalse(rctx.NutanixMachine, infrav1.VMProvisionedCondition, infrav1.DeletionFailed, capiv1beta1.ConditionSeverityWarning, "%s", err.Error())
 		v1beta2conditions.Set(rctx.NutanixMachine, metav1.Condition{
@@ -442,8 +453,98 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 
 		return reconcile.Result{}, err
 	}
-	log.Info(fmt.Sprintf("Deletion task with UUID %s received for vm %s with UUID %s. Requeueing", deleteTaskUUID, vmName, vmUUID))
+	log.Info(fmt.Sprintf("Deletion task with UUID %s received for vm %s with UUID %s. Requeueing", deleteTaskUUID, vmName, targetUUID))
 	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+// vmToDelete returns the AHV VM CAPX should delete for this Machine.
+//
+// A DR-decoupled VM (original UUID after Metro UPFO) is never deleted; DR owns it.
+// After the failed site returns, DR typically deletes that decoupled leftover. The
+// migrated VM keeps the Machine name but a new UUID. If we only look at the recorded
+// UUID we would drop the finalizer and leave that migrated VM orphaned — so we always
+// look up a non-decoupled VM by name before giving up.
+//
+// wait is true when the recorded UUID is still decoupled and no recovered VM exists yet.
+func (r *NutanixMachineReconciler) vmToDelete(rctx *nctx.MachineContext, recordedUUID, vmName string) (*vmmconfig.Vm, bool, error) {
+	ctx := rctx.Context
+	log := ctrl.LoggerFrom(ctx)
+	v3Client := nutanixV3Service(rctx.NutanixClient)
+	if v3Client == nil {
+		vm, err := FindVMByUUID(ctx, rctx.ConvergedClient, recordedUUID)
+		return vm, false, err
+	}
+
+	decoupled, err := isVMDecoupled(ctx, v3Client, recordedUUID)
+	if err != nil {
+		return nil, false, err
+	}
+	if decoupled {
+		log.Info(fmt.Sprintf("VM %s with UUID %s is decoupled; leaving it for DR", vmName, recordedUUID))
+		setNutanixMachineAnnotation(rctx.NutanixMachine, skippedDecoupledVMUUIDAnnotation, recordedUUID)
+		return r.resolveRecoveredVMForDelete(rctx, v3Client, vmName, true)
+	}
+
+	vm, err := FindVMByUUID(ctx, rctx.ConvergedClient, recordedUUID)
+	if err != nil {
+		live, _, lookupErr := r.resolveRecoveredVMForDelete(rctx, v3Client, vmName, false)
+		if lookupErr != nil {
+			return nil, false, lookupErr
+		}
+		if live != nil {
+			log.Info(fmt.Sprintf("recorded VM UUID %s lookup failed; deleting migrated VM %s with UUID %s by name", recordedUUID, vmName, ptr.Deref(live.ExtId, "")))
+			return live, false, nil
+		}
+		return nil, false, err
+	}
+	if vm != nil {
+		return vm, false, nil
+	}
+
+	// Recorded UUID is gone — DR likely deleted the decoupled leftover after the
+	// site came back. Delete the migrated VM by name so it is not left orphaned.
+	log.Info(fmt.Sprintf("recorded VM UUID %s is gone; looking for a migrated VM named %s", recordedUUID, vmName))
+	return r.resolveRecoveredVMForDelete(rctx, v3Client, vmName, false)
+}
+
+// resolveRecoveredVMForDelete finds the non-decoupled VM to delete after skipping
+// a decoupled original. If waitIfMissing is true and none exists yet, wait is true.
+func (r *NutanixMachineReconciler) resolveRecoveredVMForDelete(rctx *nctx.MachineContext, v3Client prismclientv3.Service, vmName string, waitIfMissing bool) (*vmmconfig.Vm, bool, error) {
+	ctx := rctx.Context
+	log := ctrl.LoggerFrom(ctx)
+
+	if recoveredUUID := nutanixMachineAnnotation(rctx.NutanixMachine, recoveredVMUUIDAnnotation); recoveredUUID != "" {
+		recoveredDecoupled, err := isVMDecoupled(ctx, v3Client, recoveredUUID)
+		if err != nil {
+			return nil, false, err
+		}
+		if recoveredDecoupled {
+			log.Info(fmt.Sprintf("previously recovered VM %s is now decoupled; waiting for the next recovered generation", recoveredUUID))
+			deleteNutanixMachineAnnotation(rctx.NutanixMachine, recoveredVMUUIDAnnotation)
+		} else {
+			vm, err := FindVMByUUID(ctx, rctx.ConvergedClient, recoveredUUID)
+			if err != nil {
+				return nil, false, err
+			}
+			if vm == nil {
+				log.Info(fmt.Sprintf("recovered VM %s has been deleted", recoveredUUID))
+				return nil, false, nil
+			}
+			return vm, false, nil
+		}
+	}
+
+	live, err := findNonDecoupledVMByName(ctx, rctx.ConvergedClient, v3Client, vmNamesForDelete(vmName, rctx.NutanixMachine.Name))
+	if err != nil {
+		return nil, false, err
+	}
+	if live == nil || live.ExtId == nil || *live.ExtId == "" {
+		return nil, waitIfMissing, nil
+	}
+
+	setNutanixMachineAnnotation(rctx.NutanixMachine, recoveredVMUUIDAnnotation, *live.ExtId)
+	log.Info(fmt.Sprintf("found migrated VM %s with UUID %s to delete", vmName, *live.ExtId))
+	return live, false, nil
 }
 
 func (r *NutanixMachineReconciler) detachVolumeGroups(rctx *nctx.MachineContext, vmName string, vmUUID string, vmDiskList []vmmconfig.Disk) error {

--- a/controllers/nutanixmachine_controller.go
+++ b/controllers/nutanixmachine_controller.go
@@ -465,12 +465,18 @@ func (r *NutanixMachineReconciler) reconcileDelete(rctx *nctx.MachineContext) (r
 // UUID we would drop the finalizer and leave that migrated VM orphaned — so we always
 // look up a non-decoupled VM by name before giving up.
 //
+// The v3 Groups lookup is Metro-only. Non-metro (and project-scope / least-privilege)
+// delete stays UUID-only so a Groups deny or timeout cannot block a normal Machine.
+//
 // wait is true when the recorded UUID is still decoupled and no recovered VM exists yet.
 func (r *NutanixMachineReconciler) vmToDelete(rctx *nctx.MachineContext, recordedUUID, vmName string) (*vmmconfig.Vm, bool, error) {
 	ctx := rctx.Context
 	log := ctrl.LoggerFrom(ctx)
-	v3Client := nutanixV3Service(rctx.NutanixClient)
-	if v3Client == nil {
+	var v3Client prismclientv3.Service
+	if rctx.NutanixClient != nil {
+		v3Client = rctx.NutanixClient.V3
+	}
+	if v3Client == nil || !useMetroDRDeletePath(rctx) {
 		vm, err := FindVMByUUID(ctx, rctx.ConvergedClient, recordedUUID)
 		return vm, false, err
 	}

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2697,7 +2697,10 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 			},
 			Status: infrav1.NutanixMachineStatus{VmUUID: vmUUID},
 		}
-		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName},
+			Spec:       capiv1beta2.MachineSpec{FailureDomain: metroSiteFailureDomainPrefix + "metro0-s1"},
+		}
 		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
 
 		mockConvergedClient := NewMockConvergedClient(ctrl)
@@ -2738,7 +2741,10 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 			},
 			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
 		}
-		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName},
+			Spec:       capiv1beta2.MachineSpec{FailureDomain: metroSiteFailureDomainPrefix + "metro0-s1"},
+		}
 		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
 
 		originalVM := vmmModels.NewVm()
@@ -2806,7 +2812,10 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 			},
 			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
 		}
-		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName},
+			Spec:       capiv1beta2.MachineSpec{FailureDomain: metroSiteFailureDomainPrefix + "metro0-s1"},
+		}
 		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
 
 		mockConvergedClient := NewMockConvergedClient(ctrl)
@@ -2854,7 +2863,10 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 			},
 			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
 		}
-		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		machine := &capiv1beta2.Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: vmName},
+			Spec:       capiv1beta2.MachineSpec{FailureDomain: metroSiteFailureDomainPrefix + "metro0-s1"},
+		}
 		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
 
 		migratedVM := vmmModels.NewVm()
@@ -2888,6 +2900,55 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
 		assert.Equal(t, migratedUUID, ntnxMachine.Annotations[recoveredVMUUIDAnnotation])
 		assert.Contains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+	})
+
+	t.Run("should not call groups API on non-metro delete even if v3 client is present", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "worker-1"
+		vmUUID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "worker-1",
+				Namespace:  "default",
+				Finalizers: []string{infrav1.NutanixMachineFinalizer},
+			},
+			Status: infrav1.NutanixMachineStatus{VmUUID: vmUUID},
+		}
+		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+
+		vm := vmmModels.NewVm()
+		vm.Name = ptr.To(vmName)
+		vm.ExtId = ptr.To(vmUUID)
+		vm.Disks = []vmmModels.Disk{}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(gomock.Any(), gomock.Any()).Times(0)
+		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), vmUUID).Return(vm, nil)
+		mockConvergedClient.MockTasks.EXPECT().List(gomock.Any(), FilterMatcher{ContainsExtId: vmUUID}).Return(nil, nil)
+		mockOperation := mockconverged.NewMockOperation[converged.NoEntity](ctrl)
+		mockConvergedClient.MockVMs.EXPECT().DeleteAsync(gomock.Any(), vmUUID).Return(mockOperation, nil)
+		mockOperation.EXPECT().UUID().Return("task-uuid-non-metro").AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			NutanixClient:   &prismclientv3.Client{V3: mockV3},
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		result, err := (&NutanixMachineReconciler{}).reconcileDelete(rctx)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
+		assert.Contains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+		assert.Empty(t, ntnxMachine.Annotations[skippedDecoupledVMUUIDAnnotation])
 	})
 }
 

--- a/controllers/nutanixmachine_controller_test.go
+++ b/controllers/nutanixmachine_controller_test.go
@@ -2680,6 +2680,215 @@ func TestNutanixMachineReconciler_ReconcileDelete(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
 	})
+
+	t.Run("should wait when recorded VM is decoupled and recovered VM is missing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "cp1"
+		vmUUID := "e530a7a6-3e93-4408-77af-d7ce41a3997c"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "cp1",
+				Namespace:  "default",
+				Finalizers: []string{infrav1.NutanixMachineFinalizer},
+			},
+			Status: infrav1.NutanixMachineStatus{VmUUID: vmUUID},
+		}
+		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(gomock.Any(), gomock.Any()).Return(drConfigGroupsResponse(drRoleDecoupled), nil).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{}, nil).AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			NutanixClient:   &prismclientv3.Client{V3: mockV3},
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		result, err := (&NutanixMachineReconciler{}).reconcileDelete(rctx)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
+		assert.Contains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+		assert.Equal(t, vmUUID, ntnxMachine.Annotations[skippedDecoupledVMUUIDAnnotation])
+	})
+
+	t.Run("should delete recovered VM instead of decoupled original", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "cp1"
+		originalUUID := "e530a7a6-3e93-4408-77af-d7ce41a3997c"
+		recoveredUUID := "11111111-2222-3333-4444-555555555555"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "cp1",
+				Namespace:  "default",
+				Finalizers: []string{infrav1.NutanixMachineFinalizer},
+			},
+			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
+		}
+		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+
+		originalVM := vmmModels.NewVm()
+		originalVM.Name = ptr.To(vmName)
+		originalVM.ExtId = ptr.To(originalUUID)
+		recoveredVM := vmmModels.NewVm()
+		recoveredVM.Name = ptr.To(vmName)
+		recoveredVM.ExtId = ptr.To(recoveredUUID)
+		recoveredVM.Disks = []vmmModels.Disk{}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, req *prismclientv3.GroupsGetEntitiesRequest) (*prismclientv3.GroupsGetEntitiesResponse, error) {
+				if strings.Contains(req.FilterCriteria, originalUUID) {
+					return drConfigGroupsResponse(drRoleDecoupled), nil
+				}
+				return drConfigGroupsResponse("kActive"), nil
+			},
+		).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{*originalVM, *recoveredVM}, nil).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), recoveredUUID).Return(recoveredVM, nil).AnyTimes()
+		mockConvergedClient.MockTasks.EXPECT().List(gomock.Any(), FilterMatcher{ContainsExtId: recoveredUUID}).Return(nil, nil)
+		mockOperation := mockconverged.NewMockOperation[converged.NoEntity](ctrl)
+		mockConvergedClient.MockVMs.EXPECT().DeleteAsync(gomock.Any(), recoveredUUID).Return(mockOperation, nil)
+		mockOperation.EXPECT().UUID().Return("task-uuid-recovered").AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			NutanixClient:   &prismclientv3.Client{V3: mockV3},
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		result, err := (&NutanixMachineReconciler{}).reconcileDelete(rctx)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
+		assert.Equal(t, recoveredUUID, ntnxMachine.Annotations[recoveredVMUUIDAnnotation])
+		assert.Contains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+	})
+
+	t.Run("should remove finalizers after recovered VM is gone", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "cp1"
+		originalUUID := "e530a7a6-3e93-4408-77af-d7ce41a3997c"
+		recoveredUUID := "11111111-2222-3333-4444-555555555555"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cp1",
+				Namespace: "default",
+				Finalizers: []string{
+					infrav1.NutanixMachineFinalizer,
+					infrav1.DeprecatedNutanixMachineFinalizer,
+				},
+				Annotations: map[string]string{
+					skippedDecoupledVMUUIDAnnotation: originalUUID,
+					recoveredVMUUIDAnnotation:        recoveredUUID,
+				},
+			},
+			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
+		}
+		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		mockV3.EXPECT().GroupsGetEntities(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, req *prismclientv3.GroupsGetEntitiesRequest) (*prismclientv3.GroupsGetEntitiesResponse, error) {
+				if strings.Contains(req.FilterCriteria, originalUUID) {
+					return drConfigGroupsResponse(drRoleDecoupled), nil
+				}
+				return drConfigGroupsResponse("kActive"), nil
+			},
+		).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), recoveredUUID).Return(nil, nil)
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			NutanixClient:   &prismclientv3.Client{V3: mockV3},
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		result, err := (&NutanixMachineReconciler{}).reconcileDelete(rctx)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+		assert.NotContains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+		assert.NotContains(t, ntnxMachine.Finalizers, infrav1.DeprecatedNutanixMachineFinalizer)
+	})
+
+	t.Run("should delete migrated VM by name after DR removed the decoupled original", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		vmName := "cp1"
+		originalUUID := "e530a7a6-3e93-4408-77af-d7ce41a3997c"
+		migratedUUID := "11111111-2222-3333-4444-555555555555"
+
+		ntnxMachine := &infrav1.NutanixMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "cp1",
+				Namespace:  "default",
+				Finalizers: []string{infrav1.NutanixMachineFinalizer},
+			},
+			Status: infrav1.NutanixMachineStatus{VmUUID: originalUUID},
+		}
+		machine := &capiv1beta2.Machine{ObjectMeta: metav1.ObjectMeta{Name: vmName}}
+		ntnxCluster := &infrav1.NutanixCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+
+		migratedVM := vmmModels.NewVm()
+		migratedVM.Name = ptr.To(vmName)
+		migratedVM.ExtId = ptr.To(migratedUUID)
+		migratedVM.Disks = []vmmModels.Disk{}
+
+		mockConvergedClient := NewMockConvergedClient(ctrl)
+		mockV3 := mocknutanixv3.NewMockService(ctrl)
+		// DR already deleted the decoupled leftover, so groups no longer reports kDecoupled.
+		mockV3.EXPECT().GroupsGetEntities(gomock.Any(), gomock.Any()).Return(drConfigGroupsResponse("kActive"), nil).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), originalUUID).Return(nil, nil)
+		mockConvergedClient.MockVMs.EXPECT().List(gomock.Any(), gomock.Any()).Return([]vmmModels.Vm{*migratedVM}, nil).AnyTimes()
+		mockConvergedClient.MockVMs.EXPECT().Get(gomock.Any(), migratedUUID).Return(migratedVM, nil).AnyTimes()
+		mockConvergedClient.MockTasks.EXPECT().List(gomock.Any(), FilterMatcher{ContainsExtId: migratedUUID}).Return(nil, nil)
+		mockOperation := mockconverged.NewMockOperation[converged.NoEntity](ctrl)
+		mockConvergedClient.MockVMs.EXPECT().DeleteAsync(gomock.Any(), migratedUUID).Return(mockOperation, nil)
+		mockOperation.EXPECT().UUID().Return("task-uuid-migrated").AnyTimes()
+
+		rctx := &nctx.MachineContext{
+			Context:         ctx,
+			Machine:         machine,
+			NutanixMachine:  ntnxMachine,
+			NutanixCluster:  ntnxCluster,
+			NutanixClient:   &prismclientv3.Client{V3: mockV3},
+			ConvergedClient: mockConvergedClient.Client,
+		}
+
+		result, err := (&NutanixMachineReconciler{}).reconcileDelete(rctx)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 5 * time.Second}, result)
+		assert.Equal(t, migratedUUID, ntnxMachine.Annotations[recoveredVMUUIDAnnotation])
+		assert.Contains(t, ntnxMachine.Finalizers, infrav1.NutanixMachineFinalizer)
+	})
 }
 
 func TestNutanixMachineReconciler_getOrCreateVM(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

After Metro unplanned failover (UPFO), the Machine still records the **original** VM UUID (`systemUUID` / `status.vmUUID`). The recovered AHV VM on the surviving site keeps the **same name** and gets a **new UUID**. The original leftover is DR-decoupled (`role=kDecoupled`).

Older `reconcileDelete` only looked up that recorded UUID:

1. While the failed site is down, delete of the decoupled UUID fails → `NutanixMachine` finalizer sticks → KCP will not create a replacement control-plane Machine.
2. When the site returns, DR deletes the decoupled leftover. CAPX sees the recorded UUID as gone, drops the finalizer, and **never deletes the recovered VM** → orphan.

This change:

- Never deletes a VM whose Prism Central DR config `role` is `kDecoupled` (DR owns it).
- Finds the live recovered VM **by Machine name**, skipping decoupled UUIDs, and deletes **that** UUID.
- If the recorded UUID is already gone (DR cleaned the leftover), still looks up by name so the migrated VM is not left behind.
- Persists `capx.nutanix.com/recovered-vm-uuid` so wait-vs-done can be distinguished while the original UUID is still decoupled.
- Same path for control-plane and worker `NutanixMachine` objects.

**How Has This Been Tested?**:

### Unit tests

```bash
go test ./controllers -count=1 -timeout 120s \
  -run 'TestIsVMDecoupled|TestFindNonDecoupledVMByName|TestNutanixMachineReconciler_ReconcileDelete'
```

New coverage:

| Test | What it asserts |
|---|---|
| `TestIsVMDecoupled` | `role=kDecoupled` is decoupled; other roles are not; groups API errors surface |
| `TestFindNonDecoupledVMByName` | skips decoupled UUID, returns the live recovered VM; nil when only decoupled VMs exist |
| ReconcileDelete: wait when recovered is missing | finalizer kept, `skipped-decoupled-vm-uuid` set |
| ReconcileDelete: delete recovered instead of original | `DeleteAsync` on recovered UUID, not the decoupled original |
| ReconcileDelete: finalizers after recovered is gone | finalizers dropped |
| ReconcileDelete: DR already removed the original | name lookup finds migrated VM and deletes **that** UUID |

Existing ReconcileDelete cases (no v3 client) still take the UUID-only path.

### Live cluster (Metro UPFO + MHC remediation)

Built from `5420d945` and rolled out via `CAPIStack/capi-stack` on management cluster `abhay-mgmt`:

`harbor.eng.nutanix.com/abhay-dev/cluster-api-provider-nutanix:e2e-5420d945a22c95606ed72bc424eb9ceacd54e64a@sha256:3ef0161cca7cf118acaf26133ea9e5471ccc0c81e58c2e4e13779d9896ac76a8`

Remediation of control-plane Machine `kommander/abhay-mgmt-7p5fr-p26n6`. CAPX logs (`capx-system`, `14:53:08Z`–`14:53:15Z`):

1. Recorded UUID `ef396be5-5ac3-4cfa-7827-61c6558bdcb9` was **gone** → name lookup (the site-back / DR-cleaned-original path).
2. Skipped decoupled leftover `c3b3c8c1-fe37-42ad-5a3c-f6b75ba4c54f` (not deleted).
3. Deleted live recovered VM `358e14da-94a6-4908-7ab0-0fe841d37784`.
4. After that UUID was gone, removed finalizers. `NutanixMachine` and `Machine` were both gone by `14:53:55Z`.

Without this change, CAPX would have dropped the finalizer when `ef396be5` was missing and left `358e14da` running unmanaged.

A second CP Machine on the same cluster (`abhay-mgmt-7p5fr-pkt89`) took the **normal** delete path: deleted the recorded UUID, name lookup found no recovered leftover, finalizers removed. Confirms non-UPFO delete is unchanged.

**Special notes for your reviewer**:

- Decoupled is `role == kDecoupled` only (groups `entity_dr_config`). Stretch state is not used.
- `capx.nutanix.com/recovered-vm-uuid` is delete-only bookkeeping (same pattern as `metro.nutanix.com/active-placement-pe`). A boolean is not enough for a second failover.
- Wait-for-recovered returns `RequeueAfter` with **no error** so the patch helper persists annotations.
- If `NutanixClient` / v3 is missing, delete still uses the recorded UUID only (legacy).
- Design: `docs/architecture/metro-upfo-vm-delete.md`. KB: `docs/kb/metro-upfo-control-plane-remediation-deadlock.md`.

**Release note**:

```release-note
After Metro UPFO, NutanixMachine delete skips DR-decoupled leftover VMs and deletes the recovered VM (same name, new UUID) instead of leaving it orphaned.
```
