### PR TITLE
fix: fail fast if category value exceeds 64

### DIFF
--- a/controllers/nutanixvirtualhadomain_controller.go
+++ b/controllers/nutanixvirtualhadomain_controller.go
@@ -56,6 +56,9 @@ const (
 	// vhaDefaultMovementGroup is the name of the single movement group generated for a vHA domain.
 	vhaDefaultMovementGroup = "default"
 
+	// prismNameMaxLen is Prism Central's maximum length for category values.
+	prismNameMaxLen = 64
+
 	// vhaResyncInterval is how often a successfully-reconciled vHADomain is re-enqueued so that its
 	// Prism Central resources (categories, protection policy, recovery plans) are re-validated.
 	// Those resources live in Prism Central and cannot be watched, so periodic requeue is used to
@@ -616,8 +619,12 @@ func (r *NutanixVirtualHADomainReconciler) validateRecoveryPlanExists(
 // vhaCategoryValue returns the category value generated for a vHA domain's
 // movement group at the given prism-element index. The category key is shared
 // across all clusters (VHADomainDefaultCategoryKey).
-func vhaCategoryValue(vHADomainName, group string, idx int) string {
-	return fmt.Sprintf("k8s-vha-capx-%s-%s-%d", vHADomainName, group, idx)
+func vhaCategoryValue(vHADomainName, group string, idx int) (string, error) {
+	value := fmt.Sprintf("k8s-vha-capx-%s-%s-%d", vHADomainName, group, idx)
+	if len(value) > prismNameMaxLen {
+		return "", fmt.Errorf("generated category value %q is %d characters; Prism Central limits category values to %d", value, len(value), prismNameMaxLen)
+	}
+	return value, nil
 }
 
 // vhaRecoveryPlanName returns the recovery plan name generated for a vHA domain's
@@ -645,9 +652,13 @@ func (r *NutanixVirtualHADomainReconciler) getOrCreateVHADomainGroupCategories(
 
 	categories := make([]infrav1.NutanixCategoryIdentifier, 0, len(failureDomains))
 	for i := range failureDomains {
+		categoryVal, err := vhaCategoryValue(rctx.VHADomain.Name, group, i)
+		if err != nil {
+			return nil, fmt.Errorf("movementGroup %s: %w", group, err)
+		}
 		ci := infrav1.NutanixCategoryIdentifier{
 			Key:   VHADomainDefaultCategoryKey,
-			Value: vhaCategoryValue(rctx.VHADomain.Name, group, i),
+			Value: categoryVal,
 		}
 		if _, err := getOrCreateCategory(rctx.Context, rctx.ConvergedClient, &ci); err != nil {
 			return nil, fmt.Errorf("movementGroup %s: failed to get or create category %s/%s: %w", group, ci.Key, ci.Value, err)
@@ -806,7 +817,10 @@ func (r *NutanixVirtualHADomainReconciler) getOrCreateVHADomainRecoveryPlan(
 	}
 
 	categoryKey := VHADomainDefaultCategoryKey
-	categoryVal := vhaCategoryValue(rctx.VHADomain.Name, group, primaryIndex)
+	categoryVal, err := vhaCategoryValue(rctx.VHADomain.Name, group, primaryIndex)
+	if err != nil {
+		return nil, err
+	}
 
 	networkMappingAZList := make(
 		[]*v3models.RecoveryPlanResourcesParametersNetworkMappingListItems0AvailabilityZoneNetworkMappingListItems0,

--- a/controllers/nutanixvirtualhadomain_controller_test.go
+++ b/controllers/nutanixvirtualhadomain_controller_test.go
@@ -80,10 +80,19 @@ func vhaDomainObj(name, clusterName string) *infrav1.NutanixVirtualHADomain {
 func TestVHADomainNameHelpers(t *testing.T) {
 	g := NewWithT(t)
 
-	g.Expect(vhaCategoryValue("d1", "default", 0)).To(Equal("k8s-vha-capx-d1-default-0"))
-	g.Expect(vhaCategoryValue("d1", "default", 1)).To(Equal("k8s-vha-capx-d1-default-1"))
+	cat0, err := vhaCategoryValue("d1", "default", 0)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cat0).To(Equal("k8s-vha-capx-d1-default-0"))
+	cat1, err := vhaCategoryValue("d1", "default", 1)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cat1).To(Equal("k8s-vha-capx-d1-default-1"))
 	g.Expect(vhaRecoveryPlanName("d1", "default", 0)).To(Equal("k8s-vha-capx-d1-default-0"))
 	g.Expect(vhaProtectionPolicyName("d1")).To(Equal("k8s-vha-capx-d1"))
+
+	longDomain := vHADomainName("nkp-management-cluster-rocky", "production-metro")
+	_, err = vhaCategoryValue(longDomain, vhaDefaultMovementGroup, 0)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("Prism Central limits category values to 64"))
 }
 
 // TestVHADomainDefaultCategoryKey_Contract guards the implicit contract shared with CSI and NKP for


### PR DESCRIPTION
Name generation now fails immediately if the result is longer than 64 characters. Nothing is hashed or truncated.

That applies to category values. 

Short names are unchanged. Shorten the cluster or metro name so k8s-vha-capx-{vhadomain}-{group}-{idx} stays within 64.